### PR TITLE
Add report and site page layout primitives

### DIFF
--- a/apps/web/src/app/(main)/(site)/layout.tsx
+++ b/apps/web/src/app/(main)/(site)/layout.tsx
@@ -1,9 +1,0 @@
-import type { ReactNode } from "react";
-
-// The shell (nav, footer, page padding) lives in (main)/layout.tsx. Editorial
-// pages sit in a narrower column than the data dashboards, matching the comps.
-export default function SiteLayout({
-  children,
-}: Readonly<{ children: ReactNode }>) {
-  return <div className="mx-auto w-full max-w-[1180px]">{children}</div>;
-}

--- a/apps/web/src/app/(main)/layout.tsx
+++ b/apps/web/src/app/(main)/layout.tsx
@@ -14,7 +14,12 @@ export default function MainLayout({
       <Announcement />
       <Banner />
 
-      <div className="mx-auto flex min-h-screen w-full max-w-[1560px] flex-col gap-8 px-4 py-8 sm:px-6 lg:px-9 lg:py-9">
+      {/*
+        Every page draws the same column — `max-w-page`, defined once in
+        `globals.css`. The nav and footer sit inside it, so they line up with
+        the content beneath them, and the two bars above use the same measure.
+      */}
+      <div className="mx-auto flex min-h-screen w-full max-w-page flex-col gap-8 px-4 py-8 sm:px-6 lg:px-9 lg:py-9">
         <AppNav />
         <main className="flex flex-1 flex-col gap-8">{children}</main>
         <Footer />

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -4,6 +4,12 @@
 
 @plugin "@tailwindcss/typography";
 
+/* One page measure. The nav, the content, the footer and the announcement and
+   banner bars all draw the same column, so they line up down the whole page. */
+@theme {
+  --container-page: 97.5rem; /* 1560px */
+}
+
 /* ---------------------------------------------------------------------------
    MotorMetrics theme.
 

--- a/apps/web/src/components/shared/page-head.tsx
+++ b/apps/web/src/components/shared/page-head.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@heroui/react";
 import { Breadcrumbs } from "@web/components/shared/breadcrumbs";
 import { SharePill } from "@web/components/shared/share-pill";
 import Typography from "@web/components/typography";
@@ -5,26 +6,41 @@ import type { ReactNode } from "react";
 
 /**
  * Breadcrumb + oversized title, with an optional slot for the controls the
- * comps park on the right (month picker, range tabs). Every v2 Overview page
- * opens with this exact block.
+ * comps park on the right (month picker, range tabs). Every v2 page opens with
+ * this exact block.
  *
  * The breadcrumb derives its trail from the pathname and the share pill from
  * the title, so neither needs threading through the call sites.
+ *
+ * `description` is the lede the report-family comps carry under the title and
+ * the bento-family ones do not — passing it is what distinguishes the two
+ * openings. The comps set the title two pixels apart between families (50 vs
+ * 52); that is below the threshold worth a variant, so both use one scale.
  */
 export function PageHead({
   controls,
+  description,
   title,
 }: {
   controls?: ReactNode;
+  /** Lede paragraph. Report-family pages set it; bento-family pages omit it. */
+  description?: string;
   title: string;
 }) {
   return (
     <div className="flex flex-wrap items-end gap-6">
-      <div className="flex flex-col gap-2">
+      <div
+        className={cn("flex flex-col gap-2", description && "max-w-[41rem]")}
+      >
         <Breadcrumbs />
         <Typography.H1 className="font-bold text-[2.75rem] leading-[1.05] tracking-[-0.02em] lg:text-[3.25rem]">
           {title}
         </Typography.H1>
+        {description ? (
+          <Typography.TextLg className="font-medium text-[1.0625rem] text-muted leading-normal">
+            {description}
+          </Typography.TextLg>
+        ) : null}
       </div>
       <div className="ml-auto flex flex-wrap items-center gap-3">
         {controls}

--- a/apps/web/src/components/shared/report-table.test.tsx
+++ b/apps/web/src/components/shared/report-table.test.tsx
@@ -1,0 +1,145 @@
+import { render } from "@testing-library/react";
+import {
+  Count,
+  DeltaText,
+  ReportCell,
+  ReportRow,
+  ReportTable,
+  ShareBar,
+} from "./report-table";
+
+describe("ReportTable", () => {
+  it("should render column headers and the rows passed in", () => {
+    const { getByRole, getByText } = render(
+      <ReportTable
+        columns={[
+          { label: "Make", width: "40%" },
+          { align: "end", label: "Registrations" },
+        ]}
+      >
+        <ReportRow>
+          <ReportCell>Toyota</ReportCell>
+          <ReportCell align="end">1,234</ReportCell>
+        </ReportRow>
+      </ReportTable>,
+    );
+
+    expect(getByRole("table")).toBeInTheDocument();
+    expect(getByRole("columnheader", { name: "Make" })).toHaveClass(
+      "text-left",
+    );
+    expect(getByRole("columnheader", { name: "Registrations" })).toHaveClass(
+      "text-right",
+    );
+    expect(getByText("Toyota")).toBeInTheDocument();
+  });
+
+  it("should key an unlabelled column off its width", () => {
+    const { getByRole } = render(
+      <ReportTable columns={[{ label: "", width: "30%" }]}>
+        <ReportRow>
+          <ReportCell>Share</ReportCell>
+        </ReportRow>
+      </ReportTable>,
+    );
+
+    expect(getByRole("columnheader")).toHaveStyle({ width: "30%" });
+  });
+});
+
+describe("ReportRow", () => {
+  it("should tint the active row", () => {
+    const { getByRole } = render(
+      <table>
+        <tbody>
+          <ReportRow isActive>
+            <ReportCell>Electric</ReportCell>
+          </ReportRow>
+        </tbody>
+      </table>,
+    );
+
+    expect(getByRole("row")).toHaveClass("bg-accent-soft-2");
+  });
+
+  it("should leave an inactive row untinted", () => {
+    const { getByRole } = render(
+      <table>
+        <tbody>
+          <ReportRow>
+            <ReportCell>Petrol</ReportCell>
+          </ReportRow>
+        </tbody>
+      </table>,
+    );
+
+    expect(getByRole("row")).not.toHaveClass("bg-accent-soft-2");
+  });
+});
+
+describe("ReportCell", () => {
+  it("should merge alignment and caller class names", () => {
+    const { getByRole } = render(
+      <table>
+        <tbody>
+          <tr>
+            <ReportCell align="end" className="font-bold">
+              1,234
+            </ReportCell>
+          </tr>
+        </tbody>
+      </table>,
+    );
+
+    const cell = getByRole("cell");
+    expect(cell).toHaveClass("text-right");
+    expect(cell).toHaveClass("font-bold");
+  });
+});
+
+describe("ShareBar", () => {
+  it("should size the fill to the share", () => {
+    const { container } = render(<ShareBar share={42.35} />);
+
+    const fill = container.querySelector("span > span");
+    expect(fill).toHaveStyle({ width: "42.4%" });
+    expect(fill).toHaveClass("bg-chart-5");
+  });
+
+  it("should mark the leader and clamp an over-full share", () => {
+    const { container } = render(<ShareBar isLeader share={120} />);
+
+    const fill = container.querySelector("span > span");
+    expect(fill).toHaveStyle({ width: "100.0%" });
+    expect(fill).toHaveClass("bg-chart-1");
+  });
+});
+
+describe("DeltaText", () => {
+  it("should render a rise with a leading plus", () => {
+    const { getByText } = render(<DeltaText value={12.34} />);
+    expect(getByText("+12.3%")).toHaveClass("text-success-soft-foreground");
+  });
+
+  it("should render a fall with a leading minus", () => {
+    const { getByText } = render(<DeltaText value={-4.5} />);
+    expect(getByText("−4.5%")).toHaveClass("text-warning-soft-foreground");
+  });
+
+  it("should treat zero as a rise", () => {
+    const { getByText } = render(<DeltaText value={0} />);
+    expect(getByText("+0.0%")).toBeInTheDocument();
+  });
+
+  it("should render percentage-point movements", () => {
+    const { getByText } = render(<DeltaText unit="pp" value={2} />);
+    expect(getByText("+2.0pp")).toBeInTheDocument();
+  });
+});
+
+describe("Count", () => {
+  it("should group a registration count", () => {
+    const { getByText } = render(<Count value={12345} />);
+    expect(getByText("12,345")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/shared/report-table.tsx
+++ b/apps/web/src/components/shared/report-table.tsx
@@ -1,0 +1,143 @@
+import { cn } from "@heroui/react";
+import { NumberValue } from "@heroui-pro/react";
+import type { ReactNode } from "react";
+
+/**
+ * The bare, rule-ruled table the report comps use. No card, no surface — the
+ * hairlines carry the structure, so this is a plain semantic table with the
+ * comp's type scale applied.
+ *
+ * Columns differ per table — one carries year-to-date, another a rank and a
+ * logo — so rows are composed by the caller and only the shared furniture lives
+ * here.
+ */
+export function ReportTable({
+  children,
+  columns,
+}: {
+  children: ReactNode;
+  columns: { align?: "end"; label: string; width?: string }[];
+}) {
+  return (
+    <div className="w-full overflow-x-auto">
+      <table className="w-full border-collapse tabular-nums">
+        <thead>
+          <tr>
+            {columns.map(({ align, label, width }) => (
+              <th
+                className={cn(
+                  "border-border border-b px-3.5 pb-3 font-bold text-[0.78125rem] text-muted uppercase tracking-[0.06em]",
+                  align === "end" ? "text-right" : "text-left",
+                )}
+                key={label || width}
+                scope="col"
+                style={width ? { width } : undefined}
+              >
+                {label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  );
+}
+
+/** A row. `isActive` tints the row the way the comp marks the selected fuel type. */
+export function ReportRow({
+  children,
+  isActive,
+}: {
+  children: ReactNode;
+  isActive?: boolean;
+}) {
+  return (
+    <tr
+      className={cn(
+        "transition-colors hover:bg-surface-secondary",
+        isActive && "bg-accent-soft-2",
+      )}
+    >
+      {children}
+    </tr>
+  );
+}
+
+export function ReportCell({
+  align,
+  children,
+  className,
+}: {
+  align?: "end";
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <td
+      className={cn(
+        "border-border border-b px-3.5 py-4",
+        align === "end" && "text-right",
+        className,
+      )}
+    >
+      {children}
+    </td>
+  );
+}
+
+/** The inline proportion bar the comps run in an unlabelled column. */
+export function ShareBar({
+  isLeader,
+  share,
+}: {
+  isLeader?: boolean;
+  share: number;
+}) {
+  return (
+    <span className="block h-2.5 overflow-hidden rounded-full bg-surface-secondary">
+      <span
+        className={cn(
+          "block h-full rounded-full",
+          isLeader ? "bg-chart-1" : "bg-chart-5",
+        )}
+        style={{ width: `${Math.min(share, 100).toFixed(1)}%` }}
+      />
+    </span>
+  );
+}
+
+/**
+ * Signed change as plain coloured text rather than a pill — the comps reserve
+ * the pill for the headline figure and use bare text inside tables.
+ *
+ * A rise in registrations is good news, so the sentiment follows the sign. For
+ * figures where a rise is bad news, see `(dashboard)/components/cost-trend-chip.tsx`.
+ */
+export function DeltaText({
+  unit = "%",
+  value,
+}: {
+  unit?: "%" | "pp";
+  value: number;
+}) {
+  const isUp = value >= 0;
+
+  return (
+    <span
+      className={cn(
+        "font-bold text-[0.96875rem] tabular-nums",
+        isUp ? "text-success-soft-foreground" : "text-warning-soft-foreground",
+      )}
+    >
+      {isUp ? "+" : "−"}
+      {Math.abs(value).toFixed(1)}
+      {unit}
+    </span>
+  );
+}
+
+/** Registration counts, formatted the way every other figure on the site is. */
+export function Count({ value }: { value: number }) {
+  return <NumberValue locale="en-SG" maximumFractionDigits={0} value={value} />;
+}

--- a/apps/web/src/components/shared/report.test.tsx
+++ b/apps/web/src/components/shared/report.test.tsx
@@ -1,0 +1,167 @@
+import { render } from "@testing-library/react";
+import {
+  Report,
+  ReportEyebrow,
+  ReportFilterBar,
+  ReportHeadline,
+  ReportSection,
+  ReportStat,
+} from "./report";
+
+describe("Report", () => {
+  it("should render its children in the report column", () => {
+    const { container, getByText } = render(
+      <Report>
+        <p>Section</p>
+      </Report>,
+    );
+
+    expect(getByText("Section")).toBeInTheDocument();
+    expect(container.querySelector(".gap-8")).toBeInTheDocument();
+  });
+
+  it("should merge a caller class name", () => {
+    const { container } = render(
+      <Report className="pb-16">
+        <p>Section</p>
+      </Report>,
+    );
+
+    expect(container.querySelector(".pb-16")).toBeInTheDocument();
+  });
+});
+
+describe("ReportEyebrow", () => {
+  it("should render its label", () => {
+    const { getByText } = render(<ReportEyebrow>Fuel type</ReportEyebrow>);
+    expect(getByText("Fuel type")).toBeInTheDocument();
+  });
+
+  it("should merge a caller class name", () => {
+    const { getByText } = render(
+      <ReportEyebrow className="text-accent">Fuel type</ReportEyebrow>,
+    );
+    expect(getByText("Fuel type")).toHaveClass("text-accent");
+  });
+});
+
+describe("ReportFilterBar", () => {
+  it("should render the label and the controls passed in", () => {
+    const { getByText, queryByText } = render(
+      <ReportFilterBar label="Fuel type">
+        <button type="button">Petrol</button>
+      </ReportFilterBar>,
+    );
+
+    expect(getByText("Fuel type")).toBeInTheDocument();
+    expect(getByText("Petrol")).toBeInTheDocument();
+    expect(queryByText("Range")).not.toBeInTheDocument();
+  });
+
+  it("should render a trailing control with its own label", () => {
+    const { getByText } = render(
+      <ReportFilterBar
+        className="mt-4"
+        label="Fuel type"
+        trailing={<button type="button">12 months</button>}
+        trailingLabel="Range"
+      >
+        <button type="button">Petrol</button>
+      </ReportFilterBar>,
+    );
+
+    expect(getByText("Range")).toBeInTheDocument();
+    expect(getByText("12 months")).toBeInTheDocument();
+  });
+
+  it("should render a trailing control without a label", () => {
+    const { getByText, queryByText } = render(
+      <ReportFilterBar
+        label="Fuel type"
+        trailing={<button type="button">12 months</button>}
+      >
+        <button type="button">Petrol</button>
+      </ReportFilterBar>,
+    );
+
+    expect(getByText("12 months")).toBeInTheDocument();
+    expect(queryByText("Range")).not.toBeInTheDocument();
+  });
+});
+
+describe("ReportHeadline", () => {
+  it("should render the label and figure alone", () => {
+    const { getByText, queryByText } = render(
+      <ReportHeadline label="Registrations" value="4,321" />,
+    );
+
+    expect(getByText("Registrations")).toBeInTheDocument();
+    expect(getByText("4,321")).toBeInTheDocument();
+    expect(queryByText("vs last month")).not.toBeInTheDocument();
+  });
+
+  it("should render the delta, sub-label and stat cells", () => {
+    const { getByText } = render(
+      <ReportHeadline
+        className="mb-4"
+        delta={<span>+12.3%</span>}
+        label="Registrations"
+        stats={<ReportStat label="Share" value="18.4%" />}
+        sub="vs last month"
+        value="4,321"
+      />,
+    );
+
+    expect(getByText("+12.3%")).toBeInTheDocument();
+    expect(getByText("vs last month")).toBeInTheDocument();
+    expect(getByText("Share")).toBeInTheDocument();
+  });
+});
+
+describe("ReportStat", () => {
+  it("should render a cell without a note", () => {
+    const { getByText, queryByText } = render(
+      <ReportStat label="Share" value="18.4%" />,
+    );
+
+    expect(getByText("Share")).toBeInTheDocument();
+    expect(getByText("18.4%")).toBeInTheDocument();
+    expect(queryByText("of all registrations")).not.toBeInTheDocument();
+  });
+
+  it("should render a cell with a note", () => {
+    const { getByText } = render(
+      <ReportStat label="Share" note="of all registrations" value="18.4%" />,
+    );
+
+    expect(getByText("of all registrations")).toBeInTheDocument();
+  });
+});
+
+describe("ReportSection", () => {
+  it("should render a titled block without a caption", () => {
+    const { getByRole, getByText, queryByText } = render(
+      <ReportSection title="By fuel type">
+        <p>Table</p>
+      </ReportSection>,
+    );
+
+    expect(getByRole("heading", { name: "By fuel type" })).toBeInTheDocument();
+    expect(getByText("Table")).toBeInTheDocument();
+    expect(queryByText("Year to date")).not.toBeInTheDocument();
+  });
+
+  it("should render a caption beside the title", () => {
+    const { getByText } = render(
+      <ReportSection
+        caption="Year to date"
+        className="mt-8"
+        title="By fuel type"
+      >
+        <p>Table</p>
+      </ReportSection>,
+    );
+
+    expect(getByText("Year to date")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/shared/report.tsx
+++ b/apps/web/src/components/shared/report.tsx
@@ -1,0 +1,195 @@
+import { cn } from "@heroui/react";
+import Typography from "@web/components/typography";
+import type { ReactNode } from "react";
+
+/**
+ * The v2 report layout — the editorial counterpart to `shared/bento.tsx`.
+ *
+ * The comps draw two distinct page families. Overview-tier pages use the bento:
+ * a three-column grid of rounded cards. Every detail page instead uses a plain
+ * column with no cards at all, where hairline rules do the work the card edges
+ * do in the bento. This module is that second family.
+ *
+ * It owns the column's rhythm, not its width — every page shares one measure,
+ * set on the shell in `(main)/layout.tsx`.
+ */
+export function Report({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex w-full flex-col gap-8", className)}>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The controls strip beneath the page head, ruled top and bottom.
+ *
+ * The comps put the primary dimension on the left as bare pills and a secondary
+ * one on the right as a segmented group on sand. Both are passed in rather than
+ * built here — every page filters on something different, and the tab controls
+ * are already client components bound to their own search params.
+ */
+export function ReportFilterBar({
+  children,
+  className,
+  label,
+  trailing,
+  trailingLabel,
+}: {
+  children: ReactNode;
+  className?: string;
+  /** Uppercase label naming what the left-hand control filters on. */
+  label: string;
+  /** Optional right-aligned control — a range or measure switch in the comps. */
+  trailing?: ReactNode;
+  trailingLabel?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-4 border-border border-y py-4",
+        className,
+      )}
+    >
+      <ReportEyebrow>{label}</ReportEyebrow>
+      <div className="flex flex-wrap items-center gap-2">{children}</div>
+      {trailing ? (
+        <div className="ml-auto flex flex-wrap items-center gap-3">
+          {trailingLabel ? (
+            <ReportEyebrow>{trailingLabel}</ReportEyebrow>
+          ) : null}
+          {trailing}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The small caps label the comps use to name a control or a column group.
+ * Exported because the filter bar is not the only place they appear.
+ */
+export function ReportEyebrow({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "font-bold text-[0.8125rem] text-muted uppercase tracking-[0.08em]",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+/**
+ * The headline figure and the stat cells beside it.
+ *
+ * Unlike the bento hero, which is a card, this sits directly on the page
+ * background — the figure is the only emphasis, which is why it runs to 72px
+ * with no surface behind it.
+ */
+export function ReportHeadline({
+  className,
+  delta,
+  label,
+  stats,
+  sub,
+  value,
+}: {
+  className?: string;
+  /** Signed-change pill — pass `DeltaChip`, or `CostTrendChip` where a rise is bad news. */
+  delta?: ReactNode;
+  label: string;
+  /** `ReportStat` cells, rendered hard right. */
+  stats?: ReactNode;
+  sub?: string;
+  value: ReactNode;
+}) {
+  return (
+    <div className={cn("flex flex-wrap items-end gap-12", className)}>
+      <div className="flex flex-col gap-2">
+        <Typography.TextSm className="font-semibold text-base text-muted-strong">
+          {label}
+        </Typography.TextSm>
+        <div className="flex items-center gap-4">
+          <span className="font-extrabold text-[3.5rem] tabular-nums leading-none tracking-[-0.03em] lg:text-[4.5rem]">
+            {value}
+          </span>
+          {delta}
+        </div>
+        {sub ? (
+          <Typography.TextSm className="font-medium">{sub}</Typography.TextSm>
+        ) : null}
+      </div>
+      {stats ? <div className="ml-auto flex flex-wrap">{stats}</div> : null}
+    </div>
+  );
+}
+
+/** One rule-divided cell in a `ReportHeadline`'s stat group. */
+export function ReportStat({
+  label,
+  note,
+  value,
+}: {
+  label: string;
+  note?: string;
+  value: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5 border-border border-l px-6">
+      <span className="font-semibold text-[0.8125rem] text-muted">{label}</span>
+      <span className="font-extrabold text-2xl tabular-nums tracking-[-0.02em]">
+        {value}
+      </span>
+      {note ? (
+        <span className="font-medium text-muted text-xs">{note}</span>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * A titled block — the comps run several down each detail page, each opening
+ * with a heading and a muted caption qualifying the figures beneath it.
+ */
+export function ReportSection({
+  caption,
+  children,
+  className,
+  title,
+}: {
+  caption?: string;
+  children: ReactNode;
+  className?: string;
+  title: string;
+}) {
+  return (
+    <section className={cn("flex flex-col gap-4", className)}>
+      <div className="flex flex-wrap items-baseline gap-4">
+        <Typography.H2 className="font-bold text-[1.6875rem] tracking-[-0.02em]">
+          {title}
+        </Typography.H2>
+        {caption ? (
+          <Typography.TextSm className="font-medium text-base">
+            {caption}
+          </Typography.TextSm>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/apps/web/src/components/shared/site-page.test.tsx
+++ b/apps/web/src/components/shared/site-page.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/react";
+import { SitePage } from "./site-page";
+
+describe("SitePage", () => {
+  it("should render its children in the shared column", () => {
+    const { container, getByText } = render(
+      <SitePage>
+        <p>About</p>
+      </SitePage>,
+    );
+
+    expect(getByText("About")).toBeInTheDocument();
+    expect(container.querySelector(".gap-16")).toBeInTheDocument();
+  });
+
+  it("should merge a caller class name", () => {
+    const { container } = render(
+      <SitePage className="pb-24">
+        <p>Advertise</p>
+      </SitePage>,
+    );
+
+    expect(container.querySelector(".pb-24")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/shared/site-page.tsx
+++ b/apps/web/src/components/shared/site-page.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@heroui/react";
+import type { ReactNode } from "react";
+
+/**
+ * The `(site)` pages — About, Advertise, Learn and the Learn guides.
+ *
+ * Spacing, not width: every page shares one measure, set on the shell in
+ * `(main)/layout.tsx`. What this owns is the rhythm, which the comps set far
+ * more loosely on these pages than on the dashboard — 56–72px between blocks
+ * against 32px.
+ */
+export function SitePage({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex w-full flex-col gap-16", className)}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
- Add `Report` and `SitePage` layout primitives plus a `ReportTable` helper under `components/shared`.
- Give `PageHead` an optional description lede so the report and bento openings can differ.
- Define one page measure, `--container-page`, on the `(main)` shell so the nav and footer line up with the content.
- Drop `(main)/(site)/layout.tsx` — it only existed to narrow that column.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790571890&installation_model_id=21947&pr_number=927&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F927&signature=a97a6d0a803416aa997012e8f50d386c43973f36ff7e879c7c7129dc90b4eba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

