### PR TITLE
Drop the native tooltip on the leading make sparkline

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/components/leading-make-card.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/components/leading-make-card.tsx
@@ -57,11 +57,11 @@ export async function LeadingMakeCard({
 
       {spark ? (
         <svg
+          aria-label={`${leader.make} registrations over the last ${leader.trend.length} months`}
           className="mt-1.5 h-[90px] w-full overflow-visible"
           role="img"
           viewBox="0 0 380 90"
         >
-          <title>{`${leader.make} registrations over the last ${leader.trend.length} months`}</title>
           <path d={spark.area} fill="currentColor" opacity={0.16} />
           <path
             d={spark.line}


### PR DESCRIPTION
- Remove the `title` attribute from the leading make sparkline; it duplicated the visible label.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790571953&installation_model_id=21947&pr_number=934&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F934&signature=fd66b71b5bf691716dac4d2e101b74ba14968df85fc88c43e64e215590dd7464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
