### PR TITLE
Line the bars and legal pages up with the page measure

### DIFF
--- a/apps/web/src/app/(main)/(site)/legal/privacy-policy/page.tsx
+++ b/apps/web/src/app/(main)/(site)/legal/privacy-policy/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function PrivacyPage() {
   return (
-    <article className="prose prose-neutral mx-auto max-w-4xl">
+    <article className="prose prose-neutral max-w-none">
       <header className="mb-8">
         <h1>Privacy Policy</h1>
         <p className="text-muted">Last updated: December 2024</p>

--- a/apps/web/src/app/(main)/(site)/legal/terms-of-service/page.tsx
+++ b/apps/web/src/app/(main)/(site)/legal/terms-of-service/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function TermsPage() {
   return (
-    <article className="prose prose-neutral mx-auto max-w-4xl">
+    <article className="prose prose-neutral max-w-none">
       <header className="mb-8">
         <h1>Terms of Service</h1>
         <p className="text-muted">Last updated: December 2024</p>

--- a/apps/web/src/components/__snapshots__/announcement.test.tsx.snap
+++ b/apps/web/src/components/__snapshots__/announcement.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Announcement > should prioritise path-specific announcements 1`] = `
   class="bg-accent text-accent-foreground"
 >
   <div
-    class="mx-auto w-full max-w-7xl px-4 py-2 text-center sm:px-6"
+    class="mx-auto w-full max-w-page px-4 py-2 text-center sm:px-6 lg:px-9"
   >
     <p
       class="text-pretty font-medium text-xs sm:text-sm"

--- a/apps/web/src/components/__snapshots__/banner.test.tsx.snap
+++ b/apps/web/src/components/__snapshots__/banner.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Banner > should show banner content from the store 1`] = `
     class="flex items-center overflow-x-auto whitespace-nowrap border-t bg-default shadow-md"
   >
     <div
-      class="px-6 py-4 lg:container lg:mx-auto"
+      class="mx-auto w-full max-w-page px-4 py-4 sm:px-6 lg:px-9"
     >
       <span
         data-testid="banner-content"

--- a/apps/web/src/components/announcement.tsx
+++ b/apps/web/src/components/announcement.tsx
@@ -30,7 +30,7 @@ export function Announcement() {
 
   return (
     <aside className="bg-accent text-accent-foreground">
-      <div className="mx-auto w-full max-w-7xl px-4 py-2 text-center sm:px-6">
+      <div className="mx-auto w-full max-w-page px-4 py-2 text-center sm:px-6 lg:px-9">
         <p className="text-pretty font-medium text-xs sm:text-sm">
           {activeAnnouncement.content}
         </p>

--- a/apps/web/src/components/banner.tsx
+++ b/apps/web/src/components/banner.tsx
@@ -11,7 +11,9 @@ export function Banner() {
 
   return (
     <div className="flex items-center overflow-x-auto whitespace-nowrap border-t bg-default shadow-md">
-      <div className="px-6 py-4 lg:container lg:mx-auto">{bannerContent}</div>
+      <div className="mx-auto w-full max-w-page px-4 py-4 sm:px-6 lg:px-9">
+        {bannerContent}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- Give the announcement and banner bars `max-w-page` so they sit on the same column as the nav, content and footer.
- Let the legal pages fill the column instead of capping at `max-w-4xl` under the old `(site)` wrapper.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790571906&installation_model_id=21947&pr_number=931&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F931&signature=1dd7c0cb78070ba20100f5a5894a05b8124f50208980f6c027ce7f77902eb7f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

