### PR TITLE
Compare like periods in make registration stats

### DIFF
--- a/apps/web/src/queries/cars/makes/registration-stats.test.ts
+++ b/apps/web/src/queries/cars/makes/registration-stats.test.ts
@@ -1,6 +1,32 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { queueSelect, resetDbMocks } from "../../test-utils";
-import { getMakeRegistrationStats } from "./registration-stats";
+import {
+  getComparisonWindows,
+  getMakeRegistrationStats,
+} from "./registration-stats";
+
+describe("getComparisonWindows", () => {
+  it("should end both windows on the same month rather than running the previous year to December", () => {
+    expect(getComparisonWindows("2025-08")).toEqual({
+      current: { start: "2025-01", end: "2025-08" },
+      previous: { start: "2024-01", end: "2024-08" },
+    });
+  });
+
+  it("should zero-pad a single-digit month on both sides", () => {
+    expect(getComparisonWindows("2025-03")).toEqual({
+      current: { start: "2025-01", end: "2025-03" },
+      previous: { start: "2024-01", end: "2024-03" },
+    });
+  });
+
+  it("should span the full year once the latest month is December", () => {
+    expect(getComparisonWindows("2025-12")).toEqual({
+      current: { start: "2025-01", end: "2025-12" },
+      previous: { start: "2024-01", end: "2024-12" },
+    });
+  });
+});
 
 describe("getMakeRegistrationStats", () => {
   beforeEach(() => {
@@ -54,6 +80,18 @@ describe("getMakeRegistrationStats", () => {
 
     const honda = result.find((r) => r.make === "HONDA");
     expect(honda?.yoyChange).toBeCloseTo(-16.67, 1); // (500-600)/600 * 100
+  });
+
+  it("should report no change for a make whose volume is flat across the two windows", async () => {
+    queueSelect([{ latestMonth: "2025-08" }]);
+    // January to August 2025, and the same eight months of 2024.
+    queueSelect([{ make: "TOYOTA", count: 800 }]);
+    queueSelect([]);
+    queueSelect([{ make: "TOYOTA", count: 800 }]);
+
+    const result = await getMakeRegistrationStats();
+
+    expect(result[0].yoyChange).toBeCloseTo(0, 5);
   });
 
   it("should return null yoyChange when make has no previous year data", async () => {

--- a/apps/web/src/queries/cars/makes/registration-stats.ts
+++ b/apps/web/src/queries/cars/makes/registration-stats.ts
@@ -9,6 +9,36 @@ export interface MakeRegistrationStat {
   yoyChange: number | null;
 }
 
+interface ComparisonWindow {
+  start: string;
+  end: string;
+}
+
+/**
+ * The two windows a year-over-year comparison has to use: January through the
+ * latest month with data, and exactly the same span a year earlier.
+ *
+ * Both windows end on the same month number. Running the previous side to
+ * December while the current side stopped at the latest month is what made
+ * `yoyChange` read roughly −33% in August for a make whose volume had not moved
+ * at all, because it measured a part-complete year against a complete one.
+ *
+ * Exported so the windows can be asserted directly — the query builder is
+ * mocked in tests, which leaves the `where` clauses otherwise unobservable.
+ */
+export function getComparisonWindows(latestMonth: string): {
+  current: ComparisonWindow;
+  previous: ComparisonWindow;
+} {
+  const [year, monthNumber] = latestMonth.split("-").map(Number);
+  const paddedMonth = String(monthNumber).padStart(2, "0");
+
+  return {
+    current: { start: `${year}-01`, end: `${year}-${paddedMonth}` },
+    previous: { start: `${year - 1}-01`, end: `${year - 1}-${paddedMonth}` },
+  };
+}
+
 /**
  * Get registration count, market share, and rolling 12-month trend per make.
  */
@@ -28,9 +58,9 @@ export async function getMakeRegistrationStats(): Promise<
     return [];
   }
 
-  const year = latestMonth.split("-")[0];
+  const { current, previous } = getComparisonWindows(latestMonth);
 
-  // Annual totals for the latest year (for count + share)
+  // Year-to-date totals for the latest year (for count + share)
   const annualRows = await db
     .select({
       make: cars.make,
@@ -38,7 +68,7 @@ export async function getMakeRegistrationStats(): Promise<
     })
     .from(cars)
     .where(
-      sql`${cars.month} >= ${`${year}-01`} and ${cars.month} <= ${`${year}-12`}`,
+      sql`${cars.month} >= ${current.start} and ${cars.month} <= ${current.end}`,
     )
     .groupBy(cars.make);
 
@@ -74,9 +104,7 @@ export async function getMakeRegistrationStats(): Promise<
     {},
   );
 
-  const prevYear = String(Number(year) - 1);
-
-  // Annual totals for the previous year (for YoY comparison)
+  // The same January-to-month span a year earlier (for YoY comparison)
   const prevYearRows = await db
     .select({
       make: cars.make,
@@ -84,7 +112,7 @@ export async function getMakeRegistrationStats(): Promise<
     })
     .from(cars)
     .where(
-      sql`${cars.month} >= ${`${prevYear}-01`} and ${cars.month} <= ${`${prevYear}-12`}`,
+      sql`${cars.month} >= ${previous.start} and ${cars.month} <= ${previous.end}`,
     )
     .groupBy(cars.make);
 


### PR DESCRIPTION
Fixes #915.

`getMakeRegistrationStats` measured the current year to date against the **full** previous year — its current window ran to `{year}-12` but data only exists to the latest month, while the previous window genuinely spanned twelve. Every make therefore reported a large artificial decline: in August, eight months measured against twelve, so a make with flat volume read about −33%.

- Clamps both windows to the same month span via a new `getComparisonWindows` helper
- The same class of bug was already worked around in `summary-card.tsx`; this fixes it at the source

**On the tests** — the behavioural test here cannot fail on its own. `queries/test-utils.ts` stubs `where()` as a no-op, so the mock returns whatever was queued regardless of the window the query asked for. The real guard is the direct assertions on `getComparisonWindows`, verified by reintroducing the old bound and watching two of them fail. The flat-volume test documents intent rather than catching the regression.

Split out of the page rebuilds because it stands alone and everything above it depends on the number being right.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how make registration totals, market share, and YoY are computed for the makes dashboard—correctness fix but downstream numbers will shift until data is complete for the year.
> 
> **Overview**
> Fixes incorrect **year-over-year** (`yoyChange`) and aligns **count/share** windows in `getMakeRegistrationStats` by comparing the same calendar span on both sides.
> 
> Previously the current side used January through the latest month while the prior year ran through **December**, so mid-year comparisons looked sharply negative (e.g. flat volume in August reading about **−33%**). A new exported **`getComparisonWindows`** builds matching **Jan→latest-month** windows for the current and prior year (with zero-padded months; full year when latest is December), and both aggregation queries now use those bounds.
> 
> Tests add direct coverage for **`getComparisonWindows`** plus a flat-volume `yoyChange` case; the PR notes DB mocks do not assert `where` clauses, so the window tests are the main regression guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6cf2907fd139141607b3bbc8afc8a725346fd23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->