### PR TITLE
Disable SonarCloud workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,15 +1,18 @@
 name: SonarCloud
 
+# Disabled: manual dispatch only. Restore the push/pull_request triggers below
+# to re-enable automatic scans.
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+  workflow_dispatch:
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - synchronize
+  #     - reopened
+  #     - ready_for_review
 
 env:
   HEROUI_AUTH_TOKEN: ${{ secrets.HEROUI_AUTH_TOKEN }}


### PR DESCRIPTION
- Comment out the `push` and `pull_request` triggers so SonarCloud no longer runs automatically
- Keep the workflow file and `workflow_dispatch` so it can still be run manually and re-enabled by uncommenting

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790348422&installation_model_id=21947&pr_number=923&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F923&signature=2af35c001c7529b6cb0c2d15b023935e6107216a764c1190cdacacfcb6e0be30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change; SonarCloud can still be run manually and re-enabled by uncommenting triggers, with no application or security logic affected.
> 
> **Overview**
> **Stops SonarCloud from running on every push to `main` and on pull request events** by removing those `on` triggers from `.github/workflows/sonarcloud.yml`.
> 
> The workflow is still present and can be started with **`workflow_dispatch`**. The previous `push` and `pull_request` configuration is left commented with a short note on how to turn automatic scans back on. **Job steps, secrets, and the Sonar scan itself are unchanged**—only when the workflow runs changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abcd258d0b71791dc6431476d550bb1427bf367e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->