### PR TITLE
Rebuild about, advertise and learn on the v2 comps

### DIFF
--- a/apps/web/src/app/(main)/(site)/about/components/cta-section.tsx
+++ b/apps/web/src/app/(main)/(site)/about/components/cta-section.tsx
@@ -1,92 +1,49 @@
-"use client";
-
 import { Button } from "@heroui/react";
-
 import Typography from "@web/components/typography";
-import {
-  staggerContainerVariants,
-  staggerItemVariants,
-} from "@web/config/animations";
 import { navLinks } from "@web/config/navigation";
-import { motion } from "framer-motion";
-import { ArrowRight } from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 
+/**
+ * The comp closes on a gradient panel inviting readers to subscribe. There is
+ * no mailing list, so the same panel carries the channels that do exist — the
+ * social accounts each release is posted to.
+ *
+ * `--accent-gradient` is fixed blue in both themes, so the copy takes
+ * `--ink-surface-foreground` (white either way) rather than a token that flips.
+ */
 export function CtaSection() {
   return (
-    <section className="py-20 lg:py-28">
-      <div className="container mx-auto">
-        <motion.div
-          className="flex flex-col items-center gap-10"
-          variants={staggerContainerVariants}
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, amount: 0.2 }}
-        >
-          {/* Header */}
-          <motion.div
-            className="flex flex-col items-center gap-4 text-center"
-            variants={staggerItemVariants}
-          >
-            <Typography.Label className="text-accent-strong uppercase tracking-widest">
-              Stay Updated
-            </Typography.Label>
-            <Typography.H2>Follow for the Latest Updates</Typography.H2>
-            <Typography.TextLg className="max-w-xl text-muted">
-              Get notified when new COE results, car registration data, and
-              market insights are published.
-            </Typography.TextLg>
-          </motion.div>
-
-          {/* Social links */}
-          <motion.div
-            className="flex flex-wrap items-center justify-center gap-4"
-            variants={staggerItemVariants}
-          >
-            {navLinks.socialMedia.map(({ title, url, icon: Icon }) => (
-              <a
-                key={title}
-                href={url}
-                rel="me noreferrer"
-                target="_blank"
-                className="inline-flex h-10 items-center gap-2 rounded-full border border-border px-5 font-medium text-foreground text-sm transition-all hover:border-accent hover:bg-accent/5"
-              >
-                <Icon className="size-4" />
-                <span>{title}</span>
-              </a>
-            ))}
-          </motion.div>
-
-          {/* CTA buttons */}
-          <motion.div
-            className="flex flex-col items-center gap-4 pt-4 sm:flex-row sm:gap-6"
-            variants={staggerItemVariants}
-          >
-            <Link href="/" className="no-underline">
-              <Button
-                variant="primary"
-                size="lg"
-                className="gap-2 rounded-full px-8"
-              >
-                Explore the Dashboard
-                <ArrowRight className="size-4" />
-              </Button>
-            </Link>
-            {/* TODO: Blog CTA hidden pending a decision on the blog's future.
-                Commented out rather than deleted so it can be restored.
-            <Link href="/blog" className="no-underline">
-              <Button
-                variant="outline"
-                size="lg"
-                className="gap-2 rounded-full px-8 text-foreground"
-              >
-                Read Market Insights
-              </Button>
-            </Link>
-            */}
-          </motion.div>
-        </motion.div>
+    <section className="flex flex-col items-start gap-8 rounded-4xl bg-[image:var(--accent-gradient)] p-8 text-ink-surface-foreground lg:flex-row lg:items-center lg:p-14">
+      <div className="flex max-w-[35rem] flex-col gap-3">
+        <Typography.H2 className="font-bold text-[2rem] text-ink-surface-foreground tracking-[-0.02em] lg:text-[2.375rem]">
+          Get the numbers when they land
+        </Typography.H2>
+        <Typography.Text className="font-medium text-[1.125rem] text-ink-surface-foreground/85 leading-[1.55]">
+          New COE results and registration figures are posted as soon as they
+          publish. Nothing else.
+        </Typography.Text>
+        <div className="flex flex-wrap gap-3 pt-2">
+          {navLinks.socialMedia.map(({ icon: Icon, title, url }) => (
+            <a
+              className="inline-flex items-center gap-2 rounded-full border border-ink-surface-foreground/25 px-4 py-2 font-semibold text-ink-surface-foreground text-sm no-underline transition-colors hover:bg-ink-surface-foreground/10"
+              href={url}
+              key={title}
+              rel="me noreferrer"
+              target="_blank"
+            >
+              <Icon className="size-4" />
+              {title}
+            </a>
+          ))}
+        </div>
       </div>
+      <Link className="no-underline lg:ml-auto" href="/">
+        <Button className="rounded-full" size="lg" variant="secondary">
+          Explore the dashboard
+          <ArrowUpRight className="size-4" />
+        </Button>
+      </Link>
     </section>
   );
 }

--- a/apps/web/src/app/(main)/(site)/about/components/data-section.tsx
+++ b/apps/web/src/app/(main)/(site)/about/components/data-section.tsx
@@ -1,125 +1,72 @@
-"use client";
-
-import { Card } from "@heroui/react";
 import Typography from "@web/components/typography";
-import {
-  fadeInUpVariants,
-  staggerContainerVariants,
-  staggerItemVariants,
-} from "@web/config/animations";
-import { motion } from "framer-motion";
-import { Database, RefreshCw, Shield } from "lucide-react";
 import Link from "next/link";
 
-const features = [
+/**
+ * The comp's ink panel — the one place on the page that inverts. It uses
+ * `--ink-surface` rather than `--foreground` so it stays dark in dark mode
+ * instead of flipping to cream.
+ */
+const provenance = [
   {
-    icon: Database,
-    title: "Official Government Source",
-    description:
-      "All data is sourced directly from the Land Transport Authority (LTA) DataMall, Singapore's official open data portal for transport statistics.",
+    detail: "Official government release, no third-party aggregation",
+    heading: "LTA DataMall",
+    label: "The single upstream source",
   },
   {
-    icon: RefreshCw,
-    title: "Monthly Updates",
-    description:
-      "Registration data is updated within days of each LTA release. COE results are refreshed after every bidding round—twice monthly.",
+    detail:
+      "Registrations land within days of each release; COE results after every bidding exercise",
+    heading: "Every release",
+    label: "Checked and published",
   },
   {
-    icon: Shield,
-    title: "Data Integrity",
-    description:
-      "Data is validated to match the source. Historical records are preserved without modification.",
+    detail: "Gaps are shown as gaps, never filled in",
+    heading: "No estimates",
+    label: "Numbers only",
   },
 ];
 
 export function DataSection() {
   return (
-    <section className="relative -mx-6 overflow-hidden bg-default px-6 py-20 lg:py-28">
-      {/* Subtle background pattern */}
-      <div
-        className="pointer-events-none absolute inset-0 opacity-50"
-        style={{
-          backgroundImage: `radial-gradient(circle at 1px 1px, color-mix(in srgb, var(--muted) 15%, transparent) 1px, transparent 0)`,
-          backgroundSize: "24px 24px",
-        }}
-        aria-hidden="true"
-      />
-
-      <div className="container relative mx-auto">
-        <div className="grid gap-12 lg:grid-cols-12 lg:gap-16">
-          {/* Left column - Header */}
-          <div className="lg:col-span-4">
-            <motion.div
-              className="sticky top-24 flex flex-col gap-6"
-              variants={fadeInUpVariants}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.2 }}
-            >
-              <Typography.Label className="text-accent-strong uppercase tracking-widest">
-                Data Transparency
-              </Typography.Label>
-              <Typography.H2 className="lg:text-4xl">
-                Where the data comes from
-              </Typography.H2>
-              <Typography.Text className="text-muted">
-                Here&apos;s where the data comes from and how it&apos;s
-                processed.
-              </Typography.Text>
-
-              {/* LTA Badge */}
-              <Card className="border-border">
-                <Card.Content className="flex flex-row items-center gap-4">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-default">
-                    <Database className="h-6 w-6 text-muted" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-foreground text-sm">
-                      Data Provider
-                    </div>
-                    <Link
-                      href="https://datamall.lta.gov.sg"
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-accent-strong text-sm underline"
-                    >
-                      LTA DataMall
-                    </Link>
-                  </div>
-                </Card.Content>
-              </Card>
-            </motion.div>
+    <section className="flex flex-col gap-8 rounded-4xl bg-ink-surface p-8 text-ink-surface-foreground lg:p-14">
+      <div className="flex max-w-[40rem] flex-col gap-3.5">
+        <span className="self-start rounded-full bg-accent-on-dark/20 px-4 py-2 font-bold text-accent-on-dark text-sm">
+          Where the data comes from
+        </span>
+        <Typography.H2 className="font-bold text-[2rem] text-ink-surface-foreground tracking-[-0.02em] lg:text-[2.375rem]">
+          One source, checked at every release
+        </Typography.H2>
+        <Typography.Text className="text-[1.125rem] text-ink-surface-foreground/70 leading-[1.6]">
+          Every figure on this site comes from Singapore&apos;s Land Transport
+          Authority via{" "}
+          <Link
+            className="font-medium text-accent-on-dark"
+            href="https://datamall.lta.gov.sg"
+            rel="noreferrer"
+            target="_blank"
+          >
+            DataMall
+          </Link>
+          . We do not estimate, model or fill gaps. When LTA revises a release,
+          we revise with it.
+        </Typography.Text>
+      </div>
+      <div className="grid gap-5 lg:grid-cols-3">
+        {provenance.map(({ detail, heading, label }) => (
+          <div
+            className="flex flex-col gap-2 rounded-2xl bg-ink-surface-foreground/[0.06] p-6"
+            key={heading}
+          >
+            <span className="font-extrabold text-[1.75rem] text-accent-on-dark tracking-[-0.02em]">
+              {heading}
+            </span>
+            <span className="font-semibold text-[0.9375rem] text-ink-surface-foreground/75">
+              {label}
+            </span>
+            <span className="font-medium text-ink-surface-foreground/45 text-sm leading-[1.45]">
+              {detail}
+            </span>
           </div>
-
-          {/* Right column - Features grid */}
-          <div className="lg:col-span-8">
-            <motion.div
-              className="grid gap-6 sm:grid-cols-2"
-              variants={staggerContainerVariants}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.2 }}
-            >
-              {features.map((feature) => (
-                <motion.div key={feature.title} variants={staggerItemVariants}>
-                  <Card className="group h-full border-border/80 transition-all duration-500 hover:border-accent/30 hover:shadow-accent/5 hover:shadow-lg">
-                    <Card.Content className="flex flex-col gap-4">
-                      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-default transition-colors group-hover:bg-accent/10">
-                        <feature.icon className="h-6 w-6 text-muted transition-colors group-hover:text-accent-strong" />
-                      </div>
-                      <div className="flex flex-col gap-2">
-                        <Typography.H4>{feature.title}</Typography.H4>
-                        <Typography.TextSm>
-                          {feature.description}
-                        </Typography.TextSm>
-                      </div>
-                    </Card.Content>
-                  </Card>
-                </motion.div>
-              ))}
-            </motion.div>
-          </div>
-        </div>
+        ))}
       </div>
     </section>
   );

