### PR TITLE
Cut CI cost: default runner for low-compute jobs, fix turbo --affected

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,6 +32,10 @@ jobs:
       UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
       BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
       BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+      # --affected defaults to a local `main` branch, which does not exist on a
+      # PR or merge queue checkout. Pin the range to the event payload instead.
+      TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+      TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   publish:
     name: Publish
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-latest
     needs: checks
     permissions:
       contents: write

--- a/.github/workflows/run-migrations.yml
+++ b/.github/workflows/run-migrations.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   run-migrations:
     name: Run Database Migrations
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     # Concurrency group name ensures concurrent workflow runs wait for any in-progress job to finish
     concurrency:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   sonarcloud:
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0


### PR DESCRIPTION
- Keep the 4 vCPU Blacksmith runner only for the jobs that do real work: `checks.yml` and the `checks` job in `release.yml`, both of which run `pnpm install` plus `turbo run test lint`
- Move dependency review to `ubuntu-latest` — it is a checkout and one GitHub API call, ~25-30s, but fires on every PR sync
- Move the `release` job to `ubuntu-latest` — semantic-release is git and API calls, and the `checks` job already ran the tests
- Move MCP publish, SonarCloud (currently dispatch-only) and the two `workflow_call` workflows to `ubuntu-latest`; `test.yml` and `run-migrations.yml` have no callers and have never run
- Fix `turbo run --affected` in `checks.yml`, which was silently running every task on every PR. It defaults to comparing against a local branch named `main`, but a pull_request or merge_group checkout only has the remote-tracking ref, so the range failed to resolve. `TURBO_SCM_BASE` and `TURBO_SCM_HEAD` now come from the event payload
- The repo is public, so GitHub-hosted runners are free and these jobs were paying for parallelism they cannot use