### PR TITLE
Band the nav menu section headers

### DIFF
--- a/apps/web/src/components/app-nav.tsx
+++ b/apps/web/src/components/app-nav.tsx
@@ -47,12 +47,11 @@ const menuItemClassName =
 // another row by default, and spacing alone cannot fix that — the rows sit on
 // a ~35px rhythm that a gap has to clearly beat before it registers as a
 // break. Nothing else in this UI carries a border, so the separation is tonal:
-// the eyebrow gets the warm surface tier while the rows keep the white
-// overlay. Negative margins bleed the band to the popover edge (the menu is
-// overflow-clip, so the radius still holds), and px-6 lands the label on the
-// same optical left edge as the row text.
+// the eyebrow takes the warm surface tier while the rows keep the white
+// overlay. It stays inside the menu padding and shares the rows' px-3.5 and
+// radius, so it reads as a tinted label row rather than a slab.
 const menuHeaderClassName =
-  "-mx-2.5 -mt-2.5 col-span-full mb-1.5 rounded-t-lg bg-surface-secondary px-6 py-3 font-bold text-[11.5px] text-subtle uppercase tracking-[0.12em]";
+  "col-span-full mb-1.5 rounded-sm bg-surface-secondary px-3.5 py-2.5 font-bold text-[11.5px] text-subtle uppercase tracking-[0.12em]";
 
 // The comp runs a long menu in two columns. Short menus stay in one so the
 // popover never opens wider than the handful of rows it holds.

--- a/apps/web/src/components/app-nav.tsx
+++ b/apps/web/src/components/app-nav.tsx
@@ -41,10 +41,18 @@ const pillClassName = (isActive: boolean) =>
 // Menu chrome from the MMNav comp: rows are 14px-radius pills rather than the
 // 32px HeroUI default, and section labels are small uppercase eyebrows.
 const menuItemClassName =
-  "rounded-sm px-3.5 py-2.75 font-semibold text-[15px] text-muted-strong";
+  "rounded-sm px-3.5 py-2.25 font-semibold text-[15px] text-muted-strong";
 
+// HeroUI's .menu-section ships flat (gap-0), so the eyebrow reads as just
+// another row by default, and spacing alone cannot fix that — the rows sit on
+// a ~35px rhythm that a gap has to clearly beat before it registers as a
+// break. Nothing else in this UI carries a border, so the separation is tonal:
+// the eyebrow gets the warm surface tier while the rows keep the white
+// overlay. Negative margins bleed the band to the popover edge (the menu is
+// overflow-clip, so the radius still holds), and px-6 lands the label on the
+// same optical left edge as the row text.
 const menuHeaderClassName =
-  "col-span-full px-3.5 pt-2 pb-1.5 font-bold text-[12.5px] text-subtle uppercase tracking-[0.06em]";
+  "-mx-2.5 -mt-2.5 col-span-full mb-1.5 rounded-t-lg bg-surface-secondary px-6 py-3 font-bold text-[11.5px] text-subtle uppercase tracking-[0.12em]";
 
 // The comp runs a long menu in two columns. Short menus stay in one so the
 // popover never opens wider than the handful of rows it holds.


### PR DESCRIPTION
- Give the nav menu section headers a banded treatment.
- Keep the band inside the popover so it does not bleed past the rounded edge.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790571948&installation_model_id=21947&pr_number=933&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F933&signature=407d4e5ef93cf2e0274ea24714116dcbccb4ff39b135ca28ce32847057a757cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
