### PR TITLE
Rebuild the dashboard overview on the v2 comp

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/components/charts-section.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/charts-section.tsx
@@ -1,4 +1,4 @@
-import { Card, Link, Skeleton, Tooltip } from "@heroui/react";
+import { Link, Skeleton, Tooltip } from "@heroui/react";
 import { buttonVariants } from "@heroui/styles";
 import { NumberValue } from "@heroui-pro/react";
 import Typography from "@web/components/typography";
@@ -6,62 +6,79 @@ import { getTopMakesByYear, getYearlyRegistrations } from "@web/queries/cars";
 import { ArrowUpRight } from "lucide-react";
 import { Suspense } from "react";
 
+const CARD =
+  "flex flex-col gap-6 rounded-[var(--radius-card)] bg-surface p-8 shadow-surface";
+
 async function YearlyChartContent() {
   const yearlyData = await getYearlyRegistrations();
-  const maxTotal = yearlyData.reduce((max, d) => Math.max(max, d.total), 0);
+  const series = yearlyData.slice(-8);
+  const maxTotal = series.reduce((max, d) => Math.max(max, d.total), 0) || 1;
+  const latest = series.at(-1);
 
   return (
-    <Card>
-      <Card.Content>
-        <div className="mb-5 flex items-center justify-between">
-          <div>
-            <Typography.H3>Yearly Registrations</Typography.H3>
-            <p className="text-muted text-sm">
-              Total registrations over the years
-            </p>
-          </div>
-          <Tooltip delay={300}>
-            <Link
-              aria-label="View annual registration data"
-              className={buttonVariants({
-                className: "size-10",
-                isIconOnly: true,
-                variant: "tertiary",
-              })}
-              href="/cars/annual"
+    <div className={CARD}>
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-2">
+          <Typography.TextSm className="font-semibold text-[var(--muted-strong)]">
+            Yearly registrations
+          </Typography.TextSm>
+          <span className="font-extrabold text-4xl tabular-nums tracking-[-0.02em]">
+            <NumberValue
+              locale="en-SG"
+              maximumFractionDigits={0}
+              value={latest?.total ?? 0}
+            />
+          </span>
+          <Typography.TextSm className="font-semibold text-muted">
+            registered in {latest?.year ?? "—"}
+          </Typography.TextSm>
+        </div>
+        <Tooltip delay={300}>
+          <Link
+            aria-label="View annual registration data"
+            className={buttonVariants({
+              className: "size-11 rounded-full",
+              isIconOnly: true,
+              variant: "tertiary",
+            })}
+            href="/cars/annual"
+          >
+            <ArrowUpRight className="size-6" />
+          </Link>
+          <Tooltip.Content>View annual registration data</Tooltip.Content>
+        </Tooltip>
+      </div>
+
+      <div className="flex h-[130px] items-end gap-2">
+        {series.map((item, index, arr) => {
+          const isLatest = index === arr.length - 1;
+          return (
+            <div
+              className="flex h-full flex-1 flex-col justify-end gap-2"
+              key={item.year}
             >
-              <ArrowUpRight className="size-6" />
-            </Link>
-            <Tooltip.Content>View annual registration data</Tooltip.Content>
-          </Tooltip>
-        </div>
-        <div className="flex h-[160px] items-end gap-4">
-          {yearlyData.slice(-6).map((item, i, arr) => {
-            const height = (item.total / maxTotal) * 140;
-            const isLatest = i === arr.length - 1;
-            return (
               <div
-                key={item.year}
-                className="flex flex-1 flex-col items-center gap-2"
+                className="w-full rounded-xl"
+                style={{
+                  height: `${(item.total / maxTotal) * 100}%`,
+                  backgroundColor: isLatest
+                    ? "var(--chart-1)"
+                    : "var(--accent-soft)",
+                }}
+              />
+              <span
+                className="text-center font-semibold text-xs"
+                style={{
+                  color: isLatest ? "var(--chart-1)" : "var(--subtle)",
+                }}
               >
-                <span className="font-medium text-muted text-xs tabular-nums">
-                  <NumberValue
-                    maximumFractionDigits={1}
-                    notation="compact"
-                    value={item.total}
-                  />
-                </span>
-                <div
-                  className={`w-full rounded-t-xl transition-colors ${isLatest ? "bg-[var(--chart-1)]" : "bg-default hover:bg-default"}`}
-                  style={{ height: `${height}px` }}
-                />
-                <span className="text-muted text-xs">{item.year}</span>
-              </div>
-            );
-          })}
-        </div>
-      </Card.Content>
-    </Card>
+                {item.year}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 
@@ -70,97 +87,92 @@ async function TopMakesContent() {
   const maxValue = topMakes[0]?.value ?? 1;
 
   return (
-    <Card>
-      <Card.Content>
-        <div className="mb-5 flex items-center justify-between">
-          <Typography.H3>Top Makes</Typography.H3>
-          <Tooltip delay={300}>
-            <Link
-              aria-label="View all car makes"
-              className={buttonVariants({
-                className: "size-10",
-                isIconOnly: true,
-                variant: "tertiary",
-              })}
-              href="/cars/makes"
-            >
-              <ArrowUpRight className="size-6" />
-            </Link>
-            <Tooltip.Content>View all car makes</Tooltip.Content>
-          </Tooltip>
+    <div className={CARD}>
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <Typography.TextSm className="font-semibold text-[var(--muted-strong)]">
+            Registrations
+          </Typography.TextSm>
+          <Typography.H3 className="font-bold tracking-[-0.02em]">
+            Top makes
+          </Typography.H3>
         </div>
-        <div className="flex flex-col gap-4">
-          {topMakes.slice(0, 5).map((item, i) => (
-            <div key={item.make} className="flex items-center gap-4">
-              <span className="w-5 font-medium text-muted text-sm">
-                {i + 1}
+        <Tooltip delay={300}>
+          <Link
+            aria-label="View all car makes"
+            className={buttonVariants({
+              className: "size-11 rounded-full",
+              isIconOnly: true,
+              variant: "tertiary",
+            })}
+            href="/cars/makes"
+          >
+            <ArrowUpRight className="size-6" />
+          </Link>
+          <Tooltip.Content>View all car makes</Tooltip.Content>
+        </Tooltip>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {topMakes.slice(0, 5).map((item, index) => (
+          <div className="flex flex-col gap-2" key={item.make}>
+            <div className="flex items-center gap-4">
+              <Typography.TextSm className="font-semibold">
+                {item.make}
+              </Typography.TextSm>
+              <span className="ml-auto font-extrabold text-sm tabular-nums">
+                <NumberValue
+                  locale="en-SG"
+                  maximumFractionDigits={0}
+                  value={item.value}
+                />
               </span>
-              <div className="flex-1">
-                <div className="mb-1 flex items-center justify-between">
-                  <span className="font-medium text-sm">{item.make}</span>
-                  <span className="text-muted text-xs tabular-nums">
-                    <NumberValue
-                      locale="en-SG"
-                      maximumFractionDigits={0}
-                      value={item.value}
-                    />
-                  </span>
-                </div>
-                <div className="h-1.5 overflow-hidden rounded-full bg-default">
-                  <div
-                    className="h-full rounded-full transition-all"
-                    style={{
-                      width: `${(item.value / maxValue) * 100}%`,
-                      backgroundColor: `var(--chart-${i + 1})`,
-                    }}
-                  />
-                </div>
-              </div>
             </div>
-          ))}
-        </div>
-      </Card.Content>
-    </Card>
+            <div className="h-3.5 overflow-hidden rounded-full bg-default">
+              <div
+                className="h-full rounded-full"
+                style={{
+                  width: `${(item.value / maxValue) * 100}%`,
+                  backgroundColor: `var(--chart-${index + 1})`,
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 
 function YearlyChartSkeleton() {
   return (
-    <Card>
-      <Card.Content>
-        <Skeleton className="mb-5 h-6 w-40 rounded-lg" />
-        <div className="flex h-[160px] items-end gap-4">
-          {[0, 1, 2, 3, 4, 5].map((num) => (
-            <div key={num} className="flex flex-1 flex-col items-center gap-2">
-              <Skeleton className="h-4 w-8 rounded-lg" />
-              <Skeleton className="w-full rounded-t-xl" />
-              <Skeleton className="h-4 w-8 rounded-lg" />
-            </div>
-          ))}
-        </div>
-      </Card.Content>
-    </Card>
+    <div className={CARD}>
+      <Skeleton className="h-6 w-40 rounded-lg" />
+      <div className="flex h-[130px] items-end gap-2">
+        {[0, 1, 2, 3, 4, 5, 6, 7].map((num) => (
+          <div className="flex flex-1 flex-col gap-2" key={num}>
+            <Skeleton className="h-20 w-full rounded-xl" />
+            <Skeleton className="h-4 w-full rounded-lg" />
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 
 function TopMakesSkeleton() {
   return (
-    <Card>
-      <Card.Content>
-        <Skeleton className="mb-5 h-6 w-24 rounded-lg" />
-        <div className="flex flex-col gap-4">
-          {[0, 1, 2, 3, 4].map((num) => (
-            <div key={num} className="flex items-center gap-4">
-              <Skeleton className="h-5 w-5 rounded-lg" />
-              <div className="flex-1">
-                <Skeleton className="mb-1 h-4 w-20 rounded-lg" />
-                <Skeleton className="h-1.5 w-full rounded-full" />
-              </div>
-            </div>
-          ))}
-        </div>
-      </Card.Content>
-    </Card>
+    <div className={CARD}>
+      <Skeleton className="h-6 w-24 rounded-lg" />
+      <div className="flex flex-col gap-4">
+        {[0, 1, 2, 3, 4].map((num) => (
+          <div className="flex flex-col gap-2" key={num}>
+            <Skeleton className="h-4 w-24 rounded-lg" />
+            <Skeleton className="h-3.5 w-full rounded-full" />
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/app/(main)/(dashboard)/components/coe-premiums-card.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/coe-premiums-card.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { Link, Tooltip } from "@heroui/react";
+import { buttonVariants } from "@heroui/styles";
+import { NumberValue } from "@heroui-pro/react";
+import Typography from "@web/components/typography";
+import { ArrowUpRight, Calculator } from "lucide-react";
+import { useState } from "react";
+import { CostTrendChip } from "./cost-trend-chip";
+
+export interface CoeCategorySeries {
+  category: string;
+  label: string;
+  points: { month: string; premium: number }[];
+}
+
+const CHART_WIDTH = 560;
+const CHART_HEIGHT = 170;
+const CHART_PAD = 12;
+
+function areaPath(values: number[]) {
+  if (values.length < 2) {
+    return null;
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const points = values.map((value, index) => [
+    (index / (values.length - 1)) * (CHART_WIDTH - CHART_PAD * 2) + CHART_PAD,
+    CHART_HEIGHT -
+      CHART_PAD -
+      ((value - min) / span) * (CHART_HEIGHT - CHART_PAD * 2),
+  ]);
+
+  const line = points
+    .map(
+      ([x, y], index) => `${index ? "L" : "M"}${x.toFixed(1)} ${y.toFixed(1)}`,
+    )
+    .join(" ");
+  const [lastX, lastY] = points.at(-1) ?? [0, 0];
+
+  return {
+    line,
+    area: `${line} L${CHART_WIDTH - CHART_PAD} ${CHART_HEIGHT} L${CHART_PAD} ${CHART_HEIGHT} Z`,
+    lastX: lastX.toFixed(1),
+    lastY: lastY.toFixed(1),
+  };
+}
+
+const formatMonth = (month: string) => {
+  const [year, monthPart] = month.split("-");
+  return new Date(Number(year), Number(monthPart) - 1).toLocaleString("en-SG", {
+    month: "short",
+    year: "numeric",
+  });
+};
+
+export function CoePremiumsCard({ series }: { series: CoeCategorySeries[] }) {
+  const [selected, setSelected] = useState(series[0]?.category ?? "");
+  const active = series.find((item) => item.category === selected) ?? series[0];
+
+  if (!active) {
+    return null;
+  }
+
+  const values = active.points.map((point) => point.premium);
+  const chart = areaPath(values);
+  const current = values.at(-1) ?? 0;
+  const previous = values.at(-2) ?? current;
+  const changeRatio = previous > 0 ? (current - previous) / previous : 0;
+
+  return (
+    <div className="flex flex-col gap-6 rounded-[var(--radius-card)] bg-surface p-8 shadow-surface">
+      <div className="flex flex-wrap items-center gap-4">
+        <span className="flex size-12 shrink-0 items-center justify-center rounded-full bg-accent text-[var(--accent-foreground)]">
+          <Calculator className="size-6" />
+        </span>
+        <div className="flex flex-col">
+          <Typography.H3 className="font-bold tracking-[-0.02em]">
+            COE premiums
+          </Typography.H3>
+          <Typography.TextSm className="font-semibold text-muted">
+            Latest bidding exercise
+          </Typography.TextSm>
+        </div>
+
+        <div className="ml-auto flex items-center gap-2">
+          {series.map((item) => {
+            const isActive = item.category === active.category;
+            return (
+              <button
+                aria-pressed={isActive}
+                className={`size-11 rounded-full font-extrabold text-base transition-colors ${
+                  isActive
+                    ? "bg-accent text-[var(--accent-foreground)]"
+                    : "bg-default text-[var(--muted-strong)] hover:bg-[var(--accent-soft)]"
+                }`}
+                key={item.category}
+                onClick={() => setSelected(item.category)}
+                type="button"
+              >
+                {item.label}
+              </button>
+            );
+          })}
+          <Tooltip delay={300}>
+            <Link
+              aria-label="View all COE results"
+              className={buttonVariants({
+                className: "size-11 rounded-full",
+                isIconOnly: true,
+                variant: "tertiary",
+              })}
+              href="/coe"
+            >
+              <ArrowUpRight className="size-6" />
+            </Link>
+            <Tooltip.Content>View all COE results</Tooltip.Content>
+          </Tooltip>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-4">
+          <span className="font-extrabold text-5xl tabular-nums tracking-[-0.03em]">
+            <NumberValue
+              currency="SGD"
+              locale="en-SG"
+              maximumFractionDigits={0}
+              style="currency"
+              value={current}
+            />
+          </span>
+          <CostTrendChip changeRatio={changeRatio} />
+        </div>
+        <Typography.TextSm className="font-semibold text-muted">
+          {active.category}
+        </Typography.TextSm>
+      </div>
+
+      {chart ? (
+        <div className="flex flex-col gap-2">
+          <svg
+            className="h-[170px] w-full overflow-visible"
+            preserveAspectRatio="none"
+            role="img"
+            viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+          >
+            <title>{`${active.category} premiums over the last 12 months`}</title>
+            <path d={chart.area} fill="var(--accent)" opacity={0.12} />
+            <path
+              d={chart.line}
+              fill="none"
+              stroke="var(--accent)"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={3.5}
+            />
+            <circle
+              cx={chart.lastX}
+              cy={chart.lastY}
+              fill="var(--surface)"
+              r={6.5}
+              stroke="var(--accent)"
+              strokeWidth={3.5}
+            />
+          </svg>
+          <div className="flex justify-between">
+            <Typography.Caption className="font-semibold text-[var(--subtle)]">
+              {formatMonth(active.points[0]?.month ?? "")}
+            </Typography.Caption>
+            <Typography.Caption className="font-semibold text-[var(--subtle)]">
+              {formatMonth(active.points.at(-1)?.month ?? "")}
+            </Typography.Caption>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/components/coe-section.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/coe-section.tsx
@@ -1,106 +1,43 @@
-import { Link, ScrollShadow, Skeleton, Tooltip } from "@heroui/react";
-import { buttonVariants } from "@heroui/styles";
-import { KPI, KPIGroup, TrendChip } from "@heroui-pro/react";
-import Typography from "@web/components/typography";
-import { getLatestAndPreviousCoeResults } from "@web/queries/coe";
-import { ArrowUpRight } from "lucide-react";
-import { Fragment, Suspense } from "react";
-import { calculateChangePercent, calculateTrend } from "./coe-trend-utils";
+import { Skeleton } from "@heroui/react";
+import { getAllCoeCategoryTrends } from "@web/queries/coe";
+import { Suspense } from "react";
+import { type CoeCategorySeries, CoePremiumsCard } from "./coe-premiums-card";
 
 async function CoeSectionContent() {
-  const { latest, previous } = await getLatestAndPreviousCoeResults();
+  const trends = await getAllCoeCategoryTrends();
 
-  // Create a map of previous results by vehicle class for easy lookup
-  const previousMap = new Map(previous.map((r) => [r.vehicleClass, r.premium]));
+  const series: CoeCategorySeries[] = Object.entries(trends)
+    .map(([category, points]) => ({
+      category,
+      label: category.replace("Category ", ""),
+      points: points
+        .slice()
+        .sort((a, b) => a.month.localeCompare(b.month))
+        .map(({ month, premium }) => ({ month, premium })),
+    }))
+    .filter((item) => item.points.length > 0);
 
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <Typography.H3>Latest COE Results</Typography.H3>
-        <Tooltip delay={300}>
-          <Link
-            aria-label="View all COE results"
-            className={buttonVariants({
-              className: "size-10",
-              isIconOnly: true,
-              variant: "tertiary",
-            })}
-            href="/coe"
-          >
-            <ArrowUpRight className="size-6" />
-          </Link>
-          <Tooltip.Content>View all COE results</Tooltip.Content>
-        </Tooltip>
-      </div>
-      <ScrollShadow
-        className="-mx-4 px-4 pb-1 sm:mx-0 sm:px-0"
-        hideScrollBar
-        orientation="horizontal"
-      >
-        <KPIGroup className="min-w-[44rem] sm:min-w-0">
-          {latest.map((result, index) => {
-            const previousPremium =
-              previousMap.get(result.vehicleClass) ?? result.premium;
-            const trend = calculateTrend(result.premium, previousPremium);
-            const changePercent = calculateChangePercent(
-              result.premium,
-              previousPremium,
-            );
+  if (series.length === 0) {
+    return null;
+  }
 
-            return (
-              <Fragment key={result.vehicleClass}>
-                {index > 0 ? <KPIGroup.Separator /> : null}
-                <KPI>
-                  <KPI.Header>
-                    <KPI.Title>{result.vehicleClass}</KPI.Title>
-                  </KPI.Header>
-                  <KPI.Content>
-                    <KPI.Value
-                      className="text-lg"
-                      currency="SGD"
-                      locale="en-SG"
-                      maximumFractionDigits={0}
-                      style="currency"
-                      value={result.premium}
-                    />
-                    {trend !== "neutral" ? (
-                      <TrendChip
-                        trend={trend === "up" ? "down" : "up"}
-                        variant="primary"
-                      >
-                        {changePercent}
-                      </TrendChip>
-                    ) : null}
-                  </KPI.Content>
-                  {trend === "neutral" ? (
-                    <KPI.Footer>
-                      <span className="text-muted text-xs">
-                        {changePercent}
-                      </span>
-                    </KPI.Footer>
-                  ) : null}
-                </KPI>
-              </Fragment>
-            );
-          })}
-        </KPIGroup>
-      </ScrollShadow>
-    </div>
-  );
+  return <CoePremiumsCard series={series} />;
 }
 
 function CoeSectionSkeleton() {
   return (
-    <div className="flex flex-col gap-4">
-      <Skeleton className="h-6 w-40 rounded-lg" />
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
-        {[0, 1, 2, 3, 4].map((i) => (
-          <div key={i} className="rounded-2xl bg-default p-4">
-            <Skeleton className="mb-2 h-4 w-12 rounded-lg" />
-            <Skeleton className="h-6 w-20 rounded-lg" />
-          </div>
-        ))}
+    <div className="flex flex-col gap-6 rounded-[var(--radius-card)] bg-surface p-8 shadow-surface">
+      <div className="flex items-center gap-4">
+        <Skeleton className="size-12 rounded-full" />
+        <Skeleton className="h-8 w-48 rounded-lg" />
+        <div className="ml-auto flex gap-2">
+          {[0, 1, 2, 3, 4].map((num) => (
+            <Skeleton className="size-11 rounded-full" key={num} />
+          ))}
+        </div>
       </div>
+      <Skeleton className="h-14 w-64 rounded-lg" />
+      <Skeleton className="h-[170px] w-full rounded-xl" />
     </div>
   );
 }

--- a/apps/web/src/app/(main)/(dashboard)/components/cost-trend-chip.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/cost-trend-chip.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { TrendChip } from "@heroui-pro/react";
+import { ArrowDown, ArrowUp } from "lucide-react";
+
+/**
+ * Trend chip for figures where a fall is good news (COE premiums, PQP rates).
+ *
+ * `trend` drives both the colour and the default arrow in HeroUI Pro, so the
+ * sentiment is inverted on `trend` while the arrow is overridden to follow the
+ * actual sign — otherwise the chip reads as a contradiction like "↑ -5.3%".
+ *
+ * This must stay a client component: TrendChip only suppresses its default
+ * arrow when it can identify a `TrendChip.Indicator` child, and that identity
+ * check fails across the server/client boundary, rendering two arrows.
+ */
+export function CostTrendChip({ changeRatio }: { changeRatio: number }) {
+  if (changeRatio === 0) {
+    return null;
+  }
+
+  const isUp = changeRatio > 0;
+  const Arrow = isUp ? ArrowUp : ArrowDown;
+
+  return (
+    <TrendChip trend={isUp ? "down" : "up"} variant="primary">
+      <TrendChip.Indicator>
+        <Arrow />
+      </TrendChip.Indicator>
+      {`${isUp ? "+" : ""}${(changeRatio * 100).toFixed(1)}%`}
+    </TrendChip>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/components/cost-trend-chip.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/cost-trend-chip.tsx
@@ -10,6 +10,10 @@ import { ArrowDown, ArrowUp } from "lucide-react";
  * sentiment is inverted on `trend` while the arrow is overridden to follow the
  * actual sign — otherwise the chip reads as a contradiction like "↑ -5.3%".
  *
+ * The variant is left at TrendChip's `soft` default: the comps use a pale fill
+ * with dark text throughout, matching `DeltaChip`'s soft tone beside it. The
+ * solid `primary` fill reads as a different component on the same row.
+ *
  * This must stay a client component: TrendChip only suppresses its default
  * arrow when it can identify a `TrendChip.Indicator` child, and that identity
  * check fails across the server/client boundary, rendering two arrows.
@@ -23,7 +27,7 @@ export function CostTrendChip({ changeRatio }: { changeRatio: number }) {
   const Arrow = isUp ? ArrowUp : ArrowDown;
 
   return (
-    <TrendChip trend={isUp ? "down" : "up"} variant="primary">
+    <TrendChip trend={isUp ? "down" : "up"}>
       <TrendChip.Indicator>
         <Arrow />
       </TrendChip.Indicator>

--- a/apps/web/src/app/(main)/(dashboard)/components/ev-momentum.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/ev-momentum.tsx
@@ -1,0 +1,155 @@
+import { Link, Tooltip } from "@heroui/react";
+import { buttonVariants } from "@heroui/styles";
+import { NumberValue } from "@heroui-pro/react";
+import Typography from "@web/components/typography";
+import {
+  getEvLatestSummary,
+  getEvMonthlyTrend,
+  getEvTopMakes,
+} from "@web/queries/cars";
+import { ArrowUpRight, Zap } from "lucide-react";
+
+function sparkline(values: number[], width: number, height: number, pad = 8) {
+  if (values.length < 2) {
+    return null;
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const points = values.map((value, index) => [
+    (index / (values.length - 1)) * (width - pad * 2) + pad,
+    height - pad - ((value - min) / span) * (height - pad * 2),
+  ]);
+
+  const line = points
+    .map(
+      ([x, y], index) => `${index ? "L" : "M"}${x.toFixed(1)} ${y.toFixed(1)}`,
+    )
+    .join(" ");
+  const [lastX, lastY] = points.at(-1) ?? [0, 0];
+
+  return {
+    line,
+    area: `${line} L${width - pad} ${height} L${pad} ${height} Z`,
+    lastX: lastX.toFixed(1),
+    lastY: lastY.toFixed(1),
+  };
+}
+
+export async function EvMomentum() {
+  const [summary, trend, topMakes] = await Promise.all([
+    getEvLatestSummary(),
+    getEvMonthlyTrend(),
+    getEvTopMakes(3),
+  ]);
+
+  if (!summary) {
+    return null;
+  }
+
+  const series = trend.slice(-8).map((point) => point.BEV + point.PHEV);
+  const spark = sparkline(series, 340, 84);
+  const evTotal = summary.totalEv || 1;
+
+  const [year, month] = summary.month.split("-");
+  const displayMonth = new Date(Number(year), Number(month) - 1).toLocaleString(
+    "en-SG",
+    { month: "long", year: "numeric" },
+  );
+
+  return (
+    <div className="flex flex-col gap-3 rounded-[var(--radius-lg)] bg-[var(--ink-surface)] p-7">
+      <div className="flex items-center gap-3">
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-[var(--accent-on-dark)]/20 text-[var(--accent-on-dark)]">
+          <Zap className="size-5" />
+        </span>
+        <Typography.TextSm className="font-semibold text-[var(--accent-foreground)]/85">
+          Electric momentum
+        </Typography.TextSm>
+        <Tooltip delay={300}>
+          <Link
+            aria-label="View electric vehicle data"
+            className={buttonVariants({
+              className:
+                "ml-auto size-10 rounded-full text-[var(--accent-foreground)]",
+              isIconOnly: true,
+              variant: "tertiary",
+            })}
+            href="/cars/electric"
+          >
+            <ArrowUpRight className="size-5" />
+          </Link>
+          <Tooltip.Content>View electric vehicle data</Tooltip.Content>
+        </Tooltip>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="font-extrabold text-5xl text-[var(--accent-on-dark)] tabular-nums tracking-[-0.03em]">
+          {summary.evSharePercent.toFixed(1)}%
+        </span>
+        <span className="rounded-full bg-[var(--accent-on-dark)]/20 px-4 py-2 font-bold text-[var(--accent-on-dark)] text-sm tabular-nums">
+          <NumberValue
+            locale="en-SG"
+            maximumFractionDigits={0}
+            value={summary.totalEv}
+          />
+        </span>
+      </div>
+
+      <Typography.TextSm className="font-semibold text-[var(--accent-foreground)]/60">
+        Electrified share (BEV, PHEV, hybrid) · {displayMonth}
+      </Typography.TextSm>
+
+      {spark ? (
+        <svg
+          className="h-[84px] w-full overflow-visible"
+          role="img"
+          viewBox="0 0 340 84"
+        >
+          <title>{`Electric registrations over the last ${series.length} months`}</title>
+          <path d={spark.area} fill="var(--accent-on-dark)" opacity={0.14} />
+          <path
+            d={spark.line}
+            fill="none"
+            stroke="var(--accent-on-dark)"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={3}
+          />
+          <circle
+            cx={spark.lastX}
+            cy={spark.lastY}
+            fill="var(--ink-surface)"
+            r={6}
+            stroke="var(--accent-on-dark)"
+            strokeWidth={3}
+          />
+        </svg>
+      ) : null}
+
+      <div className="flex flex-col gap-3">
+        {topMakes.map((make, index) => (
+          <div className="flex items-center gap-3" key={make.make}>
+            <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-[var(--accent-foreground)]/10 font-extrabold text-[var(--accent-foreground)] text-xs">
+              {index + 1}
+            </span>
+            <span className="font-bold text-[var(--accent-foreground)] text-sm">
+              {make.make}
+            </span>
+            <span className="ml-auto font-bold text-[var(--accent-foreground)]/85 text-sm tabular-nums">
+              <NumberValue
+                locale="en-SG"
+                maximumFractionDigits={0}
+                value={make.count}
+              />
+            </span>
+            <span className="w-12 text-right font-semibold text-[var(--accent-foreground)]/50 text-xs tabular-nums">
+              {((make.count / evTotal) * 100).toFixed(1)}%
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/components/market-overview.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/market-overview.tsx
@@ -1,62 +1,101 @@
-import { Chip } from "@heroui/react";
-import { KPI, KPIGroup } from "@heroui-pro/react";
+import { NumberValue } from "@heroui-pro/react";
 import Typography from "@web/components/typography";
 import { getCategorySummaryByYear } from "@web/queries/cars";
 
+const RADIUS = 74;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const SEGMENT_GAP = 16;
+
 export async function MarketOverview() {
   const summary = await getCategorySummaryByYear();
+  const others = Math.max(summary.total - summary.electric - summary.hybrid, 0);
+
+  const slices = [
+    { label: "Electric", value: summary.electric, color: "var(--chart-1)" },
+    { label: "Hybrid", value: summary.hybrid, color: "var(--chart-2)" },
+    { label: "Other", value: others, color: "var(--chart-5)" },
+  ];
+
+  const total = summary.total || 1;
+  let offset = 0;
+  const segments = slices.map((slice) => {
+    const full = (slice.value / total) * CIRCUMFERENCE;
+    const dash = Math.max(2, full - SEGMENT_GAP);
+    const segment = {
+      ...slice,
+      dashArray: `${dash.toFixed(2)} ${(CIRCUMFERENCE - dash).toFixed(2)}`,
+      dashOffset: (-(offset + SEGMENT_GAP / 2)).toFixed(2),
+    };
+    offset += full;
+    return segment;
+  });
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <Typography.H3>Market Overview</Typography.H3>
-        <Chip color="accent" size="sm">
-          {summary.year}
-        </Chip>
+    <div className="flex flex-col gap-6 rounded-[var(--radius-card)] bg-surface p-8 shadow-surface">
+      <div className="flex flex-col gap-1">
+        <Typography.TextSm className="font-semibold text-[var(--muted-strong)]">
+          Market overview
+        </Typography.TextSm>
+        <Typography.H3 className="font-bold tracking-[-0.02em]">
+          By powertrain
+        </Typography.H3>
       </div>
-      <KPIGroup>
-        <KPI>
-          <KPI.Header>
-            <KPI.Title>Total Cars</KPI.Title>
-          </KPI.Header>
-          <KPI.Content>
-            <KPI.Value
-              className="text-2xl text-accent"
-              locale="en-SG"
-              maximumFractionDigits={0}
+
+      <div className="relative mx-auto size-[172px]">
+        <svg className="block size-[172px]" role="img" viewBox="0 0 190 190">
+          <title>{`Registrations by powertrain, ${summary.year} year to date`}</title>
+          <g transform="rotate(-90 95 95)">
+            {segments.map((segment) => (
+              <circle
+                cx={95}
+                cy={95}
+                fill="none"
+                key={segment.label}
+                r={RADIUS}
+                stroke={segment.color}
+                strokeDasharray={segment.dashArray}
+                strokeDashoffset={segment.dashOffset}
+                strokeLinecap="round"
+                strokeWidth={24}
+              />
+            ))}
+          </g>
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1">
+          <span className="font-extrabold text-3xl tabular-nums tracking-[-0.02em]">
+            <NumberValue
+              maximumFractionDigits={1}
+              notation="compact"
               value={summary.total}
             />
-          </KPI.Content>
-        </KPI>
-        <KPIGroup.Separator />
-        <KPI>
-          <KPI.Header>
-            <KPI.Title>Electric</KPI.Title>
-          </KPI.Header>
-          <KPI.Content>
-            <KPI.Value
-              className="text-2xl text-accent"
-              locale="en-SG"
-              maximumFractionDigits={0}
-              value={summary.electric}
+          </span>
+          <Typography.Caption className="font-semibold text-muted">
+            registrations
+          </Typography.Caption>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        {slices.map((slice) => (
+          <div className="flex items-center gap-3" key={slice.label}>
+            <span
+              aria-hidden
+              className="size-3 shrink-0 rounded-full"
+              style={{ backgroundColor: slice.color }}
             />
-          </KPI.Content>
-        </KPI>
-        <KPIGroup.Separator />
-        <KPI>
-          <KPI.Header>
-            <KPI.Title>Hybrid</KPI.Title>
-          </KPI.Header>
-          <KPI.Content>
-            <KPI.Value
-              className="text-2xl text-accent"
-              locale="en-SG"
-              maximumFractionDigits={0}
-              value={summary.hybrid}
-            />
-          </KPI.Content>
-        </KPI>
-      </KPIGroup>
+            <Typography.TextSm className="font-semibold">
+              {slice.label}
+            </Typography.TextSm>
+            <span className="ml-auto font-bold text-sm tabular-nums">
+              {((slice.value / total) * 100).toFixed(1)}%
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <Typography.Caption className="text-[var(--subtle)]">
+        {summary.year} year to date
+      </Typography.Caption>
     </div>
   );
 }

--- a/apps/web/src/app/(main)/(dashboard)/components/monthly-change-summary.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/monthly-change-summary.tsx
@@ -1,6 +1,7 @@
 import { Link, Tooltip } from "@heroui/react";
 import { buttonVariants } from "@heroui/styles";
-import { KPI, NumberValue } from "@heroui-pro/react";
+import { NumberValue } from "@heroui-pro/react";
+import Typography from "@web/components/typography";
 import { getCarsComparison, getCarsLatestMonth } from "@web/queries/cars";
 import { ArrowUpRight, CalendarDays } from "lucide-react";
 
@@ -17,61 +18,63 @@ export async function MonthlyChangeSummary() {
 
   const changeAmount = currentTotal - previousTotal;
   const changeRatio = previousTotal > 0 ? changeAmount / previousTotal : 0;
-  const trend = changeRatio > 0 ? "up" : changeRatio < 0 ? "down" : "neutral";
 
-  // Format the month for display (e.g., "2025-01" -> "Jan 2025")
   const [year, month] = latestMonth.split("-");
   const displayMonth = new Date(Number(year), Number(month) - 1).toLocaleString(
     "en-SG",
-    { month: "short", year: "numeric" },
+    { month: "long", year: "numeric" },
   );
 
   return (
-    <KPI>
-      <KPI.Header>
-        <div className="flex size-11 items-center justify-center rounded-xl bg-default text-accent">
-          <CalendarDays className="size-6 text-accent" />
-        </div>
+    <div className="flex flex-col gap-4 rounded-[var(--radius)] bg-[var(--ink-surface)] p-7">
+      <div className="flex items-center gap-3">
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-[var(--accent-on-dark)]/20 text-[var(--accent-on-dark)]">
+          <CalendarDays className="size-5" />
+        </span>
+        <Typography.TextSm className="font-semibold text-[var(--accent-foreground)]/85">
+          Monthly change
+        </Typography.TextSm>
         <Tooltip delay={300}>
           <Link
             aria-label="View monthly car registration details"
             className={buttonVariants({
-              className: "ml-auto size-10",
+              className:
+                "ml-auto size-10 rounded-full text-[var(--accent-foreground)]",
               isIconOnly: true,
               variant: "tertiary",
             })}
             href={`/cars?month=${latestMonth}`}
           >
-            <ArrowUpRight className="size-6" />
+            <ArrowUpRight className="size-5" />
           </Link>
           <Tooltip.Content>
             View monthly car registration details
           </Tooltip.Content>
         </Tooltip>
-      </KPI.Header>
-      <KPI.Header>
-        <KPI.Title>Monthly Change ({displayMonth})</KPI.Title>
-      </KPI.Header>
-      <KPI.Content>
-        <KPI.Value
-          className="text-4xl tabular-nums"
-          maximumFractionDigits={1}
-          signDisplay="exceptZero"
-          style="percent"
-          value={changeRatio}
-        />
-        <KPI.Trend trend={trend} variant="primary">
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="font-extrabold text-5xl text-[var(--accent-on-dark)] tabular-nums tracking-[-0.03em]">
+          <NumberValue
+            maximumFractionDigits={1}
+            signDisplay="exceptZero"
+            style="percent"
+            value={changeRatio}
+          />
+        </span>
+        <span className="flex items-center gap-2 rounded-full bg-[var(--accent-on-dark)]/20 px-4 py-2 font-bold text-[var(--accent-on-dark)] text-sm">
           <NumberValue
             locale="en-SG"
             maximumFractionDigits={0}
             signDisplay="exceptZero"
             value={changeAmount}
           />
-        </KPI.Trend>
-      </KPI.Content>
-      <KPI.Footer>
-        <span className="text-muted text-xs">vs previous month</span>
-      </KPI.Footer>
-    </KPI>
+        </span>
+      </div>
+
+      <Typography.TextSm className="font-semibold text-[var(--accent-foreground)]/60">
+        registrations vs previous month · {displayMonth}
+      </Typography.TextSm>
+    </div>
   );
 }

--- a/apps/web/src/app/(main)/(dashboard)/components/posts-section.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/posts-section.tsx
@@ -10,12 +10,12 @@ async function PostsSectionContent() {
 
 function PostsSectionSkeleton() {
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex flex-col gap-6">
       <div className="flex items-center justify-between">
         <Skeleton className="h-6 w-28 rounded-lg" />
         <Skeleton className="size-10 rounded-full" />
       </div>
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-3 2xl:grid-cols-1">
         {[0, 1, 2].map((item) => (
           <div key={item}>
             <Skeleton className="aspect-[16/10] w-full rounded-xl" />

--- a/apps/web/src/app/(main)/(dashboard)/components/pqp-rail.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/pqp-rail.tsx
@@ -1,0 +1,94 @@
+import { NumberValue } from "@heroui-pro/react";
+import Typography from "@web/components/typography";
+import { getPqpRates } from "@web/queries/coe";
+import { CostTrendChip } from "./cost-trend-chip";
+
+const CATEGORY_NAMES: Record<string, string> = {
+  "Category A": "Cars up to 1600cc & 130bhp",
+  "Category B": "Cars above 1600cc or 130bhp",
+  "Category C": "Goods vehicles & buses",
+  "Category D": "Motorcycles",
+};
+
+const formatMonth = (month: string) => {
+  const [year, monthPart] = month.split("-");
+  return new Date(Number(year), Number(monthPart) - 1).toLocaleString("en-SG", {
+    month: "long",
+    year: "numeric",
+  });
+};
+
+export async function PqpRail() {
+  const rates = await getPqpRates();
+  const months = Object.keys(rates).sort().reverse();
+  const [latestMonth, previousMonth] = months;
+
+  if (!latestMonth) {
+    return null;
+  }
+
+  const latest = rates[latestMonth];
+  const previous = previousMonth ? rates[previousMonth] : undefined;
+
+  const rows = Object.entries(latest ?? {}).map(([category, value]) => {
+    const previousValue = previous?.[category as keyof typeof previous];
+    const changeRatio =
+      previousValue && previousValue > 0
+        ? (value - previousValue) / previousValue
+        : 0;
+    return {
+      category,
+      changeRatio,
+      letter: category.replace("Category ", ""),
+      name: CATEGORY_NAMES[category] ?? category,
+      value,
+    };
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <Typography.TextSm className="font-semibold text-muted">
+          PQP premiums · for COE renewals
+        </Typography.TextSm>
+        <Typography.H3 className="font-bold tracking-[-0.02em]">
+          {formatMonth(latestMonth)} rates
+        </Typography.H3>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {rows.map((row) => (
+          <div
+            className="flex items-center gap-3 rounded-[var(--radius)] bg-surface p-4"
+            key={row.category}
+          >
+            <span className="flex size-11 shrink-0 items-center justify-center rounded-full bg-[var(--accent-soft)] font-extrabold text-[var(--accent-strong)] text-lg">
+              {row.letter}
+            </span>
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <span className="font-bold tabular-nums">
+                <NumberValue
+                  currency="SGD"
+                  locale="en-SG"
+                  maximumFractionDigits={0}
+                  style="currency"
+                  value={row.value}
+                />
+              </span>
+              <Typography.Caption className="truncate text-muted">
+                {row.name}
+              </Typography.Caption>
+            </div>
+            <div className="ml-auto shrink-0">
+              <CostTrendChip changeRatio={row.changeRatio} />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <Typography.Caption className="text-[var(--subtle)]">
+        3-month moving average of premiums · renew 5 or 10 years
+      </Typography.Caption>
+    </div>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/components/recent-posts.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/recent-posts.tsx
@@ -12,7 +12,7 @@ interface RecentPostsProps {
 export function RecentPosts({ posts }: RecentPostsProps) {
   if (!posts || posts.length === 0) {
     return (
-      <section className="flex h-full flex-col gap-5">
+      <section className="flex h-full flex-col gap-6">
         <div className="flex items-center justify-between">
           <Typography.H3>Recent Posts</Typography.H3>
           <Tooltip delay={300}>
@@ -38,7 +38,7 @@ export function RecentPosts({ posts }: RecentPostsProps) {
   }
 
   return (
-    <section className="flex h-full flex-col gap-5">
+    <section className="flex h-full flex-col gap-6">
       <div className="flex items-center justify-between">
         <Typography.H3>Recent Posts</Typography.H3>
         <Tooltip delay={300}>
@@ -57,7 +57,7 @@ export function RecentPosts({ posts }: RecentPostsProps) {
         </Tooltip>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-3 2xl:grid-cols-1">
         {posts.slice(0, 3).map((post) => (
           <Post.Card key={post.id} post={post} />
         ))}

--- a/apps/web/src/app/(main)/(dashboard)/components/summary-card.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/summary-card.tsx
@@ -1,67 +1,169 @@
 import { Link, Tooltip } from "@heroui/react";
 import { buttonVariants } from "@heroui/styles";
-import { KPI, NumberValue } from "@heroui-pro/react";
-import { getYearlyRegistrations } from "@web/queries/cars";
-import { ArrowUpRight, BarChart3 } from "lucide-react";
+import { NumberValue } from "@heroui-pro/react";
+import Typography from "@web/components/typography";
+import {
+  getMonthlyRegistrationTotals,
+  getYearlyRegistrations,
+} from "@web/queries/cars";
+import { ArrowUpRight } from "lucide-react";
+
+/** Sparkline geometry for a series, normalised into a `width` x `height` box. */
+function sparkline(values: number[], width: number, height: number, pad = 8) {
+  if (values.length < 2) {
+    return null;
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const points = values.map((value, index) => [
+    (index / (values.length - 1)) * (width - pad * 2) + pad,
+    height - pad - ((value - min) / span) * (height - pad * 2),
+  ]);
+
+  const line = points
+    .map(
+      ([x, y], index) => `${index ? "L" : "M"}${x.toFixed(1)} ${y.toFixed(1)}`,
+    )
+    .join(" ");
+  const [lastX, lastY] = points.at(-1) ?? [0, 0];
+
+  return {
+    line,
+    area: `${line} L${width - pad} ${height} L${pad} ${height} Z`,
+    lastX: lastX.toFixed(1),
+    lastY: lastY.toFixed(1),
+  };
+}
+
+const formatMonth = (month: string, style: "long" | "short" = "long") => {
+  const [year, monthPart] = month.split("-");
+  return new Date(Number(year), Number(monthPart) - 1).toLocaleString("en-SG", {
+    month: style,
+    year: "numeric",
+  });
+};
 
 export async function SummaryCard() {
-  const yearlyData = await getYearlyRegistrations();
-  const currentYear = yearlyData.at(-1);
-  const previousYear = yearlyData.at(-2);
+  const [monthly, yearlyData] = await Promise.all([
+    getMonthlyRegistrationTotals(12),
+    getYearlyRegistrations(),
+  ]);
 
-  const totalRegistrations = currentYear?.total ?? 0;
-  const previousTotal = previousYear?.total ?? 0;
-  const displayYear = currentYear?.year ?? "No data";
+  const current = monthly.at(-1);
+  const previous = monthly.at(-2);
+
+  if (!current) {
+    return null;
+  }
+
+  const previousTotal = previous?.total ?? 0;
+  // Month-over-month, not year-over-year: comparing a part-complete year against
+  // a full one produced a headline that read as a ~75% collapse.
   const changeRatio =
-    previousTotal > 0
-      ? (totalRegistrations - previousTotal) / previousTotal
-      : 0;
-  const isPositive = totalRegistrations >= previousTotal;
-  const trend = changeRatio > 0 ? "up" : changeRatio < 0 ? "down" : "neutral";
+    previousTotal > 0 ? (current.total - previousTotal) / previousTotal : 0;
+
+  const yearToDate = yearlyData.at(-1);
+  const spark = sparkline(
+    monthly.map((item) => item.total),
+    380,
+    90,
+  );
 
   return (
-    <KPI>
-      <KPI.Header>
-        <div className="flex size-11 items-center justify-center rounded-xl bg-default text-accent">
-          <BarChart3 className="size-6 text-accent" />
+    <div
+      className="flex flex-col gap-4 rounded-[var(--radius-card)] p-8 text-[var(--accent-foreground)] shadow-surface"
+      style={{ background: "var(--accent-gradient)" }}
+    >
+      <span className="w-fit rounded-full bg-[var(--accent-foreground)]/20 px-4 py-2 font-semibold text-sm">
+        New registrations · {formatMonth(current.month)}
+      </span>
+
+      <div className="flex flex-wrap items-center gap-4">
+        <span className="font-extrabold text-6xl tabular-nums tracking-[-0.03em]">
+          <NumberValue
+            locale="en-SG"
+            maximumFractionDigits={0}
+            value={current.total}
+          />
+        </span>
+        <span className="flex items-center gap-2 rounded-full bg-[var(--accent-deep)]/85 px-4 py-2 font-bold text-sm">
+          <span
+            aria-hidden
+            className="size-2 rounded-full bg-[var(--accent-foreground)]"
+          />
+          <NumberValue
+            maximumFractionDigits={1}
+            signDisplay="exceptZero"
+            style="percent"
+            value={changeRatio}
+          />
+        </span>
+      </div>
+
+      <Typography.TextSm className="font-semibold text-[var(--accent-foreground)]/85">
+        cars registered vs{" "}
+        {previous ? formatMonth(previous.month, "short") : "previous month"}
+      </Typography.TextSm>
+
+      {spark ? (
+        <svg
+          className="h-[90px] w-full overflow-visible"
+          role="img"
+          viewBox="0 0 380 90"
+        >
+          <title>{`Monthly registrations over the last ${monthly.length} months`}</title>
+          <path d={spark.area} fill="currentColor" opacity={0.16} />
+          <path
+            d={spark.line}
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={3.5}
+          />
+          <circle
+            cx={spark.lastX}
+            cy={spark.lastY}
+            fill="var(--accent)"
+            r={6}
+            stroke="currentColor"
+            strokeWidth={3.5}
+          />
+        </svg>
+      ) : null}
+
+      <div className="flex items-center gap-4 rounded-[var(--radius)] bg-[var(--ink-surface)]/45 px-6 py-5">
+        <div className="flex flex-col gap-1">
+          <Typography.TextSm className="font-bold text-[var(--accent-foreground)] text-lg">
+            <NumberValue
+              locale="en-SG"
+              maximumFractionDigits={0}
+              value={yearToDate?.total ?? 0}
+            />{" "}
+            year to date
+          </Typography.TextSm>
+          <Typography.Caption className="text-[var(--accent-foreground)]/70">
+            cars registered in {yearToDate?.year ?? "—"}
+          </Typography.Caption>
         </div>
         <Tooltip delay={300}>
           <Link
             aria-label="View car registration overview"
             className={buttonVariants({
-              className: "ml-auto size-10",
+              className:
+                "ml-auto size-12 shrink-0 rounded-full bg-[var(--accent)] text-[var(--accent-foreground)]",
               isIconOnly: true,
               variant: "tertiary",
             })}
             href="/cars"
           >
-            <ArrowUpRight className="size-6" />
+            <ArrowUpRight className="size-5" />
           </Link>
           <Tooltip.Content>View car registration overview</Tooltip.Content>
         </Tooltip>
-      </KPI.Header>
-      <KPI.Header>
-        <KPI.Title>Total Registrations ({displayYear})</KPI.Title>
-      </KPI.Header>
-      <KPI.Content>
-        <KPI.Value
-          className="text-4xl tabular-nums"
-          locale="en-SG"
-          maximumFractionDigits={0}
-          value={totalRegistrations}
-        />
-        <KPI.Trend trend={trend} variant="primary">
-          <NumberValue
-            maximumFractionDigits={1}
-            signDisplay="exceptZero"
-            style="percent"
-            value={isPositive ? Math.abs(changeRatio) : -Math.abs(changeRatio)}
-          />
-        </KPI.Trend>
-      </KPI.Content>
-      <KPI.Footer>
-        <span className="text-muted text-xs">vs previous year</span>
-      </KPI.Footer>
-    </KPI>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/app/(main)/(dashboard)/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/page.tsx
@@ -1,4 +1,4 @@
-import { Card, Skeleton } from "@heroui/react";
+import { Skeleton } from "@heroui/react";
 import { AnimatedGrid } from "@web/app/(main)/(dashboard)/components/animated-grid";
 import { AnimatedSection } from "@web/app/(main)/(dashboard)/components/animated-section";
 import {
@@ -6,9 +6,13 @@ import {
   YearlyChart,
 } from "@web/app/(main)/(dashboard)/components/charts-section";
 import { CoeSection } from "@web/app/(main)/(dashboard)/components/coe-section";
+import { EvMomentum } from "@web/app/(main)/(dashboard)/components/ev-momentum";
 import { MarketOverview } from "@web/app/(main)/(dashboard)/components/market-overview";
-import { MonthlyChangeSummary } from "@web/app/(main)/(dashboard)/components/monthly-change-summary";
-import { PostsSection } from "@web/app/(main)/(dashboard)/components/posts-section";
+import { PqpRail } from "@web/app/(main)/(dashboard)/components/pqp-rail";
+// TODO: Not present in the Overview v2 comp. Restore if the dashboard should
+// keep a monthly-change KPI and a recent-posts block alongside the v2 layout.
+// import { MonthlyChangeSummary } from "@web/app/(main)/(dashboard)/components/monthly-change-summary";
+// import { PostsSection } from "@web/app/(main)/(dashboard)/components/posts-section";
 import { SummaryCard } from "@web/app/(main)/(dashboard)/components/summary-card";
 import { SectionErrorBoundary } from "@web/components/error-boundary";
 import { StructuredData } from "@web/components/structured-data";
@@ -82,51 +86,17 @@ const organisationSchema = {
   sameAs: [SOCIAL_URLS.instagram, SOCIAL_URLS.telegram, SOCIAL_URLS.github],
 } as const;
 
-function SummaryCardSkeleton() {
+function CardSkeleton({ className = "" }: { className?: string }) {
   return (
-    <Card>
-      <Card.Content>
-        <div className="mb-4 flex items-center justify-between">
-          <Skeleton className="h-12 w-12 rounded-2xl" />
-          <Skeleton className="h-10 w-10 rounded-full" />
-        </div>
+    <div
+      className={`rounded-[var(--radius-card)] bg-surface p-7 shadow-surface ${className}`}
+    >
+      <div className="flex flex-col gap-4">
         <Skeleton className="h-4 w-32 rounded-lg" />
-        <Skeleton className="mt-2 h-10 w-28 rounded-lg" />
-        <Skeleton className="mt-4 h-6 w-40 rounded-full" />
-      </Card.Content>
-    </Card>
-  );
-}
-
-function MarketOverviewSkeleton() {
-  return (
-    <div className="flex flex-col gap-4">
-      <Skeleton className="h-6 w-36 rounded-lg" />
-      <div className="grid grid-cols-3 gap-4">
-        {[0, 1, 2].map((i) => (
-          <div key={i} className="rounded-2xl bg-default p-4">
-            <Skeleton className="h-4 w-16 rounded-lg" />
-            <Skeleton className="mt-2 h-7 w-20 rounded-lg" />
-          </div>
-        ))}
+        <Skeleton className="h-12 w-40 rounded-lg" />
+        <Skeleton className="h-6 w-44 rounded-full" />
       </div>
     </div>
-  );
-}
-
-function MonthlyChangeSummarySkeleton() {
-  return (
-    <Card>
-      <Card.Content>
-        <div className="mb-4 flex items-center justify-between">
-          <Skeleton className="h-12 w-12 rounded-2xl" />
-          <Skeleton className="h-10 w-10 rounded-full" />
-        </div>
-        <Skeleton className="h-4 w-32 rounded-lg" />
-        <Skeleton className="mt-2 h-10 w-28 rounded-lg" />
-        <Skeleton className="mt-4 h-6 w-40 rounded-full" />
-      </Card.Content>
-    </Card>
   );
 }
 
@@ -135,65 +105,93 @@ const HomePage = () => {
     <>
       <StructuredData data={webSiteSchema} />
       <StructuredData data={organisationSchema} />
-      <section className="flex flex-col gap-8">
-        <div className="flex max-w-3xl flex-col gap-2">
-          <Typography.H1>Overview</Typography.H1>
-          <Typography.TextLg className="text-muted">
-            Singapore vehicle registrations and COE market movement at a glance.
-          </Typography.TextLg>
-        </div>
-        {/* Bento Grid */}
-        <AnimatedGrid className="grid grid-cols-12 gap-4">
-          {/* Row 1: Summary Cards */}
-          <AnimatedSection className="col-span-12 lg:col-span-6">
+
+      {/* Page head */}
+      <div className="flex flex-col gap-2">
+        <span className="font-semibold text-[var(--subtle)] text-sm">
+          Singapore car market&ensp;·&ensp;updated daily from LTA DataMall
+        </span>
+        <Typography.H1 className="font-bold text-[2.75rem] leading-[1.05] tracking-[-0.02em] lg:text-[3.25rem]">
+          Overview
+        </Typography.H1>
+      </div>
+
+      {/* Bento — 430px / fluid / 400px, matching Overview v2 */}
+      <div className="grid grid-cols-1 items-start gap-6 xl:grid-cols-2 2xl:grid-cols-[minmax(0,380px)_minmax(0,1fr)_minmax(0,380px)]">
+        {/* Left column */}
+        <AnimatedGrid className="flex flex-col gap-6">
+          <AnimatedSection>
             <SectionErrorBoundary title="Registration summary unavailable">
-              <Suspense fallback={<SummaryCardSkeleton />}>
+              <Suspense fallback={<CardSkeleton className="h-[420px]" />}>
                 <SummaryCard />
               </Suspense>
             </SectionErrorBoundary>
           </AnimatedSection>
-          <AnimatedSection className="col-span-12 lg:col-span-6">
-            <SectionErrorBoundary title="Monthly change unavailable">
-              <Suspense fallback={<MonthlyChangeSummarySkeleton />}>
-                <MonthlyChangeSummary />
-              </Suspense>
-            </SectionErrorBoundary>
-          </AnimatedSection>
-
-          {/* Row 2: COE Results */}
-          <AnimatedSection className="col-span-12">
-            <SectionErrorBoundary title="COE results unavailable">
-              <CoeSection />
-            </SectionErrorBoundary>
-          </AnimatedSection>
-
-          {/* Row 3: Top Makes + Posts */}
-          <AnimatedSection className="col-span-12 md:col-span-6 lg:col-span-4">
-            <SectionErrorBoundary title="Top makes unavailable">
-              <TopMakesSection />
-            </SectionErrorBoundary>
-          </AnimatedSection>
-          <AnimatedSection className="col-span-12 md:col-span-6 lg:col-span-8">
-            <SectionErrorBoundary title="Recent posts unavailable">
-              <PostsSection />
-            </SectionErrorBoundary>
-          </AnimatedSection>
-
-          {/* Row 4: Yearly Chart + Market Overview */}
-          <AnimatedSection className="col-span-12 md:col-span-6 lg:col-span-4">
+          <AnimatedSection>
             <SectionErrorBoundary title="Yearly chart unavailable">
               <YearlyChart />
             </SectionErrorBoundary>
           </AnimatedSection>
-          <AnimatedSection className="col-span-12 lg:col-span-8">
-            <SectionErrorBoundary title="Market overview unavailable">
-              <Suspense fallback={<MarketOverviewSkeleton />}>
-                <MarketOverview />
+        </AnimatedGrid>
+
+        {/* Middle column */}
+        <AnimatedGrid className="flex flex-col gap-6">
+          <AnimatedSection>
+            <SectionErrorBoundary title="COE results unavailable">
+              <CoeSection />
+            </SectionErrorBoundary>
+          </AnimatedSection>
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            <AnimatedSection>
+              <SectionErrorBoundary title="Top makes unavailable">
+                <TopMakesSection />
+              </SectionErrorBoundary>
+            </AnimatedSection>
+            <AnimatedSection>
+              <SectionErrorBoundary title="Market overview unavailable">
+                <Suspense fallback={<CardSkeleton className="h-[430px]" />}>
+                  <MarketOverview />
+                </Suspense>
+              </SectionErrorBoundary>
+            </AnimatedSection>
+          </div>
+        </AnimatedGrid>
+
+        {/* Right rail — warm sand well: PQP rates over a dark EV panel */}
+        <AnimatedGrid className="flex flex-col gap-6 rounded-[var(--radius-rail)] bg-[var(--surface-alt)] p-6 shadow-surface xl:col-span-2 xl:p-8 2xl:col-span-1">
+          <AnimatedSection>
+            <SectionErrorBoundary title="PQP rates unavailable">
+              <Suspense fallback={<CardSkeleton className="h-96" />}>
+                <PqpRail />
+              </Suspense>
+            </SectionErrorBoundary>
+          </AnimatedSection>
+          <AnimatedSection>
+            <SectionErrorBoundary title="Electric momentum unavailable">
+              <Suspense fallback={<CardSkeleton className="h-96" />}>
+                <EvMomentum />
               </Suspense>
             </SectionErrorBoundary>
           </AnimatedSection>
         </AnimatedGrid>
-      </section>
+
+        {/* TODO: Neither block appears in Overview v2. Commented out rather than
+            deleted so they can be restored if the dashboard should diverge from
+            the comp.
+        <AnimatedSection>
+          <SectionErrorBoundary title="Monthly change unavailable">
+            <Suspense fallback={<CardSkeleton className="h-40" />}>
+              <MonthlyChangeSummary />
+            </Suspense>
+          </SectionErrorBoundary>
+        </AnimatedSection>
+        <AnimatedSection>
+          <SectionErrorBoundary title="Recent posts unavailable">
+            <PostsSection />
+          </SectionErrorBoundary>
+        </AnimatedSection>
+        */}
+      </div>
     </>
   );
 };

--- a/apps/web/src/components/__snapshots__/recent-posts.test.tsx.snap
+++ b/apps/web/src/components/__snapshots__/recent-posts.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`RecentPosts > should render title and view all link 1`] = `
 <div>
   <section
-    class="flex h-full flex-col gap-5"
+    class="flex h-full flex-col gap-6"
   >
     <div
       class="flex items-center justify-between"
@@ -44,7 +44,7 @@ exports[`RecentPosts > should render title and view all link 1`] = `
       </span>
     </div>
     <div
-      class="grid grid-cols-1 gap-4 lg:grid-cols-3"
+      class="grid grid-cols-1 gap-4 xl:grid-cols-3 2xl:grid-cols-1"
     >
       <article
         data-testid="post-card-post-1"

--- a/apps/web/src/queries/cars/monthly-registrations.ts
+++ b/apps/web/src/queries/cars/monthly-registrations.ts
@@ -138,3 +138,33 @@ export async function getCarsComparison(month: string): Promise<Comparison> {
     },
   };
 }
+
+export interface MonthlyTotal {
+  month: string;
+  total: number;
+}
+
+/**
+ * Monthly registration totals, oldest first. Backs the Overview hero sparkline,
+ * which needs a month-over-month series rather than the yearly totals used by
+ * the annual chart.
+ */
+export async function getMonthlyRegistrationTotals(
+  limit = 12,
+): Promise<MonthlyTotal[]> {
+  "use cache";
+  cacheLife("max");
+  cacheTag("cars:monthly-totals");
+
+  const results = await db
+    .select({
+      month: cars.month,
+      total: sql<number>`sum(${cars.number})`.mapWith(Number),
+    })
+    .from(cars)
+    .groupBy(cars.month)
+    .orderBy(desc(cars.month))
+    .limit(limit);
+
+  return results.reverse();
+}


### PR DESCRIPTION
Stacked on #909.

- Rebuild the overview as a three-column bento with a warm sand right rail
- Add the COE premiums card, PQP rail, EV momentum panel and cost trend chip
- Restyle the summary, charts, COE and market blocks against the skin tokens
- Comment out the monthly change and recent posts blocks rather than deleting them — neither appears in the comp
- Refresh the `recent-posts` snapshot for the new grid columns

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Most changes are dashboard UI and read-only cached queries; the summary metric fix is a presentation correction, not a data pipeline change.
> 
> **Overview**
> Replaces the overview **bento** with a three-column **Overview v2** layout: registration hero and yearly chart on the left, COE premiums plus top makes and market overview in the middle, and a warm **surface-alt** right rail for **PQP** rates and **EV momentum**.
> 
> The **summary hero** now highlights the latest month’s registrations with a 12-month sparkline and **month-over-month** change (backed by new `getMonthlyRegistrationTotals`), plus a year-to-date footer—avoiding the misleading year-over-year headline on a partial year.
> 
> **COE** moves from a horizontal KPI strip to an interactive **COE premiums** card with category toggles, SVG area chart, and **`CostTrendChip`** (inverted sentiment for “cost down is good”). **Market overview** becomes a powertrain donut; yearly and top-makes charts share skin **`CARD`** styling instead of HeroUI `Card`.
> 
> **Monthly change** and **recent posts** are **commented out** on the home page (components restyled but not shown). Recent-posts grid breakpoints and a Vitest snapshot are updated for the new column rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb1983fd15ff3c1c3a55bb4dd85264fc36abf02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->