--- a/apps/web/src/app/(main)/(site)/about/components/datasets-section.tsx
+++ b/apps/web/src/app/(main)/(site)/about/components/datasets-section.tsx
@@ -1,0 +1,98 @@
+import { Card } from "@heroui/react";
+import Typography from "@web/components/typography";
+import {
+  BarChart3,
+  Car,
+  DollarSign,
+  FileMinus,
+  History,
+  type LucideIcon,
+  Zap,
+} from "lucide-react";
+import type { Route } from "next";
+import Link from "next/link";
+
+interface Dataset {
+  description: string;
+  href: Route;
+  icon: LucideIcon;
+  title: string;
+}
+
+const datasets: Dataset[] = [
+  {
+    description:
+      "Monthly car registrations by make, vehicle type and fuel type.",
+    href: "/cars/registrations",
+    icon: BarChart3,
+    title: "New registrations",
+  },
+  {
+    description:
+      "Every bidding exercise across Categories A to E, with quota and bids received.",
+    href: "/coe/premiums",
+    icon: DollarSign,
+    title: "COE premiums",
+  },
+  {
+    description:
+      "The prevailing quota premium for renewing a COE, as a 3-month moving average.",
+    href: "/coe/pqp",
+    icon: History,
+    title: "PQP rates",
+  },
+  {
+    description: "Vehicles taken off the road each month, by category.",
+    href: "/cars/deregistrations",
+    icon: FileMinus,
+    title: "Deregistrations",
+  },
+  {
+    description:
+      "Every vehicle on Singapore roads, split by fuel type and year.",
+    href: "/cars/annual",
+    icon: Car,
+    title: "Vehicle population",
+  },
+  {
+    description:
+      "Battery-electric and hybrid share of new registrations, by make and month.",
+    href: "/cars/electric-vehicles",
+    icon: Zap,
+    title: "EV adoption",
+  },
+];
+
+export function DatasetsSection() {
+  return (
+    <section className="flex flex-col gap-7">
+      <div className="grid items-start gap-4 lg:grid-cols-[300px_1fr] lg:gap-14">
+        <Typography.H2 className="font-bold text-[2.125rem] tracking-[-0.02em]">
+          What we track
+        </Typography.H2>
+        <Typography.Text className="max-w-[38rem] text-[1.1875rem] leading-[1.65]">
+          Six datasets, each with its own history and filters.
+        </Typography.Text>
+      </div>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {datasets.map(({ description, href, icon: Icon, title }) => (
+          <Link className="no-underline" href={href} key={title}>
+            <Card className="h-full transition-shadow hover:shadow-hover">
+              <Card.Content className="flex flex-col gap-3">
+                <span className="flex size-12 items-center justify-center rounded-full bg-accent-soft text-accent-strong">
+                  <Icon className="size-5.5" />
+                </span>
+                <Typography.H3 className="font-bold text-[1.3125rem] tracking-[-0.01em]">
+                  {title}
+                </Typography.H3>
+                <Typography.TextSm className="font-medium text-base leading-[1.5]">
+                  {description}
+                </Typography.TextSm>
+              </Card.Content>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/(main)/(site)/about/components/faq-data.ts
+++ b/apps/web/src/app/(main)/(site)/about/components/faq-data.ts
@@ -1,0 +1,36 @@
+export interface Faq {
+  answer: string;
+  question: string;
+}
+
+/**
+ * Shared between the accordion and the page's `FAQPage` structured data, so
+ * the answers Google indexes are the ones actually on the page.
+ */
+export const FAQS: Faq[] = [
+  {
+    answer:
+      "Registration figures are refreshed within days of each LTA release. COE results are published after every bidding exercise, twice a month.",
+    question: "How often is the data updated?",
+  },
+  {
+    answer:
+      "All figures are sourced from Singapore's Land Transport Authority via DataMall. Nothing is estimated or modelled.",
+    question: "Where does the data come from?",
+  },
+  {
+    answer:
+      "Yes. The platform is free and open, with no account required to explore the data.",
+    question: "Is MotorMetrics free to use?",
+  },
+  {
+    answer:
+      "Yes, with attribution to MotorMetrics and LTA DataMall. The underlying data remains subject to LTA's own terms of use.",
+    question: "Can I use the charts in my own work?",
+  },
+  {
+    answer:
+      "LTA occasionally revises past releases. When that happens we replace our copy rather than keep the old number, so the site always reflects the current official figure.",
+    question: "Why do some historical figures change?",
+  },
+];

--- a/apps/web/src/app/(main)/(site)/about/components/faq-section.tsx
+++ b/apps/web/src/app/(main)/(site)/about/components/faq-section.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Accordion } from "@heroui/react";
+import { FAQS } from "@web/app/(main)/(site)/about/components/faq-data";
+import Typography from "@web/components/typography";
+import { ChevronDown } from "lucide-react";
+
+/**
+ * The comp opens the first question and leaves the rest closed, one at a time —
+ * which is the Accordion default, so only `defaultExpandedKeys` is set here.
+ */
+export function FaqSection() {
+  return (
+    <section className="grid items-start gap-8 lg:grid-cols-[300px_1fr] lg:gap-14">
+      <Typography.H2 className="font-bold text-[2.125rem] tracking-[-0.02em]">
+        Common questions
+      </Typography.H2>
+      <Accordion
+        className="w-full"
+        defaultExpandedKeys={[FAQS[0].question]}
+        variant="surface"
+      >
+        {FAQS.map(({ answer, question }) => (
+          <Accordion.Item id={question} key={question}>
+            <Accordion.Heading>
+              <Accordion.Trigger className="font-bold text-[1.1875rem] tracking-[-0.01em]">
+                {question}
+                <Accordion.Indicator>
+                  <ChevronDown />
+                </Accordion.Indicator>
+              </Accordion.Trigger>
+            </Accordion.Heading>
+            <Accordion.Panel>
+              <Accordion.Body className="max-w-[40rem] text-[1.0625rem] text-muted leading-[1.6]">
+                {answer}
+              </Accordion.Body>
+            </Accordion.Panel>
+          </Accordion.Item>
+        ))}
+      </Accordion>
+    </section>
+  );
+}

--- a/apps/web/src/app/(main)/(site)/about/components/hero-section.tsx
+++ b/apps/web/src/app/(main)/(site)/about/components/hero-section.tsx
@@ -1,10 +1,42 @@
-import { SitePageHero } from "@web/components/site-page-hero";
+import { Button } from "@heroui/react";
+import { Breadcrumbs } from "@web/components/shared/breadcrumbs";
+import Typography from "@web/components/typography";
+import { ArrowUpRight } from "lucide-react";
+import Link from "next/link";
 
+/**
+ * The comp opens the `(site)` pages on the breadcrumb, an eyebrow pill and an
+ * oversized title — larger than the dashboard `PageHead`, which is why this is
+ * written here rather than reusing it. There is also no share pill: these are
+ * prose pages, not a figure anyone would send on.
+ */
 export function HeroSection() {
   return (
-    <SitePageHero
-      description="Vehicle registration data and COE bidding results, presented in a way that's easier to understand. No spreadsheets required."
-      title="Making Sense of Singapore's Car Market"
-    />
+    <section className="flex flex-col gap-6">
+      <Breadcrumbs />
+      <span className="self-start rounded-full bg-accent-soft px-4 py-2 font-bold text-accent-strong text-sm">
+        Singapore car market data
+      </span>
+      <Typography.H1 className="max-w-[56rem] font-bold text-[3rem] leading-[1.02] tracking-[-0.03em] lg:text-[4.75rem]">
+        Making sense of Singapore&apos;s car market
+      </Typography.H1>
+      <Typography.TextLg className="max-w-[45rem] font-medium text-[1.375rem] text-muted leading-[1.5]">
+        Vehicle registration data and COE bidding results, presented in a way
+        that is easier to understand. No spreadsheets required.
+      </Typography.TextLg>
+      <div className="flex flex-wrap gap-3 pt-2">
+        <Link className="no-underline" href="/">
+          <Button className="rounded-full" size="lg" variant="primary">
+            Explore the data
+            <ArrowUpRight className="size-4" />
+          </Button>
+        </Link>
+        <Link className="no-underline" href="/learn">
+          <Button className="rounded-full" size="lg" variant="secondary">
+            Read the guides
+          </Button>
+        </Link>
+      </div>
+    </section>
   );
 }

--- a/apps/web/src/app/(main)/(site)/about/components/mission-section.tsx
+++ b/apps/web/src/app/(main)/(site)/about/components/mission-section.tsx
@@ -1,95 +1,47 @@
-"use client";
-
-import { Card } from "@heroui/react";
-
 import Typography from "@web/components/typography";
 import { SITE_TITLE } from "@web/config";
-import { fadeInUpVariants } from "@web/config/animations";
-import { motion } from "framer-motion";
+import Link from "next/link";
 
+/**
+ * The comp runs the prose blocks as a two-column split: the heading holds a
+ * fixed 300px rail on the left and the paragraphs take the rest. It collapses
+ * to a single column below `lg`, where 300px would leave the text too narrow.
+ */
 export function MissionSection() {
   return (
-    <section className="py-20 lg:py-28">
-      <div className="grid gap-12 lg:grid-cols-12 lg:gap-16">
-        {/* Left column - Pull quote */}
-        <div className="lg:col-span-5">
-          <motion.div
-            className="sticky top-24"
-            initial={{ opacity: 0, y: 32 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.2 }}
-            transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
+    <section className="grid items-start gap-8 lg:grid-cols-[300px_1fr] lg:gap-14">
+      <Typography.H2 className="font-bold text-[2.125rem] tracking-[-0.02em]">
+        What we do
+      </Typography.H2>
+      <div className="flex flex-col gap-5">
+        <Typography.Text className="text-[1.1875rem] leading-[1.65]">
+          Each time LTA publishes, we pull the latest figures from DataMall,
+          check them against the previous release, and turn them into charts you
+          can read in a few seconds. Registrations, deregistrations, COE
+          premiums, PQP rates, fuel type mix and the vehicle population all sit
+          on one platform.
+        </Typography.Text>
+        <Typography.Text className="text-[1.1875rem] leading-[1.65]">
+          The raw data is public, but it arrives as spreadsheets with column
+          headers like <em>MonthOfRegistration</em> and no context. We do the
+          joining, the naming and the arithmetic, then show the trend beside the
+          number so you can tell whether this month&apos;s premium is high or
+          low.
+        </Typography.Text>
+        <Typography.Text className="text-[1.1875rem] leading-[1.65]">
+          {SITE_TITLE} is free and open. There is no account to create and
+          nothing behind a paywall. It is an independent project, built and
+          maintained by{" "}
+          <Link
+            className="font-medium text-accent-strong"
+            href="https://ruchern.dev"
+            rel="noreferrer"
+            target="_blank"
           >
-            <blockquote className="border-accent border-l-4 pl-6">
-              <p className="font-medium text-2xl text-foreground leading-relaxed lg:text-3xl">
-                Car buying in Singapore shouldn&apos;t feel like navigating a
-                maze blindfolded.
-              </p>
-            </blockquote>
-          </motion.div>
-        </div>
-
-        {/* Right column - Mission text */}
-        <div className="flex flex-col gap-8 lg:col-span-7">
-          <motion.div
-            className="flex flex-col gap-6"
-            initial={{ opacity: 0, y: 32 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.2 }}
-            transition={{ duration: 0.7, delay: 0.1, ease: [0.16, 1, 0.3, 1] }}
-          >
-            <Typography.H2 className="lg:text-4xl">Our Mission</Typography.H2>
-            <div className="flex flex-col gap-4">
-              <Typography.TextLg className="text-muted">
-                Singapore&apos;s car market is uniquely complex. Between COE
-                premiums that swing wildly, registration quotas that change
-                monthly, and a maze of vehicle categories, making informed
-                decisions feels nearly impossible.
-              </Typography.TextLg>
-              <Typography.TextLg className="text-muted">
-                We built {SITE_TITLE} to change that. By aggregating official
-                data from the Land Transport Authority and presenting it through
-                intuitive visualisations, we hope to make this data easier to
-                find and explore, rather than scattered across government
-                portals and industry reports.
-              </Typography.TextLg>
-              <Typography.TextLg className="text-muted">
-                Whether you&apos;re a first-time buyer trying to time your
-                purchase, a dealer analysing market trends, or simply curious
-                about Singapore&apos;s automotive landscape—this site might
-                help.
-              </Typography.TextLg>
-            </div>
-          </motion.div>
-
-          {/* Key points */}
-          <motion.div
-            className="grid gap-6 border-border border-t pt-8 sm:grid-cols-2"
-            variants={fadeInUpVariants}
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true, amount: 0.2 }}
-            transition={{ delay: 0.2 }}
-          >
-            <Card className="border-none bg-transparent shadow-none">
-              <Card.Content className="flex flex-col gap-2 p-0">
-                <Typography.H4>Data-Driven Decisions</Typography.H4>
-                <Typography.TextSm>
-                  Historical trends to help inform your decisions.
-                </Typography.TextSm>
-              </Card.Content>
-            </Card>
-            <Card className="border-none bg-transparent shadow-none">
-              <Card.Content className="flex flex-col gap-2 p-0">
-                <Typography.H4>Always Up-to-Date</Typography.H4>
-                <Typography.TextSm>
-                  Fresh data after every COE bidding round and monthly
-                  registration release.
-                </Typography.TextSm>
-              </Card.Content>
-            </Card>
-          </motion.div>
-        </div>
+            Ru Chern
+          </Link>
+          , a software engineer, alongside a full-time job.
+        </Typography.Text>
       </div>
     </section>
   );

--- a/apps/web/src/app/(main)/(site)/about/components/stats-section.tsx
+++ b/apps/web/src/app/(main)/(site)/about/components/stats-section.tsx
@@ -1,103 +1,32 @@
-"use client";
-
-import { Card } from "@heroui/react";
-import { NumberValue } from "@heroui-pro/react";
-
 import Typography from "@web/components/typography";
-import {
-  staggerContainerVariants,
-  staggerItemVariants,
-} from "@web/config/animations";
-import { motion } from "framer-motion";
-import { useState } from "react";
 
-interface StatItemProps {
-  value: number;
-  suffix?: string;
-  label: string;
-}
-
-const StatItem = ({ value, suffix = "", label }: StatItemProps) => {
-  const [isInView, setIsInView] = useState(false);
-
-  return (
-    <motion.div
-      variants={staggerItemVariants}
-      onViewportEnter={() => setIsInView(true)}
-      viewport={{ once: true }}
-    >
-      <Card className="group border-border bg-surface shadow-sm transition-all duration-500 hover:border-accent/30 hover:shadow-accent/5 hover:shadow-lg">
-        <Card.Content className="flex flex-col gap-2">
-          <div className="font-semibold text-4xl text-foreground tracking-tight lg:text-5xl">
-            {isInView ? (
-              <NumberValue
-                locale="en-SG"
-                maximumFractionDigits={0}
-                value={value}
-              >
-                {suffix ? (
-                  <NumberValue.Suffix>{suffix}</NumberValue.Suffix>
-                ) : null}
-              </NumberValue>
-            ) : (
-              <NumberValue locale="en-SG" maximumFractionDigits={0} value={0}>
-                {suffix ? (
-                  <NumberValue.Suffix>{suffix}</NumberValue.Suffix>
-                ) : null}
-              </NumberValue>
-            )}
-          </div>
-          <div className="text-muted text-sm">{label}</div>
-        </Card.Content>
-        {/* Subtle accent line */}
-        <div
-          className="absolute right-6 bottom-0 left-6 h-0.5 scale-x-0 bg-gradient-to-r from-accent to-accent/60 transition-transform duration-300 group-hover:scale-x-100"
-          aria-hidden="true"
-        />
-      </Card>
-    </motion.div>
-  );
-};
+/**
+ * Four bare figures under hairline rules — the comp gives them no card and no
+ * count-up, so the number carries the whole block on its own.
+ */
+const stats = [
+  { label: "Years of COE and registration history", value: "10+" },
+  { label: "Car makes tracked every month", value: "50+" },
+  { label: "COE bidding exercises analysed", value: "120+" },
+  { label: "Monthly data points across every dataset", value: "10,000+" },
+];
 
 export function StatsSection() {
-  const stats = [
-    { value: 10, suffix: "+", label: "Years of historical data" },
-    { value: 50, suffix: "+", label: "Car makes tracked" },
-    { value: 120, suffix: "+", label: "COE bidding rounds analysed" },
-    { value: 10000, suffix: "+", label: "Monthly data points" },
-  ];
-
   return (
-    <section className="py-20 lg:py-28">
-      <div className="flex flex-col gap-12">
-        {/* Section header */}
-        <div className="flex flex-col gap-4">
-          <Typography.Label className="text-accent-strong uppercase tracking-widest">
-            By the Numbers
-          </Typography.Label>
-          <Typography.H2 className="max-w-lg lg:text-4xl">
-            Singapore car market data at a glance
-          </Typography.H2>
-        </div>
-
-        {/* Stats grid - asymmetric */}
-        <motion.div
-          className="grid grid-cols-2 gap-4 lg:grid-cols-4 lg:gap-6"
-          variants={staggerContainerVariants}
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, amount: 0.3 }}
+    <section className="grid grid-cols-2 gap-6 lg:grid-cols-4">
+      {stats.map(({ label, value }) => (
+        <div
+          className="flex flex-col gap-1.5 border-border border-t-2 pt-7"
+          key={label}
         >
-          {stats.map((stat) => (
-            <StatItem
-              key={stat.label}
-              value={stat.value}
-              suffix={stat.suffix}
-              label={stat.label}
-            />
-          ))}
-        </motion.div>
-      </div>
+          <span className="font-extrabold text-[2.5rem] text-foreground tabular-nums leading-none tracking-[-0.03em] lg:text-[2.875rem]">
+            {value}
+          </span>
+          <Typography.TextSm className="font-semibold text-[0.9375rem]">
+            {label}
+          </Typography.TextSm>
+        </div>
+      ))}
     </section>
   );
 }

--- a/apps/web/src/app/(main)/(site)/about/page.tsx
+++ b/apps/web/src/app/(main)/(site)/about/page.tsx
@@ -1,15 +1,23 @@
+import { CtaSection } from "@web/app/(main)/(site)/about/components/cta-section";
+import { DataSection } from "@web/app/(main)/(site)/about/components/data-section";
+import { DatasetsSection } from "@web/app/(main)/(site)/about/components/datasets-section";
+import { FAQS } from "@web/app/(main)/(site)/about/components/faq-data";
+import { FaqSection } from "@web/app/(main)/(site)/about/components/faq-section";
+import { HeroSection } from "@web/app/(main)/(site)/about/components/hero-section";
+import { MissionSection } from "@web/app/(main)/(site)/about/components/mission-section";
+import { StatsSection } from "@web/app/(main)/(site)/about/components/stats-section";
+import { SitePage } from "@web/components/shared/site-page";
 import { StructuredData } from "@web/components/structured-data";
 import { LOGO_URL, SITE_TITLE, SITE_URL } from "@web/config";
 import { SOCIAL_HANDLE, SOCIAL_URLS } from "@web/config/socials";
 import type { Metadata } from "next";
-import type { Organization, Person, WebPage, WithContext } from "schema-dts";
-import { CreatorSection } from "./components/creator-section";
-import { CtaSection } from "./components/cta-section";
-import { DataSection } from "./components/data-section";
-import { HeroSection } from "./components/hero-section";
-import { MissionSection } from "./components/mission-section";
-import { StatsSection } from "./components/stats-section";
-import { TimelineSection } from "./components/timeline-section";
+import type {
+  FAQPage,
+  Organization,
+  Person,
+  WebPage,
+  WithContext,
+} from "schema-dts";
 
 const title = `About ${SITE_TITLE} (formerly SG Cars Trends)`;
 const description = `Learn about ${SITE_TITLE}, a platform for exploring Singapore car registration statistics, COE bidding results, and market data. Built to make car market information easier to find and understand.`;
@@ -85,21 +93,32 @@ export default async function AboutPage() {
     jobTitle: "Software Engineer",
   };
 
+  const faqSchema: WithContext<FAQPage> = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQS.map(({ answer, question }) => ({
+      "@type": "Question",
+      name: question,
+      acceptedAnswer: { "@type": "Answer", text: answer },
+    })),
+  };
+
   return (
     <>
       <StructuredData data={webPageSchema} />
       <StructuredData data={organizationSchema} />
       <StructuredData data={personSchema} />
+      <StructuredData data={faqSchema} />
 
-      <div className="flex flex-col">
+      <SitePage>
         <HeroSection />
         <StatsSection />
         <MissionSection />
+        <DatasetsSection />
         <DataSection />
-        <TimelineSection />
-        <CreatorSection />
+        <FaqSection />
         <CtaSection />
-      </div>
+      </SitePage>
     </>
   );
 }

--- a/apps/web/src/app/(main)/(site)/advertise/components/audience-section.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/components/audience-section.tsx
@@ -1,0 +1,24 @@
+import Typography from "@web/components/typography";
+
+export function AudienceSection() {
+  return (
+    <section className="grid items-start gap-8 lg:grid-cols-[300px_1fr] lg:gap-14">
+      <Typography.H2 className="font-bold text-[2.125rem] tracking-[-0.02em]">
+        Who reads this
+      </Typography.H2>
+      <div className="flex flex-col gap-5">
+        <Typography.Text className="text-[1.1875rem] leading-[1.65]">
+          Readers arrive mid-decision: buyers comparing COE categories, owners
+          weighing a renewal against deregistration, and the dealers, brokers
+          and analysts who advise them. Traffic follows the release calendar —
+          bidding days and the monthly registration release.
+        </Typography.Text>
+        <Typography.Text className="text-[1.1875rem] leading-[1.65]">
+          Targeting is contextual: you choose the pages, not the people. There
+          is no audience segment to buy, and creative is static — nothing that
+          follows a reader from one page to the next.
+        </Typography.Text>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/(main)/(site)/advertise/components/cta-section.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/components/cta-section.tsx
@@ -1,49 +1,91 @@
-import { Button, Card } from "@heroui/react";
+import { Button } from "@heroui/react";
 import Typography from "@web/components/typography";
 import { Mail } from "lucide-react";
 import { cacheLife } from "next/cache";
 
+const ADVERTISE_EMAIL = "advertise@motormetrics.app";
+
+const rules = [
+  {
+    note: "No creative inside or overlapping a chart, table or metric card.",
+    number: "01",
+  },
+  {
+    note: "No units that resemble a figure, chip or trend badge we publish.",
+    number: "02",
+  },
+  {
+    note: "No autoplay video, audio, interstitials or expanding units.",
+    number: "03",
+  },
+  {
+    note: "Sponsored content is labelled as such and never framed as our analysis.",
+    number: "04",
+  },
+];
+
+/**
+ * The comp closes on an ink panel pairing the creative rules with the booking
+ * form. There is no form endpoint, so the right-hand card carries the same copy
+ * and hands off to email instead.
+ */
 export async function CtaSection() {
   "use cache";
   cacheLife("days");
 
   return (
-    <section id="contact" className="scroll-mt-20 py-20 lg:py-28">
-      <div className="container mx-auto">
-        <div className="flex flex-col items-center gap-10">
-          {/* Header */}
-          <div className="flex flex-col items-center gap-4 text-center">
-            <Typography.Label className="text-accent-strong uppercase tracking-widest">
-              Get in Touch
-            </Typography.Label>
-            <Typography.H2>Ready to reach car enthusiasts?</Typography.H2>
-            <Typography.TextLg className="max-w-xl text-muted">
-              Drop us an email to discuss how we can help promote your product
-              to our audience.
-            </Typography.TextLg>
-          </div>
-
-          {/* Contact card */}
-          <Card className="w-full max-w-md border-border shadow-sm">
-            <Card.Content className="flex flex-col items-center gap-4 text-center">
-              <div className="rounded-xl bg-accent/10 p-3">
-                <Mail className="size-6 text-accent-strong" />
-              </div>
-              <Typography.H4>Email Us</Typography.H4>
-              <Typography.TextSm className="text-muted">
-                For enquiries, proposals, and custom packages
-              </Typography.TextSm>
-              <a
-                href="mailto:advertise@motormetrics.app"
-                className="mt-2 no-underline"
-              >
-                <Button variant="primary" className="rounded-full">
-                  advertise@motormetrics.app
-                </Button>
-              </a>
-            </Card.Content>
-          </Card>
+    <section
+      className="grid scroll-mt-24 items-start gap-10 rounded-4xl bg-ink-surface p-8 text-ink-surface-foreground lg:grid-cols-[1fr_360px] lg:p-14"
+      id="contact"
+    >
+      <div className="flex flex-col gap-4">
+        <span className="self-start rounded-full bg-accent-on-dark/20 px-4 py-2 font-bold text-accent-on-dark text-sm">
+          What we will not run
+        </span>
+        <Typography.H2 className="font-bold text-[2rem] text-ink-surface-foreground tracking-[-0.02em] lg:text-[2.25rem]">
+          Rules that protect the data
+        </Typography.H2>
+        <Typography.Text className="max-w-[33rem] text-[1.09375rem] text-ink-surface-foreground/70 leading-[1.6]">
+          Advertising sits around the charts, never inside them. We decline
+          anything that could be mistaken for a figure we publish.
+        </Typography.Text>
+        <div className="flex flex-col gap-3 pt-1">
+          {rules.map(({ note, number }) => (
+            <div
+              className="flex items-start gap-3 border-ink-surface-foreground/10 border-t pt-3"
+              key={number}
+            >
+              <span className="shrink-0 font-extrabold text-accent-on-dark text-sm tabular-nums">
+                {number}
+              </span>
+              <span className="font-medium text-[0.96875rem] text-ink-surface-foreground/75 leading-[1.5]">
+                {note}
+              </span>
+            </div>
+          ))}
         </div>
+      </div>
+
+      <div className="flex flex-col gap-4 rounded-2xl bg-ink-surface-foreground/[0.06] p-8">
+        <Typography.H3 className="font-bold text-[1.3125rem] text-ink-surface-foreground">
+          Book a placement
+        </Typography.H3>
+        <Typography.Text className="font-medium text-[0.9375rem] text-ink-surface-foreground/60 leading-[1.55]">
+          Tell us the pages and the months you have in mind. We reply with
+          availability, the rate and the creative spec.
+        </Typography.Text>
+        <a
+          className="self-start no-underline"
+          href={`mailto:${ADVERTISE_EMAIL}`}
+        >
+          <Button className="rounded-full" variant="primary">
+            <Mail className="size-4" />
+            Send an enquiry
+          </Button>
+        </a>
+        <Typography.Caption className="font-medium text-ink-surface-foreground/40">
+          Or write to {ADVERTISE_EMAIL}
+        </Typography.Caption>
       </div>
     </section>
   );

--- a/apps/web/src/app/(main)/(site)/advertise/components/hero-section.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/components/hero-section.tsx
@@ -1,27 +1,37 @@
 import { Button } from "@heroui/react";
-import { SitePageHero } from "@web/components/site-page-hero";
-import { SITE_TITLE } from "@web/config";
-import { ArrowRight } from "lucide-react";
+import { Breadcrumbs } from "@web/components/shared/breadcrumbs";
+import Typography from "@web/components/typography";
+import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 
 export function HeroSection() {
   return (
-    <SitePageHero
-      actions={
-        <>
-          <Link href="#pricing" className="no-underline">
-            <Button variant="primary">
-              See Plans
-              <ArrowRight className="size-4" />
-            </Button>
-          </Link>
-          <Link href="#stats" className="no-underline">
-            <Button variant="outline">View Traffic</Button>
-          </Link>
-        </>
-      }
-      description={`${SITE_TITLE} reaches an engaged, technical audience of car buyers, owners, and enthusiasts actively researching Singapore's automotive market.`}
-      title="Put Your Product in Front of Car Enthusiasts"
-    />
+    <section className="flex flex-col gap-6">
+      <Breadcrumbs />
+      <span className="self-start rounded-full bg-accent-soft px-4 py-2 font-bold text-accent-strong text-sm">
+        Advertise with us
+      </span>
+      <Typography.H1 className="max-w-[52rem] font-bold text-[2.75rem] leading-[1.04] tracking-[-0.03em] lg:text-[4.125rem]">
+        Reach people at the moment they are pricing a car
+      </Typography.H1>
+      <Typography.TextLg className="max-w-[42rem] font-medium text-[1.3125rem] text-muted leading-[1.55]">
+        Readers arrive with a specific question: what a COE closed at, what a
+        renewal costs, which makes are moving. Placements sit beside that
+        answer, not on top of it.
+      </Typography.TextLg>
+      <div className="flex flex-wrap gap-3 pt-2">
+        <Link className="no-underline" href="#contact">
+          <Button className="rounded-full" size="lg" variant="primary">
+            Enquire about a placement
+            <ArrowUpRight className="size-4" />
+          </Button>
+        </Link>
+        <Link className="no-underline" href="#placements">
+          <Button className="rounded-full" size="lg" variant="secondary">
+            See the placements
+          </Button>
+        </Link>
+      </div>
+    </section>
   );
 }

--- a/apps/web/src/app/(main)/(site)/advertise/components/placements-section.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/components/placements-section.tsx
@@ -1,29 +1,28 @@
-import { Card, Chip } from "@heroui/react";
 import Typography from "@web/components/typography";
 import { Layout, Rows3, StickyNote } from "lucide-react";
 import { cacheLife } from "next/cache";
 
 const placements = [
   {
+    description:
+      "A persistent unit in the bottom-right corner of every page. Always visible, never covering a chart.",
     icon: Layout,
-    title: "Floating Banner",
-    description:
-      "A persistent banner in the bottom-right corner of every page. Always visible without being intrusive.",
-    highlight: "Every page",
+    title: "Floating banner",
+    where: "Every page",
   },
   {
+    description:
+      "A dedicated sponsored block on high-traffic pages such as car makes and COE results.",
     icon: StickyNote,
-    title: "Pinned Cards",
-    description:
-      "Dedicated sponsored sections on high-traffic pages like car makes and COE results.",
-    highlight: "High visibility",
+    title: "Pinned cards",
+    where: "High-traffic pages",
   },
   {
-    icon: Rows3,
-    title: "In-feed Cards",
     description:
-      "Native-style cards within browsing feeds that blend naturally with the content experience.",
-    highlight: "Native feel",
+      "Cards within browsing feeds, in the site's own card shape and always labelled as sponsored.",
+    icon: Rows3,
+    title: "In-feed cards",
+    where: "Listing feeds",
   },
 ];
 
@@ -32,53 +31,37 @@ export async function PlacementsSection() {
   cacheLife("days");
 
   return (
-    <section className="py-20 lg:py-28">
-      <div className="flex flex-col gap-12">
-        {/* Section header */}
-        <div className="flex flex-col gap-4">
-          <Typography.Label className="text-accent-strong uppercase tracking-widest">
-            Ad Placements
-          </Typography.Label>
-          <Typography.H2 className="max-w-lg lg:text-4xl">
-            Placements on every listing page
-          </Typography.H2>
-          <Typography.TextLg className="max-w-2xl text-muted">
-            Choose from three placement types designed to reach users at
-            different points in their browsing journey.
-          </Typography.TextLg>
-        </div>
-
-        {/* Placement cards */}
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-3 lg:gap-6">
-          {placements.map(({ icon: Icon, title, description, highlight }) => (
-            <Card
-              key={title}
-              className="group h-full border-border shadow-sm transition-all duration-500 hover:border-accent/30 hover:shadow-accent/5 hover:shadow-lg"
-            >
-              <Card.Header className="flex flex-col items-start gap-3 pb-2">
-                <div className="flex items-center gap-3">
-                  <div className="rounded-xl bg-accent/10 p-2.5">
-                    <Icon className="size-5 text-accent-strong" />
-                  </div>
-                  <Chip
-                    size="sm"
-                    variant="primary"
-                    color="accent"
-                    className="font-medium text-xs"
-                  >
-                    {highlight}
-                  </Chip>
-                </div>
-                <Typography.H3 className="text-xl">{title}</Typography.H3>
-              </Card.Header>
-              <Card.Content className="pt-0">
-                <Typography.Text className="text-muted">
-                  {description}
-                </Typography.Text>
-              </Card.Content>
-            </Card>
-          ))}
-        </div>
+    <section className="flex scroll-mt-24 flex-col gap-7" id="placements">
+      <div className="grid items-start gap-4 lg:grid-cols-[300px_1fr] lg:gap-14">
+        <Typography.H2 className="font-bold text-[2.125rem] tracking-[-0.02em]">
+          Placements
+        </Typography.H2>
+        <Typography.Text className="max-w-[38rem] text-[1.1875rem] leading-[1.65]">
+          Three units, all static, all outside the charts.
+        </Typography.Text>
+      </div>
+      <div className="flex flex-col">
+        {placements.map(({ description, icon: Icon, title, where }) => (
+          <div
+            className="flex flex-col gap-3 border-border border-t py-6 sm:flex-row sm:items-baseline sm:gap-10"
+            key={title}
+          >
+            <div className="flex min-w-[15rem] items-center gap-3">
+              <span className="flex size-10 shrink-0 items-center justify-center rounded-sm bg-accent-soft text-accent-strong">
+                <Icon className="size-5" />
+              </span>
+              <span className="font-bold text-[1.1875rem] tracking-[-0.01em]">
+                {title}
+              </span>
+            </div>
+            <Typography.Text className="max-w-[34rem] text-base leading-[1.55]">
+              {description}
+            </Typography.Text>
+            <span className="shrink-0 font-bold text-[0.8125rem] text-muted uppercase tracking-[0.08em] sm:ml-auto">
+              {where}
+            </span>
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/apps/web/src/app/(main)/(site)/advertise/components/pricing-section.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/components/pricing-section.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Chip, Separator } from "@heroui/react";
+import { Button, Card, Chip, cn } from "@heroui/react";
 import Typography from "@web/components/typography";
 import { Check } from "lucide-react";
 import { cacheLife } from "next/cache";
@@ -6,16 +6,15 @@ import Link from "next/link";
 
 const plans = [
   {
-    name: "Starter",
-    price: "$400",
-    description: "Great for testing the waters",
+    cta: "Check availability",
     features: ["Floating banner", "30-day placement", "Basic analytics"],
     featured: false,
+    name: "Starter",
+    note: "A single static unit, to test the waters.",
+    price: "$400",
   },
   {
-    name: "Growth",
-    price: "$700",
-    description: "Best value for most advertisers",
+    cta: "Enquire about this",
     features: [
       "Floating banner",
       "Pinned cards",
@@ -24,11 +23,12 @@ const plans = [
       "Priority support",
     ],
     featured: true,
+    name: "Growth",
+    note: "The banner plus a pinned card on the pages that carry the most traffic.",
+    price: "$700",
   },
   {
-    name: "Premium",
-    price: "$1,000",
-    description: "Maximum visibility across the platform",
+    cta: "Check availability",
     features: [
       "Floating banner",
       "Pinned cards",
@@ -39,6 +39,9 @@ const plans = [
       "Custom creative review",
     ],
     featured: false,
+    name: "Premium",
+    note: "Every placement type, across the whole platform.",
+    price: "$1,000",
   },
 ];
 
@@ -47,84 +50,80 @@ export async function PricingSection() {
   cacheLife("days");
 
   return (
-    <section id="pricing" className="scroll-mt-20 py-20 lg:py-28">
-      <div className="flex flex-col gap-12">
-        {/* Section header */}
-        <div className="flex flex-col items-center gap-4 text-center">
-          <Typography.Label className="text-accent-strong uppercase tracking-widest">
-            Simple Pricing
-          </Typography.Label>
-          <Typography.H2 className="lg:text-4xl">
-            Monthly plans that fit your budget
-          </Typography.H2>
-          <Typography.TextLg className="max-w-xl text-muted">
-            Billed monthly. Cancel anytime. No long-term commitments.
-          </Typography.TextLg>
-        </div>
-
-        {/* Pricing cards */}
-        <div className="mx-auto grid max-w-4xl grid-cols-1 gap-4 md:grid-cols-3 lg:gap-6">
-          {plans.map((plan) => (
-            <Card
-              key={plan.name}
-              className={`relative h-full shadow-sm transition-all duration-500 ${
-                plan.featured
-                  ? "border-accent shadow-accent/10 shadow-lg"
-                  : "border-border hover:border-accent/30 hover:shadow-accent/5 hover:shadow-lg"
-              }`}
-            >
-              {plan.featured && (
-                <div className="absolute top-4 right-4">
+    <section className="flex scroll-mt-24 flex-col gap-7" id="pricing">
+      <div className="grid items-start gap-4 lg:grid-cols-[300px_1fr] lg:gap-14">
+        <Typography.H2 className="font-bold text-[2.125rem] tracking-[-0.02em]">
+          Packages
+        </Typography.H2>
+        <Typography.Text className="max-w-[38rem] text-[1.1875rem] leading-[1.65]">
+          Booked by the month. No long-term commitment.
+        </Typography.Text>
+      </div>
+      <div className="grid gap-6 lg:grid-cols-3">
+        {plans.map(({ cta, features, featured, name, note, price }) => (
+          <Card
+            className={cn("h-full", featured && "border-2 border-accent")}
+            key={name}
+          >
+            <Card.Content className="flex h-full flex-col gap-3.5">
+              <div className="flex items-center gap-3">
+                <Typography.H3 className="font-bold text-[1.375rem] tracking-[-0.01em]">
+                  {name}
+                </Typography.H3>
+                {featured ? (
                   <Chip
-                    size="sm"
+                    className="ml-auto font-bold"
                     color="accent"
+                    size="sm"
                     variant="primary"
-                    className="font-semibold text-xs"
                   >
-                    Recommended
+                    Most booked
                   </Chip>
-                </div>
-              )}
-              <Card.Header className="flex flex-col items-start gap-2">
-                <Typography.H3 className="text-xl">{plan.name}</Typography.H3>
-                <div className="flex items-baseline gap-1">
-                  <span className="font-bold text-4xl text-foreground tracking-tight">
-                    {plan.price}
-                  </span>
-                  <span className="text-muted text-sm">/month</span>
-                </div>
-                <Typography.TextSm className="text-muted">
-                  {plan.description}
-                </Typography.TextSm>
-              </Card.Header>
-              <Separator />
-              <Card.Content className="gap-3">
-                {plan.features.map((feature) => (
-                  <div key={feature} className="flex items-center gap-2">
-                    <Check className="size-4 shrink-0 text-accent-strong" />
-                    <Typography.TextSm>{feature}</Typography.TextSm>
+                ) : null}
+              </div>
+              <div className="flex items-baseline gap-2">
+                <span className="font-extrabold text-[2.5rem] tabular-nums leading-none tracking-[-0.03em]">
+                  {price}
+                </span>
+                <span className="font-semibold text-muted text-sm">
+                  per month
+                </span>
+              </div>
+              <Typography.TextSm className="font-medium text-base leading-[1.55]">
+                {note}
+              </Typography.TextSm>
+              <div className="flex flex-col gap-2.5 pt-1">
+                {features.map((feature) => (
+                  <div className="flex items-start gap-2.5" key={feature}>
+                    <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-accent-soft text-accent-strong">
+                      <Check className="size-3" strokeWidth={3} />
+                    </span>
+                    <span className="font-semibold text-[0.9375rem] text-muted-strong leading-[1.45]">
+                      {feature}
+                    </span>
                   </div>
                 ))}
-              </Card.Content>
-              <Card.Footer>
-                <Link href="#contact" className="w-full no-underline">
-                  <Button
-                    variant={plan.featured ? "primary" : "outline"}
-                    fullWidth
-                    className={
-                      plan.featured
-                        ? "rounded-full"
-                        : "rounded-full text-foreground"
-                    }
-                  >
-                    Get Started
-                  </Button>
-                </Link>
-              </Card.Footer>
-            </Card>
-          ))}
-        </div>
+              </div>
+              <Link
+                className="mt-auto w-full pt-3 no-underline"
+                href="#contact"
+              >
+                <Button
+                  className="rounded-full"
+                  fullWidth
+                  variant={featured ? "primary" : "secondary"}
+                >
+                  {cta}
+                </Button>
+              </Link>
+            </Card.Content>
+          </Card>
+        ))}
       </div>
+      <Typography.Caption className="font-medium text-subtle">
+        Rates are in Singapore dollars. Creative must be static — no autoplay,
+        no interstitials.
+      </Typography.Caption>
     </section>
   );
 }

--- a/apps/web/src/app/(main)/(site)/advertise/components/stats-section.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/components/stats-section.tsx
@@ -1,15 +1,4 @@
-"use client";
-
-import { Card } from "@heroui/react";
-import { NumberValue } from "@heroui-pro/react";
-
 import Typography from "@web/components/typography";
-import {
-  staggerContainerVariants,
-  staggerItemVariants,
-} from "@web/config/animations";
-import { motion } from "framer-motion";
-import { useState } from "react";
 
 interface TrafficStats {
   uniqueVisitors: number;
@@ -17,110 +6,48 @@ interface TrafficStats {
   pagesPerVisitor: number;
 }
 
-interface StatItemProps {
-  value: number;
-  suffix?: string;
-  label: string;
-  description: string;
-}
-
-function StatItem({ value, suffix = "", label, description }: StatItemProps) {
-  const [isInView, setIsInView] = useState(false);
-
-  return (
-    <motion.div
-      variants={staggerItemVariants}
-      onViewportEnter={() => setIsInView(true)}
-      viewport={{ once: true }}
-    >
-      <Card className="group border-border bg-surface shadow-sm transition-all duration-500 hover:border-accent/30 hover:shadow-accent/5 hover:shadow-lg">
-        <Card.Content className="flex flex-col gap-2">
-          <div className="font-semibold text-4xl text-foreground tracking-tight lg:text-5xl">
-            {isInView ? (
-              <NumberValue
-                locale="en-SG"
-                maximumFractionDigits={0}
-                value={value}
-              >
-                {suffix ? (
-                  <NumberValue.Suffix>{suffix}</NumberValue.Suffix>
-                ) : null}
-              </NumberValue>
-            ) : (
-              <NumberValue locale="en-SG" maximumFractionDigits={0} value={0}>
-                {suffix ? (
-                  <NumberValue.Suffix>{suffix}</NumberValue.Suffix>
-                ) : null}
-              </NumberValue>
-            )}
-          </div>
-          <Typography.Text className="font-medium text-foreground">
-            {label}
-          </Typography.Text>
-          <Typography.TextSm className="text-muted">
-            {description}
-          </Typography.TextSm>
-        </Card.Content>
-        {/* Subtle accent line */}
-        <div
-          className="absolute right-6 bottom-0 left-6 h-0.5 scale-x-0 bg-gradient-to-r from-accent to-accent/60 transition-transform duration-300 group-hover:scale-x-100"
-          aria-hidden="true"
-        />
-      </Card>
-    </motion.div>
-  );
-}
-
+/**
+ * The comp shows four audience figures under hairline rules. Only three of them
+ * exist as measured numbers — the fourth in the comp is invented — so this runs
+ * the three PostHog reports and leaves it there.
+ */
 export function StatsSection({ stats }: { stats: TrafficStats }) {
-  const statItems = [
+  const items = [
     {
-      value: stats.uniqueVisitors,
-      label: "Unique Visitors",
-      description: "Monthly unique visitors across the platform",
+      label: "Page views in the last 30 days",
+      value: stats.pageViews.toLocaleString("en-SG", {
+        maximumFractionDigits: 0,
+      }),
     },
     {
-      value: stats.pageViews,
-      label: "Page Views",
-      description: "Total pages viewed in the last 30 days",
+      label: "Unique readers, no account required",
+      value: stats.uniqueVisitors.toLocaleString("en-SG", {
+        maximumFractionDigits: 0,
+      }),
     },
     {
-      value: stats.pagesPerVisitor,
-      label: "Pages per Visitor",
-      description: "Average engagement depth per session",
+      label: "Pages read per visitor, on average",
+      value: stats.pagesPerVisitor.toLocaleString("en-SG", {
+        maximumFractionDigits: 1,
+      }),
     },
   ];
 
   return (
-    <section id="stats" className="scroll-mt-20 py-20 lg:py-28">
-      <div className="flex flex-col gap-12">
-        {/* Section header */}
-        <div className="flex flex-col gap-4">
-          <Typography.Label className="text-accent-strong uppercase tracking-widest">
-            Audience Metrics
-          </Typography.Label>
-          <Typography.H2 className="max-w-lg lg:text-4xl">
-            Transparent, public analytics
-          </Typography.H2>
-          <Typography.TextLg className="max-w-2xl text-muted">
-            Real traffic data from the last 30 days. Our audience comprises car
-            buyers, owners, and enthusiasts actively evaluating the Singapore
-            market.
-          </Typography.TextLg>
-        </div>
-
-        {/* Stats grid */}
-        <motion.div
-          className="grid grid-cols-1 gap-4 sm:grid-cols-3 lg:gap-6"
-          variants={staggerContainerVariants}
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, amount: 0.3 }}
+    <section className="grid scroll-mt-24 gap-6 sm:grid-cols-3" id="stats">
+      {items.map(({ label, value }) => (
+        <div
+          className="flex flex-col gap-1.5 border-border border-t-2 pt-7"
+          key={label}
         >
-          {statItems.map((stat) => (
-            <StatItem key={stat.label} {...stat} />
-          ))}
-        </motion.div>
-      </div>
+          <span className="font-extrabold text-[2.5rem] text-foreground tabular-nums leading-none tracking-[-0.03em] lg:text-[2.875rem]">
+            {value}
+          </span>
+          <Typography.TextSm className="font-semibold text-[0.9375rem]">
+            {label}
+          </Typography.TextSm>
+        </div>
+      ))}
     </section>
   );
 }

--- a/apps/web/src/app/(main)/(site)/advertise/components/traffic-chart-section.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/components/traffic-chart-section.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { Card } from "@heroui/react";
 import { AreaChart, ChartTooltip, NumberValue } from "@heroui-pro/react";
-
 import Typography from "@web/components/typography";
 
 interface DailyTraffic {
@@ -11,117 +9,99 @@ interface DailyTraffic {
   pageViews: number;
 }
 
+/**
+ * The comp has no chart here, but the figures above it are real and this is
+ * where they came from, so it stays — restyled to the comp's bare treatment:
+ * a heading, a caption and the plot straight on the page, with no card.
+ */
 export function TrafficChartSection({ data }: { data: DailyTraffic[] }) {
   if (data.length === 0) {
     return null;
   }
 
   return (
-    <section className="py-20 lg:py-28">
-      <div className="flex flex-col gap-12">
-        {/* Section header */}
-        <div className="flex flex-col gap-4">
-          <Typography.Label className="text-accent-strong uppercase tracking-widest">
-            Traffic Trend
-          </Typography.Label>
-          <Typography.H2 className="max-w-lg lg:text-4xl">
-            Daily visitors over the last 30 days
-          </Typography.H2>
-        </div>
-
-        {/* Chart */}
-        <Card>
-          <Card.Header className="flex flex-col items-start gap-2">
-            <Typography.H4>Daily Visitors</Typography.H4>
-            <Typography.TextSm className="text-muted">
-              Unique visitors and page views per day
-            </Typography.TextSm>
-          </Card.Header>
-          <Card.Content className="pt-2">
-            <AreaChart
-              data={data as unknown as Record<string, string | number>[]}
-              height={300}
-            >
-              <defs>
-                <linearGradient id="fillVisitors" x1="0" y1="0" x2="0" y2="1">
-                  <stop
-                    offset="5%"
-                    stopColor="var(--chart-1)"
-                    stopOpacity={0.3}
-                  />
-                  <stop
-                    offset="95%"
-                    stopColor="var(--chart-1)"
-                    stopOpacity={0}
-                  />
-                </linearGradient>
-              </defs>
-              <AreaChart.Grid
-                vertical={false}
-                strokeDasharray="3 3"
-                className="stroke-chart-grid"
-              />
-              <AreaChart.XAxis
-                dataKey="date"
-                tickLine={false}
-                axisLine={false}
-                tickFormatter={(value: string) => {
-                  const date = new Date(value);
-                  return date.toLocaleDateString("en-SG", {
-                    day: "numeric",
-                    month: "short",
-                  });
-                }}
-              />
-              <AreaChart.YAxis tickLine={false} axisLine={false} />
-              <AreaChart.Tooltip
-                content={({ active, label, payload }) => {
-                  if (!active || !payload?.length) return null;
-
-                  const dateLabel = (() => {
-                    if (typeof label !== "string") return label;
-
-                    const date = new Date(label);
-                    return date.toLocaleDateString("en-SG", {
-                      day: "numeric",
-                      month: "long",
-                      year: "numeric",
-                    });
-                  })();
-
-                  return (
-                    <ChartTooltip>
-                      <ChartTooltip.Header>{dateLabel}</ChartTooltip.Header>
-                      {payload.map((entry) => (
-                        <ChartTooltip.Item key={String(entry.dataKey)}>
-                          <ChartTooltip.Indicator
-                            color={entry.color ?? entry.stroke}
-                          />
-                          <ChartTooltip.Label>{entry.name}</ChartTooltip.Label>
-                          <ChartTooltip.Value>
-                            <NumberValue
-                              locale="en-SG"
-                              maximumFractionDigits={0}
-                              value={Number(entry.value)}
-                            />
-                          </ChartTooltip.Value>
-                        </ChartTooltip.Item>
-                      ))}
-                    </ChartTooltip>
-                  );
-                }}
-              />
-              <AreaChart.Area
-                dataKey="visitors"
-                type="monotone"
-                fill="url(#fillVisitors)"
-                stroke="var(--chart-1)"
-                strokeWidth={2}
-              />
-            </AreaChart>
-          </Card.Content>
-        </Card>
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-baseline gap-4">
+        <Typography.H2 className="font-bold text-[1.6875rem] tracking-[-0.02em]">
+          Daily visitors
+        </Typography.H2>
+        <Typography.TextSm className="font-medium text-base">
+          Last 30 days · unique visitors per day
+        </Typography.TextSm>
       </div>
+      <AreaChart
+        data={data as unknown as Record<string, string | number>[]}
+        height={300}
+      >
+        <defs>
+          <linearGradient id="fillVisitors" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="var(--chart-1)" stopOpacity={0.3} />
+            <stop offset="95%" stopColor="var(--chart-1)" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <AreaChart.Grid
+          vertical={false}
+          strokeDasharray="3 3"
+          className="stroke-chart-grid"
+        />
+        <AreaChart.XAxis
+          dataKey="date"
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={(value: string) => {
+            const date = new Date(value);
+            return date.toLocaleDateString("en-SG", {
+              day: "numeric",
+              month: "short",
+            });
+          }}
+        />
+        <AreaChart.YAxis tickLine={false} axisLine={false} />
+        <AreaChart.Tooltip
+          content={({ active, label, payload }) => {
+            if (!active || !payload?.length) return null;
+
+            const dateLabel = (() => {
+              if (typeof label !== "string") return label;
+
+              const date = new Date(label);
+              return date.toLocaleDateString("en-SG", {
+                day: "numeric",
+                month: "long",
+                year: "numeric",
+              });
+            })();
+
+            return (
+              <ChartTooltip>
+                <ChartTooltip.Header>{dateLabel}</ChartTooltip.Header>
+                {payload.map((entry) => (
+                  <ChartTooltip.Item key={String(entry.dataKey)}>
+                    <ChartTooltip.Indicator
+                      color={entry.color ?? entry.stroke}
+                    />
+                    <ChartTooltip.Label>{entry.name}</ChartTooltip.Label>
+                    <ChartTooltip.Value>
+                      <NumberValue
+                        locale="en-SG"
+                        maximumFractionDigits={0}
+                        value={Number(entry.value)}
+                      />
+                    </ChartTooltip.Value>
+                  </ChartTooltip.Item>
+                ))}
+              </ChartTooltip>
+            );
+          }}
+        />
+        <AreaChart.Area
+          dataKey="visitors"
+          type="monotone"
+          fill="url(#fillVisitors)"
+          stroke="var(--chart-1)"
+          strokeWidth={2}
+        />
+      </AreaChart>
     </section>
   );
 }

--- a/apps/web/src/app/(main)/(site)/advertise/page.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/page.tsx
@@ -1,3 +1,11 @@
+import { AudienceSection } from "@web/app/(main)/(site)/advertise/components/audience-section";
+import { CtaSection } from "@web/app/(main)/(site)/advertise/components/cta-section";
+import { HeroSection } from "@web/app/(main)/(site)/advertise/components/hero-section";
+import { PlacementsSection } from "@web/app/(main)/(site)/advertise/components/placements-section";
+import { PricingSection } from "@web/app/(main)/(site)/advertise/components/pricing-section";
+import { StatsSection } from "@web/app/(main)/(site)/advertise/components/stats-section";
+import { TrafficChartSection } from "@web/app/(main)/(site)/advertise/components/traffic-chart-section";
+import { SitePage } from "@web/components/shared/site-page";
 import { StructuredData } from "@web/components/structured-data";
 import { SITE_TITLE, SITE_URL } from "@web/config";
 import { SOCIAL_HANDLE } from "@web/config/socials";
@@ -6,12 +14,6 @@ import { getDailyTraffic, getTrafficStats } from "@web/lib/posthog";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import type { WebPage, WithContext } from "schema-dts";
-import { CtaSection } from "./components/cta-section";
-import { HeroSection } from "./components/hero-section";
-import { PlacementsSection } from "./components/placements-section";
-import { PricingSection } from "./components/pricing-section";
-import { StatsSection } from "./components/stats-section";
-import { TrafficChartSection } from "./components/traffic-chart-section";
 
 const title = "Advertise";
 const description = `Reach Singapore's most engaged car enthusiasts. See our traffic stats, ad placements, and pricing to promote your product on ${SITE_TITLE}.`;
@@ -71,14 +73,15 @@ export default async function AdvertisePage() {
     <>
       <StructuredData data={webPageSchema} />
 
-      <div className="flex flex-col">
+      <SitePage>
         <HeroSection />
         <StatsSection stats={stats} />
         <TrafficChartSection data={dailyTraffic} />
+        <AudienceSection />
         <PlacementsSection />
         <PricingSection />
         <CtaSection />
-      </div>
+      </SitePage>
     </>
   );
 }

--- a/apps/web/src/app/(main)/(site)/learn/[slug]/components/guide-head.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/[slug]/components/guide-head.tsx
@@ -1,0 +1,79 @@
+import type { Guide } from "@web/app/(main)/(site)/learn/lib/guides";
+import { getReadingMinutes } from "@web/app/(main)/(site)/learn/lib/guides";
+import { SharePill } from "@web/components/shared/share-pill";
+import Typography from "@web/components/typography";
+import Link from "next/link";
+
+/**
+ * The comp's guide opening: crumb, term pill, title, lede, then the reading
+ * estimate, the revision date and the share control on one line.
+ *
+ * The trail is written out rather than taken from `shared/breadcrumbs`, which
+ * derives its labels from the pathname: "/learn/coe" would title-case to "Coe"
+ * where the term is an abbreviation and should read "COE".
+ *
+ * Capped at the comp's 860px so the title breaks over a reading measure rather
+ * than the full 1180px page.
+ */
+export function GuideHead({ guide }: { guide: Guide }) {
+  return (
+    <div className="flex max-w-[53.75rem] flex-col gap-5">
+      <nav aria-label="Breadcrumb">
+        <ol className="flex flex-wrap items-center gap-2">
+          {[
+            { href: "/", label: "Home" },
+            { href: "/learn", label: "Learn" },
+          ].map(({ href, label }) => (
+            <li className="flex items-center gap-2" key={href}>
+              <Link
+                className="font-medium text-muted text-sm no-underline transition-colors hover:text-foreground"
+                href={href}
+              >
+                {label}
+              </Link>
+              <span aria-hidden className="text-muted text-sm">
+                /
+              </span>
+            </li>
+          ))}
+          <li>
+            <span
+              aria-current="page"
+              className="font-semibold text-muted text-sm"
+            >
+              {guide.term}
+            </span>
+          </li>
+        </ol>
+      </nav>
+
+      <span className="self-start rounded-full bg-accent-soft-2 px-4 py-2 font-bold text-accent-strong text-sm">
+        {guide.term}
+      </span>
+
+      <Typography.H1 className="font-bold text-[2.75rem] leading-[1.06] tracking-[-0.03em] lg:text-[3.375rem]">
+        {guide.title}
+      </Typography.H1>
+
+      <Typography.TextLg className="max-w-[43.75rem] font-medium text-muted leading-[1.55]">
+        {guide.excerpt}
+      </Typography.TextLg>
+
+      <div className="flex flex-wrap items-center gap-3.5">
+        <span className="font-semibold text-base text-muted">
+          {getReadingMinutes(guide.content)} min read
+        </span>
+        <span aria-hidden className="size-1.5 rounded-full bg-border" />
+        <span className="font-semibold text-base text-muted">
+          Updated{" "}
+          {new Date(guide.lastUpdated).toLocaleDateString("en-SG", {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+          })}
+        </span>
+        <SharePill title={guide.title} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(main)/(site)/learn/[slug]/components/guide-sidebar.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/[slug]/components/guide-sidebar.tsx
@@ -1,0 +1,114 @@
+import { GLOSSARY_CATEGORIES } from "@web/app/(main)/(site)/learn/components/glossary-data";
+import type { Guide } from "@web/app/(main)/(site)/learn/lib/guides";
+import {
+  getAllGuideSlugs,
+  getGuideHeadings,
+} from "@web/app/(main)/(site)/learn/lib/guides";
+import { InkPanel } from "@web/components/shared/bento";
+import Typography from "@web/components/typography";
+import type { Route } from "next";
+import Link from "next/link";
+
+const DEFINITIONS = new Map(
+  GLOSSARY_CATEGORIES.flatMap(({ terms }) =>
+    terms.map(({ definition, term }) => [term, definition] as const),
+  ),
+);
+
+const guideSlugs = getAllGuideSlugs();
+
+/**
+ * The comp's right-hand rail: contents, the terms the guide leans on, and the
+ * pages carrying the live figures.
+ *
+ * The contents are read out of the guide's own markdown rather than listed
+ * separately, so they cannot fall out of step with the article, and the ids
+ * match the ones `rehype-slug` gives the rendered headings.
+ */
+export function GuideSidebar({ guide }: { guide: Guide }) {
+  const headings = getGuideHeadings(guide.content);
+  const terms = guide.relatedTerms
+    .map((term) => ({ definition: DEFINITIONS.get(term), term }))
+    .filter(
+      (entry): entry is { definition: string; term: string } =>
+        entry.definition !== undefined,
+    );
+
+  return (
+    <aside className="flex flex-col gap-6 lg:sticky lg:top-9">
+      {headings.length > 0 ? (
+        <nav
+          aria-label="On this page"
+          className="flex flex-col gap-3.5 rounded-2xl bg-surface-secondary p-7"
+        >
+          <Typography.H3 className="font-bold text-base">
+            In this guide
+          </Typography.H3>
+          <ol className="flex flex-col gap-0.5">
+            {headings.map(({ id, title }) => (
+              <li key={id}>
+                <Link
+                  className="block rounded-lg px-3 py-2 font-semibold text-muted text-sm no-underline transition-colors hover:bg-surface hover:text-foreground"
+                  href={`#${id}` as Route}
+                >
+                  {title}
+                </Link>
+              </li>
+            ))}
+          </ol>
+        </nav>
+      ) : null}
+
+      {terms.length > 0 ? (
+        <div className="flex flex-col gap-3.5 rounded-2xl bg-surface p-7 shadow-surface">
+          <Typography.H3 className="font-bold text-base">
+            Key terms
+          </Typography.H3>
+          {terms.map(({ definition, term }) => {
+            const slug = term.toLowerCase();
+
+            return (
+              <div
+                className="flex flex-col gap-1 border-border border-t pt-3"
+                key={term}
+              >
+                {guideSlugs.includes(slug) ? (
+                  <Link
+                    className="font-bold text-accent-strong text-sm no-underline transition-colors hover:text-accent-deep"
+                    href={`/learn/${slug}`}
+                  >
+                    {term} →
+                  </Link>
+                ) : (
+                  <span className="font-bold text-accent-strong text-sm">
+                    {term}
+                  </span>
+                )}
+                <Typography.Caption className="font-medium text-muted leading-[1.5]">
+                  {definition}
+                </Typography.Caption>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {guide.relatedLinks.length > 0 ? (
+        <InkPanel className="rounded-2xl">
+          <Typography.TextSm className="font-semibold text-accent-foreground/85 text-base">
+            Check the current figures
+          </Typography.TextSm>
+          {guide.relatedLinks.map(({ href, label }) => (
+            <Link
+              className="font-bold text-accent-on-dark text-sm no-underline transition-colors hover:text-accent-foreground"
+              href={href as Route}
+              key={href}
+            >
+              {label} →
+            </Link>
+          ))}
+        </InkPanel>
+      ) : null}
+    </aside>
+  );
+}

--- a/apps/web/src/app/(main)/(site)/learn/[slug]/components/related-guides.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/[slug]/components/related-guides.tsx
@@ -1,0 +1,45 @@
+import { GuideCard } from "@web/app/(main)/(site)/learn/components/guide-card";
+import type { Guide } from "@web/app/(main)/(site)/learn/lib/guides";
+import { GUIDES } from "@web/app/(main)/(site)/learn/lib/guides";
+import Typography from "@web/components/typography";
+
+/** How many the comp's row holds. */
+const LIMIT = 3;
+
+/**
+ * "Next in this series" — the guides this one leans on, in the order it names
+ * them, topped up from the rest of the set if it names fewer than three.
+ */
+export function RelatedGuides({ guide }: { guide: Guide }) {
+  const byTerm = new Map(GUIDES.map((entry) => [entry.term, entry]));
+
+  const related = guide.relatedTerms
+    .map((term) => byTerm.get(term))
+    .filter((entry): entry is Guide => entry !== undefined);
+
+  const filled = [
+    ...related,
+    ...GUIDES.filter(
+      (entry) => entry.slug !== guide.slug && !related.includes(entry),
+    ),
+  ]
+    .filter((entry) => entry.slug !== guide.slug)
+    .slice(0, LIMIT);
+
+  if (filled.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="flex flex-col gap-7">
+      <Typography.H2 className="font-bold text-[2.125rem] tracking-[-0.02em]">
+        Next in this series
+      </Typography.H2>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {filled.map((entry) => (
+          <GuideCard guide={entry} key={entry.slug} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/(main)/(site)/learn/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/[slug]/page.tsx
@@ -1,21 +1,23 @@
-import { Button, Card, Chip, Separator } from "@heroui/react";
+import { GuideHead } from "@web/app/(main)/(site)/learn/[slug]/components/guide-head";
+import { GuideSidebar } from "@web/app/(main)/(site)/learn/[slug]/components/guide-sidebar";
+import { RelatedGuides } from "@web/app/(main)/(site)/learn/[slug]/components/related-guides";
+import {
+  getAllGuideSlugs,
+  getGuideBySlug,
+} from "@web/app/(main)/(site)/learn/lib/guides";
+import { SitePage } from "@web/components/shared/site-page";
 import { StructuredData } from "@web/components/structured-data";
-import Typography from "@web/components/typography";
 import { SITE_TITLE, SITE_URL } from "@web/config";
 import { SOCIAL_HANDLE } from "@web/config/socials";
 import { generateBreadcrumbSchema } from "@web/lib/metadata";
-import { ArrowLeft, ArrowRight, BookOpen } from "lucide-react";
 import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
-import Link from "next/link";
-import NextLink from "next/link";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import type { Article, DefinedTerm, WithContext } from "schema-dts";
-import { GUIDES, getAllGuideSlugs, getGuideBySlug } from "../lib/guides";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -65,6 +67,12 @@ export async function generateStaticParams() {
   return getAllGuideSlugs().map((slug) => ({ slug }));
 }
 
+/**
+ * The article body, held at the comp's 700px reading measure.
+ *
+ * `prose` carries the markdown; the modifiers pull its greys onto the site's
+ * own tokens so the copy matches the type around it.
+ */
 async function GuideContent({
   slug,
   content,
@@ -77,7 +85,7 @@ async function GuideContent({
   cacheTag(`learn:${slug}`);
 
   return (
-    <article className="prose dark:prose-invert max-w-none">
+    <article className="prose dark:prose-invert max-w-[43.75rem] prose-headings:font-bold prose-a:text-accent-strong prose-headings:text-foreground prose-li:text-muted prose-p:text-muted prose-strong:text-foreground prose-td:text-muted prose-th:text-foreground prose-p:leading-[1.7] prose-headings:tracking-[-0.02em]">
       <MDXRemote
         source={content}
         options={{
@@ -110,12 +118,6 @@ export default async function GuidePage({ params }: PageProps) {
   if (!guide) {
     notFound();
   }
-
-  // Find previous and next guides for navigation
-  const currentIndex = GUIDES.findIndex((g) => g.slug === slug);
-  const previousGuide = currentIndex > 0 ? GUIDES[currentIndex - 1] : null;
-  const nextGuide =
-    currentIndex < GUIDES.length - 1 ? GUIDES[currentIndex + 1] : null;
 
   const articleSchema: WithContext<Article> = {
     "@context": "https://schema.org",
@@ -171,111 +173,16 @@ export default async function GuidePage({ params }: PageProps) {
         data={{ "@context": "https://schema.org", ...breadcrumbSchema }}
       />
 
-      <div className="container mx-auto flex flex-col gap-8 px-6 py-8">
-        {/* Back to Learn link */}
-        <Link
-          href="/learn"
-          className="flex w-fit items-center gap-2 text-foreground text-sm"
-        >
-          <ArrowLeft className="size-4" />
-          Back to Learn
-        </Link>
+      <SitePage className="gap-14">
+        <GuideHead guide={guide} />
 
-        {/* Header */}
-        <header className="flex flex-col gap-4">
-          <Chip variant="primary" color="accent" size="sm">
-            <BookOpen className="size-3" />
-            {guide.term}
-          </Chip>
-          <Typography.H1>{guide.title}</Typography.H1>
-          <Typography.TextLg className="text-muted">
-            {guide.excerpt}
-          </Typography.TextLg>
-          <Typography.Caption>
-            Last updated:{" "}
-            {new Date(guide.lastUpdated).toLocaleDateString("en-SG", {
-              day: "numeric",
-              month: "long",
-              year: "numeric",
-            })}
-          </Typography.Caption>
-        </header>
-
-        <Separator />
-
-        {/* Main Content */}
-        <GuideContent slug={guide.slug} content={guide.content} />
-
-        {/* Related Links */}
-        {guide.relatedLinks.length > 0 && (
-          <Card className="shadow-sm">
-            <Card.Header>
-              <Typography.H4>Explore Data</Typography.H4>
-            </Card.Header>
-            <Card.Content className="flex flex-row flex-wrap gap-2">
-              {guide.relatedLinks.map((link) => (
-                <NextLink
-                  key={link.href}
-                  href={link.href}
-                  className="no-underline"
-                >
-                  <Button variant="primary" size="sm">
-                    {link.label}
-                  </Button>
-                </NextLink>
-              ))}
-            </Card.Content>
-          </Card>
-        )}
-
-        <Separator />
-
-        {/* Guide Navigation */}
-        <nav className="flex justify-between gap-4">
-          {previousGuide ? (
-            <NextLink
-              href={`/learn/${previousGuide.slug}`}
-              className="flex-1 no-underline"
-            >
-              <Button variant="outline" className="w-full justify-start">
-                <ArrowLeft className="size-4" />
-                <span className="flex flex-col items-start">
-                  <span className="text-muted text-xs">Previous</span>
-                  <span>{previousGuide.term}</span>
-                </span>
-              </Button>
-            </NextLink>
-          ) : (
-            <div className="flex-1" />
-          )}
-          {nextGuide ? (
-            <NextLink
-              href={`/learn/${nextGuide.slug}`}
-              className="flex-1 no-underline"
-            >
-              <Button variant="outline" className="w-full justify-end">
-                <span className="flex flex-col items-end">
-                  <span className="text-muted text-xs">Next</span>
-                  <span>{nextGuide.term}</span>
-                </span>
-                <ArrowRight className="size-4" />
-              </Button>
-            </NextLink>
-          ) : (
-            <div className="flex-1" />
-          )}
-        </nav>
-
-        {/* Back to Learn */}
-        <div className="flex justify-center pb-8">
-          <NextLink href="/learn" className="no-underline">
-            <Button variant="ghost">
-              <BookOpen className="size-4" />
-              Back to Learn Hub
-            </Button>
-          </NextLink>
+        <div className="grid grid-cols-1 items-start gap-12 lg:grid-cols-[minmax(0,1fr)_300px] lg:gap-14">
+          <GuideContent content={guide.content} slug={guide.slug} />
+          <GuideSidebar guide={guide} />
         </div>
-      </div>
+
+        <RelatedGuides guide={guide} />
+      </SitePage>
     </>
   );
 }

--- a/apps/web/src/app/(main)/(site)/learn/components/data-sources-section.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/components/data-sources-section.tsx
@@ -1,180 +1,85 @@
-"use client";
-
-import { Card, Chip } from "@heroui/react";
+import { ReportEyebrow } from "@web/components/shared/report";
 import Typography from "@web/components/typography";
-import {
-  fadeInUpVariants,
-  staggerContainerVariants,
-  staggerItemVariants,
-} from "@web/config/animations";
-import { motion } from "framer-motion";
-import { AlertTriangle, Calendar, Database, RefreshCw } from "lucide-react";
-import Link from "next/link";
+import type { ReactNode } from "react";
 
-const features = [
+const FACTS: { detail: ReactNode; title: string }[] = [
   {
-    icon: Database,
-    iconColor: "text-accent-strong",
-    containerBg: "bg-accent/10",
-    title: "Primary Data Source",
-    description: (
+    detail: (
       <>
-        All vehicle registration and COE data is sourced directly from
-        Singapore&apos;s{" "}
-        <strong>Land Transport Authority (LTA) DataMall</strong>, the official
-        government open data platform for transport-related datasets.
+        Every registration, deregistration and COE figure on this site comes
+        from <strong className="font-bold">LTA DataMall</strong>, the Land
+        Transport Authority&apos;s open data platform. Nothing is modelled or
+        estimated.
       </>
     ),
-    chip: (
-      <Chip size="sm" color="accent" variant="primary">
-        Official Government Data
-      </Chip>
-    ),
+    title: "Primary source",
   },
   {
-    icon: RefreshCw,
-    iconColor: "text-success",
-    containerBg: "bg-success/10",
-    title: "Update Frequency",
-    description: (
+    detail: (
       <>
-        Data is updated <strong>monthly</strong> following LTA&apos;s official
-        release schedule. New data typically becomes available 2-3 weeks after
-        the end of each month.
+        Registration data is published{" "}
+        <strong className="font-bold">monthly</strong>, and usually lands two to
+        three weeks after the month it covers. COE results follow each bidding
+        exercise, twice a month.
       </>
     ),
-    extra: (
-      <Typography.TextSm>
-        COE bidding results are updated after each exercise (twice monthly).
-      </Typography.TextSm>
-    ),
+    title: "Update frequency",
   },
   {
-    icon: Calendar,
-    iconColor: "text-muted",
-    containerBg: "bg-muted/10",
-    title: "Data Coverage",
-    description: (
+    detail: (
       <>
-        Our dataset covers Singapore vehicle registration and COE data from{" "}
-        <strong>January 2015 to present</strong>, with monthly granularity.
+        Car registrations, COE bidding results, deregistrations, vehicle
+        population and PQP rates, from{" "}
+        <strong className="font-bold">January 2015</strong> to the present, at
+        monthly granularity.
       </>
     ),
-    chips: (
-      <div className="flex flex-wrap gap-2">
-        <Chip size="sm" variant="primary">
-          Car Registrations
-        </Chip>
-        <Chip size="sm" variant="primary">
-          COE Bidding Results
-        </Chip>
-        <Chip size="sm" variant="primary">
-          Vehicle Deregistrations
-        </Chip>
-        <Chip size="sm" variant="primary">
-          Vehicle Population
-        </Chip>
-        <Chip size="sm" variant="primary">
-          PQP Rates
-        </Chip>
-      </div>
-    ),
+    title: "Coverage",
   },
   {
-    icon: AlertTriangle,
-    iconColor: "text-warning",
-    containerBg: "bg-warning/10",
-    title: "Accuracy Disclaimer",
-    description:
-      "While we strive for accuracy, this platform is not affiliated with the Singapore government. Data is provided for informational purposes only. For official records and legal matters, please refer directly to LTA's official channels. Minor discrepancies may occur due to data processing and formatting.",
+    detail:
+      "This site is not affiliated with the Singapore government and is published for information only. For official records, refer to LTA directly. Minor discrepancies can arise from processing and formatting, and LTA revises past releases from time to time.",
+    title: "Accuracy",
   },
 ];
 
+/**
+ * Where the figures come from, in the same narrow-heading layout as the
+ * glossary and the FAQ. Cards would overstate four short paragraphs, so the
+ * facts are hairline-ruled rows.
+ */
 export function DataSourcesSection() {
   return (
-    <section id="data-sources" className="scroll-mt-24 py-20 lg:py-28">
-      <div className="container mx-auto">
-        <div className="grid gap-12 lg:grid-cols-12 lg:gap-16">
-          {/* Left column - Sticky header */}
-          <div className="lg:col-span-4">
-            <motion.div
-              className="sticky top-24 flex flex-col gap-6"
-              variants={fadeInUpVariants}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.2 }}
-            >
-              <Typography.Label className="text-accent-strong uppercase tracking-widest">
-                Data Transparency
-              </Typography.Label>
-              <Typography.H2 className="lg:text-4xl">
-                Where Our Data Comes From
-              </Typography.H2>
-              <Typography.Text className="text-muted">
-                All data is sourced from official government channels and
-                updated regularly.
-              </Typography.Text>
+    <section
+      className="grid scroll-mt-24 grid-cols-1 gap-10 lg:grid-cols-[280px_minmax(0,1fr)] lg:gap-14"
+      id="data-sources"
+    >
+      <div className="flex flex-col gap-3">
+        <Typography.H2 className="font-bold text-[2.125rem] tracking-[-0.02em]">
+          Where the data comes from
+        </Typography.H2>
+        <a
+          className="font-bold text-accent-strong text-base no-underline transition-colors hover:text-accent-deep"
+          href="https://datamall.lta.gov.sg"
+          rel="noreferrer"
+          target="_blank"
+        >
+          LTA DataMall →
+        </a>
+      </div>
 
-              {/* LTA Badge */}
-              <Card className="border-border">
-                <Card.Content className="flex flex-row items-center gap-4">
-                  <div className="flex size-12 items-center justify-center rounded-lg bg-default">
-                    <Database className="size-6 text-muted" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-foreground text-sm">
-                      Data Provider
-                    </div>
-                    <Link
-                      href="https://datamall.lta.gov.sg"
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-accent-strong text-sm underline"
-                    >
-                      LTA DataMall
-                    </Link>
-                  </div>
-                </Card.Content>
-              </Card>
-            </motion.div>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        {FACTS.map(({ detail, title }) => (
+          <div
+            className="flex flex-col gap-2 border-border border-t pt-4"
+            key={title}
+          >
+            <ReportEyebrow>{title}</ReportEyebrow>
+            <Typography.TextSm className="font-medium text-base text-muted leading-[1.6]">
+              {detail}
+            </Typography.TextSm>
           </div>
-
-          {/* Right column - Feature cards */}
-          <div className="lg:col-span-8">
-            <motion.div
-              className="grid gap-6 sm:grid-cols-2"
-              variants={staggerContainerVariants}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.2 }}
-            >
-              {features.map((feature) => (
-                <motion.div key={feature.title} variants={staggerItemVariants}>
-                  <Card className="group h-full border-border/80 transition-all duration-500 hover:border-accent/30 hover:shadow-accent/5 hover:shadow-lg">
-                    <Card.Content className="flex flex-col gap-4">
-                      <div
-                        className={`flex size-12 items-center justify-center rounded-xl ${feature.containerBg} transition-colors`}
-                      >
-                        <feature.icon
-                          className={`size-6 ${feature.iconColor}`}
-                        />
-                      </div>
-                      <div className="flex flex-col gap-2">
-                        <Typography.H4>{feature.title}</Typography.H4>
-                        <Typography.TextSm>
-                          {feature.description}
-                        </Typography.TextSm>
-                      </div>
-                      {feature.extra}
-                      {feature.chip}
-                      {feature.chips}
-                    </Card.Content>
-                  </Card>
-                </motion.div>
-              ))}
-            </motion.div>
-          </div>
-        </div>
+        ))}
       </div>
     </section>
   );

--- a/apps/web/src/app/(main)/(site)/learn/components/faq-section.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/components/faq-section.tsx
@@ -1,234 +1,59 @@
 "use client";
 
-import { Accordion, Card } from "@heroui/react";
-
+import { Accordion } from "@heroui/react";
+import { FAQ_SECTIONS } from "@web/app/(main)/(site)/learn/components/faq-data";
+import { ReportEyebrow } from "@web/components/shared/report";
 import Typography from "@web/components/typography";
-import { SITE_TITLE } from "@web/config";
-import {
-  fadeInUpVariants,
-  staggerContainerVariants,
-  staggerItemVariants,
-} from "@web/config/animations";
-import { motion } from "framer-motion";
-import type { LucideIcon } from "lucide-react";
-import {
-  BarChart3,
-  Car,
-  FileText,
-  Landmark,
-  MessageCircleQuestion,
-  Zap,
-} from "lucide-react";
 
-interface FAQItem {
-  question: string;
-  answer: string;
-}
-
-interface FAQSectionData {
-  title: string;
-  icon: LucideIcon;
-  iconColor: string;
-  items: FAQItem[];
-}
-
-export const FAQ_SECTIONS: FAQSectionData[] = [
-  {
-    title: "Certificate of Entitlement (COE)",
-    icon: Landmark,
-    iconColor: "text-accent-strong",
-    items: [
-      {
-        question: "What is COE in Singapore?",
-        answer:
-          "Certificate of Entitlement (COE) is a quota licence required in Singapore to own a vehicle. It gives the holder the right to register, purchase and use a vehicle in Singapore for a period of 10 years. The COE system was introduced in May 1990 to control vehicle population growth and manage traffic congestion.",
-      },
-      {
-        question: "How does COE bidding work?",
-        answer:
-          "COE bidding exercises are held twice monthly, typically on the first and third Wednesday of each month. Bidders submit their bids for different vehicle categories through authorised dealers or online platforms. COE is awarded to the highest bidders up to the quota available for each category. The lowest successful bid becomes the COE price for that category.",
-      },
-      {
-        question: "What are the COE categories?",
-        answer:
-          "There are 5 COE categories: Category A (cars up to 1,600cc and 130bhp, electric cars with power up to 110kW), Category B (cars above 1,600cc or 130bhp, electric cars with power above 110kW), Category C (goods vehicles and buses), Category D (motorcycles), and Category E (open category for all vehicle types).",
-      },
-      {
-        question: "How long is COE valid?",
-        answer:
-          "COE is valid for 10 years from the date of vehicle registration. After 10 years, vehicle owners must either renew their COE for another 5 or 10 years by paying the Prevailing Quota Premium (PQP), or deregister their vehicle.",
-      },
-      {
-        question: "What affects COE prices?",
-        answer:
-          "COE prices are determined by supply and demand. Key factors include the monthly quota set by the government (based on vehicle scrappage and target vehicle population growth), economic conditions, consumer confidence, interest rates, and seasonal demand patterns. External factors like global chip shortages or new model launches can also influence demand.",
-      },
-    ],
-  },
-  {
-    title: "Car Registration and Market Trends",
-    icon: Car,
-    iconColor: "text-success",
-    items: [
-      {
-        question: "How often is car registration data updated?",
-        answer:
-          "Car registration data is updated monthly following the Land Transport Authority's (LTA) official data releases. The data typically becomes available 2-3 weeks after the end of each month and includes comprehensive breakdowns by manufacturer, fuel type, and vehicle category.",
-      },
-      {
-        question: `What data sources does ${SITE_TITLE} use?`,
-        answer:
-          "All vehicle registration and COE data is sourced directly from Singapore's Land Transport Authority (LTA), ensuring accuracy and official government backing. We process and format this data to provide insights and analytics for easier understanding of market trends.",
-      },
-      {
-        question: "Why do some months show higher car registrations?",
-        answer:
-          "Car registration patterns can vary due to several factors including COE price fluctuations, new model launches, promotional periods by dealers, economic conditions, and seasonal buying patterns. Lower COE prices or attractive financing options typically lead to higher registrations.",
-      },
-    ],
-  },
-  {
-    title: "Electric and Hybrid Vehicles",
-    icon: Zap,
-    iconColor: "text-warning",
-    items: [
-      {
-        question: "How are electric vehicles categorised for COE?",
-        answer:
-          "Electric vehicles are categorised based on their power output: those with power up to 110kW fall under Category A, while those with power above 110kW are placed in Category B. This system treats electric vehicles similarly to petrol cars based on their performance characteristics.",
-      },
-      {
-        question: "What incentives exist for electric vehicles?",
-        answer:
-          "Singapore offers various incentives for electric vehicles including rebates under the Electric Vehicle Early Adoption Incentive (EEAI), additional registration fee (ARF) rebates, and road tax concessions. The government aims to phase out internal combustion engine vehicles by 2040.",
-      },
-    ],
-  },
-  {
-    title: "PARF and Vehicle Deregistration",
-    icon: FileText,
-    iconColor: "text-muted",
-    items: [
-      {
-        question: "What is PARF?",
-        answer:
-          "The Preferential Additional Registration Fee (PARF) is a rebate given when you deregister a vehicle before its COE expires. It is calculated as a percentage of the Additional Registration Fee (ARF) paid at registration, with the percentage decreasing as the vehicle ages. No PARF rebate is given for vehicles older than 10 years.",
-      },
-      {
-        question: "What changed with PARF in Budget 2026?",
-        answer:
-          "Budget 2026 reduced PARF rebate percentages by 45 percentage points across all vehicle age brackets. For example, vehicles aged 5 years or younger now receive 30% of ARF (down from 75%). The rebate cap was also halved from $60,000 to $30,000. These changes apply to vehicles registered with COEs obtained from the 2nd bidding exercise in February 2026 onwards.",
-      },
-      {
-        question: "How is the PARF rebate calculated?",
-        answer:
-          "The PARF rebate equals a percentage of the ARF you paid when registering the vehicle, based on the vehicle's age at deregistration. Under the new rates (effective Feb 2026): 30% for vehicles 5 years and younger, 25% for >5-6 years, 20% for >6-7 years, 15% for >7-8 years, 10% for >8-9 years, 5% for >9-10 years, and nil for vehicles over 10 years. The rebate is capped at $30,000.",
-      },
-    ],
-  },
-  {
-    title: `Using ${SITE_TITLE}`,
-    icon: BarChart3,
-    iconColor: "text-accent-strong",
-    items: [
-      {
-        question: "How can I access historical data?",
-        answer:
-          "Historical data is available through our website's month selector feature on various pages. You can also access our API endpoints for programmatic access to historical car registration and COE data dating back to 2020.",
-      },
-    ],
-  },
-];
-
+/**
+ * The questions, laid out the way the comp lays out the glossary: a heading in
+ * a narrow left column, the content in the wide one, hairlines rather than
+ * cards.
+ *
+ * Client-side for the accordion alone; the questions themselves come from
+ * `faq-data`, which the page also reads to build the FAQPage schema.
+ */
 export function FAQSection() {
   return (
-    <section id="faq" className="scroll-mt-24 py-20 lg:py-28">
-      <div className="container mx-auto">
-        <div className="grid gap-12 lg:grid-cols-12 lg:gap-16">
-          {/* Left column - Sticky header */}
-          <div className="lg:col-span-4">
-            <motion.div
-              className="sticky top-24 flex flex-col gap-6"
-              variants={fadeInUpVariants}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.2 }}
-            >
-              <Typography.Label className="text-accent-strong uppercase tracking-widest">
-                Common Questions
-              </Typography.Label>
-              <Typography.H2 className="lg:text-4xl">
-                Frequently Asked Questions
-              </Typography.H2>
-              <Typography.Text className="text-muted">
-                Everything you need to know about Singapore&apos;s vehicle
-                market, from COE bidding to PARF rebates.
-              </Typography.Text>
-            </motion.div>
-          </div>
+    <section
+      className="grid scroll-mt-24 grid-cols-1 gap-10 lg:grid-cols-[280px_minmax(0,1fr)] lg:gap-14"
+      id="faq"
+    >
+      <div className="flex flex-col gap-3 lg:sticky lg:top-9 lg:self-start">
+        <Typography.H2 className="font-bold text-[2.125rem] tracking-[-0.02em]">
+          Frequently asked
+        </Typography.H2>
+        <Typography.TextSm className="font-medium text-base text-muted leading-[1.55]">
+          The questions that come up most often about bidding, rebates and where
+          the figures on this site come from.
+        </Typography.TextSm>
+      </div>
 
-          {/* Right column - FAQ categories */}
-          <div className="lg:col-span-8">
-            <motion.div
-              className="flex flex-col gap-8"
-              variants={staggerContainerVariants}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.1 }}
-            >
-              {FAQ_SECTIONS.map((section) => (
-                <motion.div
-                  key={section.title}
-                  className="flex flex-col gap-4"
-                  variants={staggerItemVariants}
-                >
-                  <div className="flex items-center gap-3">
-                    <section.icon className={`size-5 ${section.iconColor}`} />
-                    <Typography.H3>{section.title}</Typography.H3>
-                  </div>
-                  <Accordion>
-                    {section.items.map(({ answer, question }) => (
-                      <Accordion.Item key={question}>
-                        <Accordion.Heading>
-                          <Accordion.Trigger>
-                            {question}
-                            <Accordion.Indicator />
-                          </Accordion.Trigger>
-                        </Accordion.Heading>
-                        <Accordion.Panel>
-                          <Accordion.Body>
-                            <Typography.Text>{answer}</Typography.Text>
-                          </Accordion.Body>
-                        </Accordion.Panel>
-                      </Accordion.Item>
-                    ))}
-                  </Accordion>
-                </motion.div>
+      <div className="flex flex-col gap-9">
+        {FAQ_SECTIONS.map((section) => (
+          <div className="flex flex-col gap-4" key={section.title}>
+            <ReportEyebrow>{section.title}</ReportEyebrow>
+            <Accordion>
+              {section.items.map(({ answer, question }) => (
+                <Accordion.Item key={question}>
+                  <Accordion.Heading>
+                    <Accordion.Trigger>
+                      {question}
+                      <Accordion.Indicator />
+                    </Accordion.Trigger>
+                  </Accordion.Heading>
+                  <Accordion.Panel>
+                    <Accordion.Body>
+                      <Typography.Text className="text-muted leading-[1.6]">
+                        {answer}
+                      </Typography.Text>
+                    </Accordion.Body>
+                  </Accordion.Panel>
+                </Accordion.Item>
               ))}
-
-              {/* Still Have Questions? */}
-              <motion.div variants={staggerItemVariants}>
-                <Card className="border border-accent/20 bg-accent/5">
-                  <Card.Content className="flex flex-row items-start gap-4">
-                    <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent/10">
-                      <MessageCircleQuestion className="size-5 text-accent-strong" />
-                    </div>
-                    <div className="flex flex-col gap-2">
-                      <Typography.H4>Still Have Questions?</Typography.H4>
-                      <Typography.TextSm>
-                        If you have additional questions about Singapore&apos;s
-                        automotive market or need help understanding specific
-                        data points, feel free to explore our comprehensive car
-                        registration and COE data through the navigation menu
-                        above.
-                      </Typography.TextSm>
-                    </div>
-                  </Card.Content>
-                </Card>
-              </motion.div>
-            </motion.div>
+            </Accordion>
           </div>
-        </div>
+        ))}
       </div>
     </section>
   );

--- a/apps/web/src/app/(main)/(site)/learn/components/featured-guide.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/components/featured-guide.tsx
@@ -1,0 +1,69 @@
+import {
+  GUIDES,
+  getGuideBySlug,
+  getReadingMinutes,
+} from "@web/app/(main)/(site)/learn/lib/guides";
+import { InkPanel } from "@web/components/shared/bento";
+import Typography from "@web/components/typography";
+import { ArrowUpRight } from "lucide-react";
+import type { Route } from "next";
+import Link from "next/link";
+
+/**
+ * The comp's "Start here" panel: the one guide a reader should open first,
+ * given the width of a whole block.
+ *
+ * The comp fills the right-hand column with a priced breakdown of a new car.
+ * Those figures are drawn from nothing in this codebase, so the column carries
+ * the guide's own onward links to the live figures instead.
+ */
+export function FeaturedGuide() {
+  const guide = getGuideBySlug("coe") ?? GUIDES[0];
+
+  if (!guide) {
+    return null;
+  }
+
+  return (
+    <InkPanel className="gap-10 p-8 lg:grid lg:grid-cols-[minmax(0,1fr)_300px] lg:items-center lg:gap-11 lg:p-12">
+      <div className="flex flex-col gap-4">
+        <span className="self-start rounded-full bg-accent-on-dark/20 px-4 py-2 font-bold text-[0.84375rem] text-accent-on-dark">
+          Start here
+        </span>
+        <Typography.H2 className="font-bold text-[2.25rem] text-accent-foreground leading-[1.14] tracking-[-0.02em]">
+          {guide.title}
+        </Typography.H2>
+        <Typography.Text className="max-w-[35rem] text-accent-foreground/70 leading-[1.6]">
+          {guide.excerpt}
+        </Typography.Text>
+        <div className="flex flex-wrap items-center gap-3.5 pt-2">
+          <Link
+            className="inline-flex items-center gap-2.5 rounded-full bg-accent px-7 py-3.5 font-bold text-accent-foreground text-base no-underline transition-[filter] hover:brightness-105"
+            href={`/learn/${guide.slug}`}
+          >
+            Read the guide
+            <ArrowUpRight aria-hidden className="size-[1.125rem]" />
+          </Link>
+          <span className="font-semibold text-accent-foreground/50 text-sm">
+            {getReadingMinutes(guide.content)} min read
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <span className="font-semibold text-accent-foreground/50 text-sm">
+          The figures behind it
+        </span>
+        {guide.relatedLinks.map(({ href, label }) => (
+          <Link
+            className="font-bold text-accent-on-dark text-base no-underline transition-colors hover:text-accent-foreground"
+            href={href as Route}
+            key={href}
+          >
+            {label} →
+          </Link>
+        ))}
+      </div>
+    </InkPanel>
+  );
+}

--- a/apps/web/src/app/(main)/(site)/learn/components/glossary-section.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/components/glossary-section.tsx
@@ -1,110 +1,70 @@
-"use client";
-
-import { Card } from "@heroui/react";
+import { GLOSSARY_CATEGORIES } from "@web/app/(main)/(site)/learn/components/glossary-data";
+import { getAllGuideSlugs } from "@web/app/(main)/(site)/learn/lib/guides";
+import { ReportEyebrow } from "@web/components/shared/report";
 import Typography from "@web/components/typography";
-import {
-  fadeInUpVariants,
-  staggerContainerVariants,
-  staggerItemVariants,
-} from "@web/config/animations";
-import { motion } from "framer-motion";
-import { ArrowRight } from "lucide-react";
 import Link from "next/link";
-import { getAllGuideSlugs } from "../lib/guides";
-import { GLOSSARY_CATEGORIES } from "./glossary-data";
 
 const guideSlugs = getAllGuideSlugs();
 
+/**
+ * The comp sets the glossary as a heading in a narrow left column against a
+ * two-up list of hairline-topped terms — no cards, the rules do the dividing.
+ *
+ * The comp draws one flat list; the data is grouped into five categories and
+ * the grouping is worth keeping, so each category opens with a small caps label
+ * over its own two-up list.
+ */
 export function GlossarySection() {
   return (
     <section
+      className="grid scroll-mt-24 grid-cols-1 gap-10 lg:grid-cols-[280px_minmax(0,1fr)] lg:gap-14"
       id="glossary"
-      className="relative -mx-6 scroll-mt-24 overflow-hidden bg-default px-6 py-20 lg:py-28"
     >
-      {/* Dot pattern background */}
-      <div
-        className="pointer-events-none absolute inset-0 opacity-50"
-        style={{
-          backgroundImage:
-            "radial-gradient(circle at 1px 1px, color-mix(in srgb, var(--muted) 15%, transparent) 1px, transparent 0)",
-          backgroundSize: "24px 24px",
-        }}
-        aria-hidden="true"
-      />
+      <div className="flex flex-col gap-3">
+        <Typography.H2 className="font-bold text-[2.125rem] tracking-[-0.02em]">
+          Glossary
+        </Typography.H2>
+        <Typography.TextSm className="font-medium text-base text-muted leading-[1.55]">
+          The abbreviations that appear on every invoice, quotation and bidding
+          result, in one place.
+        </Typography.TextSm>
+      </div>
 
-      <div className="container relative mx-auto">
-        {/* Section header */}
-        <motion.div
-          className="flex flex-col items-center gap-4 pb-12 text-center"
-          variants={fadeInUpVariants}
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, amount: 0.2 }}
-        >
-          <Typography.Label className="text-accent-strong uppercase tracking-widest">
-            Terminology
-          </Typography.Label>
-          <Typography.H2 className="lg:text-4xl">
-            Glossary of Key Terms
-          </Typography.H2>
-          <Typography.Text className="max-w-2xl text-muted">
-            Understanding Singapore&apos;s automotive terminology is essential
-            for navigating the car market.
-          </Typography.Text>
-        </motion.div>
+      <div className="flex flex-col gap-10">
+        {GLOSSARY_CATEGORIES.map((category) => (
+          <div className="flex flex-col gap-5" key={category.title}>
+            <ReportEyebrow>{category.title}</ReportEyebrow>
+            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+              {category.terms.map(({ definition, term }) => {
+                const slug = term.toLowerCase();
+                const hasGuide = guideSlugs.includes(slug);
 
-        {/* Categories */}
-        <div className="flex flex-col gap-12">
-          {GLOSSARY_CATEGORIES.map((category) => (
-            <motion.div
-              key={category.title}
-              className="flex flex-col gap-6"
-              variants={staggerContainerVariants}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.1 }}
-            >
-              <div className="flex items-center gap-3">
-                <category.icon className={`size-5 ${category.iconColor}`} />
-                <Typography.H3>{category.title}</Typography.H3>
-              </div>
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-                {category.terms.map(({ term, definition }) => {
-                  const slug = term.toLowerCase();
-                  const hasGuide = guideSlugs.includes(slug);
-
-                  const card = (
-                    <Card className="h-full border-border/80 transition-all duration-500 hover:border-accent/30 hover:shadow-accent/5 hover:shadow-lg">
-                      <Card.Header className="pb-0">
-                        <div className="flex w-full items-center justify-between">
-                          <Typography.H4>{term}</Typography.H4>
-                          {hasGuide && (
-                            <ArrowRight className="size-4 text-accent-strong" />
-                          )}
-                        </div>
-                      </Card.Header>
-                      <Card.Content>
-                        <Typography.TextSm>{definition}</Typography.TextSm>
-                      </Card.Content>
-                    </Card>
-                  );
-
-                  return (
-                    <motion.div key={term} variants={staggerItemVariants}>
-                      {hasGuide ? (
-                        <Link href={`/learn/${slug}`} className="block h-full">
-                          {card}
-                        </Link>
-                      ) : (
-                        card
-                      )}
-                    </motion.div>
-                  );
-                })}
-              </div>
-            </motion.div>
-          ))}
-        </div>
+                return (
+                  <div
+                    className="flex flex-col gap-1 border-border border-t pt-4"
+                    key={term}
+                  >
+                    {hasGuide ? (
+                      <Link
+                        className="font-bold text-[1.0625rem] text-accent-strong no-underline transition-colors hover:text-accent-deep"
+                        href={`/learn/${slug}`}
+                      >
+                        {term} →
+                      </Link>
+                    ) : (
+                      <span className="font-bold text-[1.0625rem] text-accent-strong">
+                        {term}
+                      </span>
+                    )}
+                    <Typography.TextSm className="font-medium text-muted leading-[1.55]">
+                      {definition}
+                    </Typography.TextSm>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/apps/web/src/app/(main)/(site)/learn/components/guide-card.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/components/guide-card.tsx
@@ -1,0 +1,41 @@
+import type { Guide } from "@web/app/(main)/(site)/learn/lib/guides";
+import { getReadingMinutes } from "@web/app/(main)/(site)/learn/lib/guides";
+import Typography from "@web/components/typography";
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+
+/**
+ * One guide in a grid — the comps use the same card in the index's "All guides"
+ * block and at the foot of a guide under "Next in this series", so it lives
+ * here rather than in either.
+ *
+ * The comps also carry a difficulty pill beside the topic. Nothing in the guide
+ * data records one, so only the term pill is drawn.
+ */
+export function GuideCard({ guide }: { guide: Guide }) {
+  return (
+    <Link
+      className="group flex h-full flex-col gap-3.5 rounded-2xl bg-surface p-7 text-foreground no-underline shadow-surface transition-shadow hover:shadow-hover"
+      href={`/learn/${guide.slug}`}
+    >
+      <span className="self-start rounded-full bg-surface-secondary px-3.5 py-1.5 font-bold text-[0.8125rem] text-muted">
+        {guide.term}
+      </span>
+      <Typography.H3 className="font-bold text-[1.375rem] leading-[1.24] tracking-[-0.01em]">
+        {guide.title}
+      </Typography.H3>
+      <Typography.TextSm className="font-medium text-base text-muted leading-[1.55]">
+        {guide.excerpt}
+      </Typography.TextSm>
+      <div className="mt-auto flex items-center gap-2.5 pt-3.5">
+        <span className="font-semibold text-muted text-sm">
+          {getReadingMinutes(guide.content)} min read
+        </span>
+        <ChevronRight
+          aria-hidden
+          className="ml-auto size-[1.125rem] text-accent-strong transition-transform group-hover:translate-x-0.5"
+        />
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/src/app/(main)/(site)/learn/components/guides-section.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/components/guides-section.tsx
@@ -1,122 +1,30 @@
-"use client";
-
-import { Card } from "@heroui/react";
-
+import { GuideCard } from "@web/app/(main)/(site)/learn/components/guide-card";
+import { GUIDES } from "@web/app/(main)/(site)/learn/lib/guides";
 import Typography from "@web/components/typography";
-import {
-  fadeInUpVariants,
-  staggerContainerVariants,
-  staggerItemVariants,
-} from "@web/config/animations";
-import { motion } from "framer-motion";
 
-interface GuideSection {
-  title: string;
-  content: string[];
-}
-
-const GUIDES: GuideSection[] = [
-  {
-    title: "How COE Bidding Works",
-    content: [
-      "The Certificate of Entitlement (COE) bidding system uses a uniform-price auction format. All successful bidders pay the same price \u2014 the lowest successful bid (known as the Quota Premium).",
-      "Bidding exercises are held twice a month, typically on the first and third Wednesday, and run for three days. You can submit, modify, or withdraw your bid during this period.",
-      "To bid, you must place a deposit through an authorised dealer or via the OneMotoring portal. The deposit is typically $10,000 for Category A/B/E, or $200 for Category D (motorcycles).",
-      "If your bid is successful, you have six months to register a vehicle using the COE. Unused COEs are forfeited, and the deposit is not refunded.",
-    ],
-  },
-  {
-    title: "Understanding PARF Rebates",
-    content: [
-      "When you deregister a vehicle before its 10-year COE expires, you receive a PARF rebate \u2014 a percentage of the Additional Registration Fee (ARF) you paid at registration.",
-      "The rebate percentage decreases as your vehicle ages. Under the new Budget 2026 rates: 30% for 5 years and younger, 25% for >5-6 years, 20% for >6-7 years, 15% for >7-8 years, 10% for >8-9 years, and 5% for >9-10 years.",
-      "If your vehicle is over 10 years old, you receive no PARF rebate. The maximum PARF rebate is capped at $30,000 (reduced from $60,000 under Budget 2026).",
-      "The PARF rebate is separate from the COE rebate, which refunds a pro-rated portion of the COE premium based on remaining validity.",
-    ],
-  },
-  {
-    title: "Reading the Charts and Data",
-    content: [
-      "Registration charts show the number of new vehicles registered each month, broken down by make, fuel type, or vehicle type. A rising trend suggests increased demand, while dips may indicate higher COE prices or seasonal effects.",
-      "COE premium charts track the winning bid price over time for each category. Comparing Category A (smaller cars) and Category B (larger cars) can reveal shifting buyer preferences.",
-      "Deregistration data shows vehicles leaving the road \u2014 whether scrapped, exported, or reaching the end of their COE. High deregistration months typically lead to more COE quotas in future exercises.",
-      "Use the month selector on each page to navigate through historical data. You can compare month-on-month and year-on-year trends to identify patterns in Singapore\u2019s car market.",
-    ],
-  },
-];
-
+/**
+ * The comp's "All guides" grid.
+ *
+ * The comp heads it with topic tabs (COE, Costs, Electric, Data). The guides
+ * carry no topic, and all five sit under one heading anyway, so a filter would
+ * be a control with nothing to do — the count stands in its place.
+ */
 export function GuidesSection() {
   return (
-    <section
-      id="guides"
-      className="relative -mx-6 scroll-mt-24 overflow-hidden bg-default px-6 py-20 lg:py-28"
-    >
-      {/* Dot pattern background */}
-      <div
-        className="pointer-events-none absolute inset-0 opacity-50"
-        style={{
-          backgroundImage:
-            "radial-gradient(circle at 1px 1px, color-mix(in srgb, var(--muted) 15%, transparent) 1px, transparent 0)",
-          backgroundSize: "24px 24px",
-        }}
-        aria-hidden="true"
-      />
+    <section className="flex scroll-mt-24 flex-col gap-7" id="guides">
+      <div className="flex flex-wrap items-baseline gap-5">
+        <Typography.H2 className="font-bold text-[2.125rem] tracking-[-0.02em]">
+          All guides
+        </Typography.H2>
+        <span className="font-semibold text-base text-muted">
+          {GUIDES.length} {GUIDES.length === 1 ? "guide" : "guides"}
+        </span>
+      </div>
 
-      <div className="container relative mx-auto">
-        <div className="grid gap-12 lg:grid-cols-12 lg:gap-16">
-          {/* Left column - Sticky header */}
-          <div className="lg:col-span-4">
-            <motion.div
-              className="sticky top-24 flex flex-col gap-6"
-              variants={fadeInUpVariants}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.2 }}
-            >
-              <Typography.Label className="text-accent-strong uppercase tracking-widest">
-                Learn
-              </Typography.Label>
-              <Typography.H2 className="lg:text-4xl">
-                Guides &amp; Tutorials
-              </Typography.H2>
-              <Typography.Text className="text-muted">
-                Step-by-step guides to help you understand Singapore&apos;s
-                vehicle market and make the most of our platform.
-              </Typography.Text>
-            </motion.div>
-          </div>
-
-          {/* Right column - Guide cards */}
-          <div className="lg:col-span-8">
-            <motion.div
-              className="flex flex-col gap-6"
-              variants={staggerContainerVariants}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.1 }}
-            >
-              {GUIDES.map((guide, index) => (
-                <motion.div key={guide.title} variants={staggerItemVariants}>
-                  <Card className="group border-border/80 transition-all duration-500 hover:border-accent/30 hover:shadow-accent/5 hover:shadow-lg">
-                    <Card.Content className="flex flex-row gap-6">
-                      <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-accent font-semibold text-accent-foreground text-sm">
-                        {String(index + 1).padStart(2, "0")}
-                      </div>
-                      <div className="flex flex-col gap-4">
-                        <Typography.H3>{guide.title}</Typography.H3>
-                        {guide.content.map((paragraph) => (
-                          <Typography.Text key={paragraph.slice(0, 40)}>
-                            {paragraph}
-                          </Typography.Text>
-                        ))}
-                      </div>
-                    </Card.Content>
-                  </Card>
-                </motion.div>
-              ))}
-            </motion.div>
-          </div>
-        </div>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {GUIDES.map((guide) => (
+          <GuideCard guide={guide} key={guide.slug} />
+        ))}
       </div>
     </section>
   );

--- a/apps/web/src/app/(main)/(site)/learn/components/learn-stats.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/components/learn-stats.tsx
@@ -1,0 +1,56 @@
+import { FAQ_SECTIONS } from "@web/app/(main)/(site)/learn/components/faq-data";
+import { GLOSSARY_CATEGORIES } from "@web/app/(main)/(site)/learn/components/glossary-data";
+import { GUIDES } from "@web/app/(main)/(site)/learn/lib/guides";
+
+/**
+ * The four rule-topped figures the comp runs under the head.
+ *
+ * Every figure is counted from the page's own content rather than written down,
+ * so the row cannot drift out of step with what is published beneath it. The
+ * comp's other two figures — "6 cost components" and "10 yrs" as a headline —
+ * are not counted anywhere in the codebase, so the row carries the COE term as
+ * the one domain constant and counts the rest.
+ */
+const STATS = [
+  {
+    label: "In-depth guides to the rules that set the price",
+    value: String(GUIDES.length),
+  },
+  {
+    label: "Terms defined in the glossary",
+    value: String(
+      GLOSSARY_CATEGORIES.reduce(
+        (total, category) => total + category.terms.length,
+        0,
+      ),
+    ),
+  },
+  {
+    label: "Questions answered in the FAQ",
+    value: String(
+      FAQ_SECTIONS.reduce((total, section) => total + section.items.length, 0),
+    ),
+  },
+  {
+    label: "COE term before renewal or deregistration",
+    value: "10 yrs",
+  },
+];
+
+export function LearnStats() {
+  return (
+    <div className="grid grid-cols-2 gap-6 lg:grid-cols-4">
+      {STATS.map(({ label, value }) => (
+        <div
+          className="flex flex-col gap-1.5 border-border border-t-2 pt-7"
+          key={label}
+        >
+          <span className="font-extrabold text-[2.625rem] tabular-nums leading-none tracking-[-0.03em]">
+            {value}
+          </span>
+          <span className="font-semibold text-muted text-sm">{label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/(main)/(site)/learn/lib/guides.ts
+++ b/apps/web/src/app/(main)/(site)/learn/lib/guides.ts
@@ -706,3 +706,47 @@ export function getGuideBySlug(slug: string): Guide | undefined {
 export function getAllGuideSlugs(): string[] {
   return GUIDES.map((guide) => guide.slug);
 }
+
+/** Words a minute, for the reading estimate the guide cards and heads carry. */
+const WORDS_PER_MINUTE = 200;
+
+/**
+ * Reading estimate for a guide, derived from its own body rather than stored
+ * alongside it — the figure would otherwise drift every time a guide is edited.
+ */
+export function getReadingMinutes(content: string): number {
+  const words = content.trim().split(/\s+/).length;
+
+  return Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+}
+
+export interface GuideHeading {
+  id: string;
+  title: string;
+}
+
+/**
+ * The `##` headings of a guide, for the sidebar contents.
+ *
+ * The ids are slugged the way `rehype-slug` slugs the rendered markdown, so the
+ * links land on the headings the article actually renders.
+ */
+export function getGuideHeadings(content: string): GuideHeading[] {
+  const headings: GuideHeading[] = [];
+  const pattern = /^## (.+)$/gm;
+
+  let match = pattern.exec(content);
+  while (match !== null) {
+    const title = match[1].trim();
+    headings.push({
+      id: title
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, "")
+        .replace(/\s+/g, "-"),
+      title,
+    });
+    match = pattern.exec(content);
+  }
+
+  return headings;
+}

--- a/apps/web/src/app/(main)/(site)/learn/page.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/page.tsx
@@ -1,3 +1,13 @@
+import { DataSourcesSection } from "@web/app/(main)/(site)/learn/components/data-sources-section";
+import { FAQ_SECTIONS } from "@web/app/(main)/(site)/learn/components/faq-data";
+import { FAQSection } from "@web/app/(main)/(site)/learn/components/faq-section";
+import { FeaturedGuide } from "@web/app/(main)/(site)/learn/components/featured-guide";
+import { GLOSSARY_CATEGORIES } from "@web/app/(main)/(site)/learn/components/glossary-data";
+import { GlossarySection } from "@web/app/(main)/(site)/learn/components/glossary-section";
+import { GuidesSection } from "@web/app/(main)/(site)/learn/components/guides-section";
+import { LearnStats } from "@web/app/(main)/(site)/learn/components/learn-stats";
+import { PageHead } from "@web/components/shared/page-head";
+import { SitePage } from "@web/components/shared/site-page";
 import { StructuredData } from "@web/components/structured-data";
 import { SITE_TITLE, SITE_URL } from "@web/config";
 import { SOCIAL_HANDLE } from "@web/config/socials";
@@ -8,15 +18,6 @@ import {
 } from "@web/lib/metadata";
 import type { Metadata } from "next";
 import type { WebPage, WithContext } from "schema-dts";
-import { CtaSection } from "./components/cta-section";
-import { DataSourcesSection } from "./components/data-sources-section";
-import { FAQ_SECTIONS } from "./components/faq-data";
-import { FAQSection } from "./components/faq-section";
-import { GLOSSARY_CATEGORIES } from "./components/glossary-data";
-import { GlossarySection } from "./components/glossary-section";
-import { GuidesSection } from "./components/guides-section";
-import { HeroSection } from "./components/hero-section";
-import { QuickNavSection } from "./components/quick-nav-section";
 
 const title = "Car & COE Guides";
 const description =
@@ -78,15 +79,19 @@ export default function LearnPage() {
       <StructuredData
         data={{ "@context": "https://schema.org", ...breadcrumbSchema }}
       />
-      <div className="flex flex-col">
-        <HeroSection />
-        <QuickNavSection />
-        <FAQSection />
-        <GlossarySection />
-        <DataSourcesSection />
+
+      <SitePage>
+        <PageHead
+          description="COE, ARF, OMV, PARF and PQP, in plain language — the rules that set the price of a car in Singapore, with worked examples."
+          title="Learn how car ownership costs actually work"
+        />
+        <LearnStats />
+        <FeaturedGuide />
         <GuidesSection />
-        <CtaSection />
-      </div>
+        <GlossarySection />
+        <FAQSection />
+        <DataSourcesSection />
+      </SitePage>
     </>
   );
 }


### PR DESCRIPTION
- Rebuild `/about`, `/advertise` and `/learn` (including guide detail) on `SitePage` and the shared section components.
- Add the learn guides library and per-page section components; align the blog post page with the same shell.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790571898&installation_model_id=21947&pr_number=929&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F929&signature=c0f26a66211cd35694cb6bd08df805747f17a72f1af606e116e06301a2d8e153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
