### PR TITLE
Make the (main) pages usable on a phone

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/annual/components/population-table.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/annual/components/population-table.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { cn, Typography } from "@heroui/react";
+import type { SortDescriptor } from "@heroui/react";
+
+import { cn, Table, Typography } from "@heroui/react";
 import {
   changeRatio,
   type DimensionLabels,
@@ -8,14 +10,9 @@ import {
 } from "@web/app/(main)/(dashboard)/cars/annual/population-series";
 import { SurfaceCard } from "@web/components/shared/bento";
 import { DeltaChip } from "@web/components/shared/delta-chip";
-import { TABLE_HEADER_CLASS } from "@web/components/shared/report-table";
 import { useMemo, useState } from "react";
 
 type SortKey = "name" | "population" | "change";
-type SortDirection = "asc" | "desc";
-
-/** Shared padding and hover wash for every body cell. */
-const CELL_CLASS = "px-4 py-4 align-middle";
 
 /** Ranks past this share the last chart colour rather than wrapping around. */
 const CHART_COLOURS = 6;
@@ -51,7 +48,9 @@ interface PopulationRank {
  *
  * A real `<table>` rather than the comp's CSS grid, because sortable headers
  * need `aria-sort` on a `columnheader` and overriding a table's `display`
- * strips those semantics in most browsers.
+ * strips those semantics in most browsers. HeroUI's `Table` supplies both that
+ * and the `ScrollContainer` the columns need on a phone — laid out in full the
+ * four columns want ~450px, which is wider than the viewport.
  */
 export function PopulationTable({
   entities,
@@ -69,8 +68,10 @@ export function PopulationTable({
   previousYear: string | null;
   year: string;
 }) {
-  const [sortKey, setSortKey] = useState<SortKey>("population");
-  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>({
+    column: "population",
+    direction: "descending",
+  });
   const [isExpanded, setIsExpanded] = useState(false);
 
   const ranked = useMemo<PopulationRank[]>(() => {
@@ -91,7 +92,9 @@ export function PopulationTable({
   const largest = Math.max(...ranked.map((row) => row.population), 1);
 
   const sorted = useMemo(() => {
-    const sign = sortDirection === "asc" ? 1 : -1;
+    const sortKey = sortDescriptor.column as SortKey;
+    const sign = sortDescriptor.direction === "ascending" ? 1 : -1;
+
     return ranked.slice().sort((first, second) => {
       if (sortKey === "name") {
         return sign * first.name.localeCompare(second.name, "en-SG");
@@ -101,32 +104,10 @@ export function PopulationTable({
       }
       return sign * (first.population - second.population);
     });
-  }, [ranked, sortDirection, sortKey]);
+  }, [ranked, sortDescriptor]);
 
   const isTruncated = !isExpanded && sorted.length > COLLAPSED_ROWS;
   const displayed = isTruncated ? sorted.slice(0, COLLAPSED_ROWS) : sorted;
-
-  const toggleSort = (key: SortKey) => {
-    if (key === sortKey) {
-      setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
-      return;
-    }
-    setSortKey(key);
-    setSortDirection(key === "name" ? "asc" : "desc");
-  };
-
-  const headers: {
-    align: "left" | "right";
-    key: SortKey | "share";
-    label: string;
-    /** Omitted on the name column, which takes whatever is left over. */
-    width?: string;
-  }[] = [
-    { align: "left", key: "name", label: labels.column },
-    { align: "right", key: "population", label: "Population", width: "w-28" },
-    { align: "left", key: "share", label: "Share", width: "w-[11rem]" },
-    { align: "right", key: "change", label: "Change", width: "w-28" },
-  ];
 
   return (
     <SurfaceCard className="gap-5">
@@ -138,140 +119,106 @@ export function PopulationTable({
           </Typography.Paragraph>
         </div>
         <span className="ml-auto whitespace-nowrap font-semibold text-muted text-sm">
-          Sorted by {SORT_LABELS[sortKey]},{" "}
-          {sortDirection === "asc" ? "ascending" : "descending"}
+          Sorted by {SORT_LABELS[sortDescriptor.column as SortKey]},{" "}
+          {sortDescriptor.direction === "ascending"
+            ? "ascending"
+            : "descending"}
         </span>
       </div>
 
-      <table className="w-full table-fixed border-separate border-spacing-0">
-        <caption className="sr-only">
-          {labels.title}, {year}
-        </caption>
-        <thead>
-          <tr>
-            {headers.map((header) => {
-              const alignment =
-                header.align === "right" ? "text-right" : "text-left";
-              const cellClass = cn(
-                "border-border border-b px-4 pt-4 pb-3",
-                header.width,
-                alignment,
-              );
-
-              if (header.key === "share") {
+      <Table variant="secondary">
+        <Table.ScrollContainer>
+          <Table.Content
+            aria-label={`${labels.title}, ${year}`}
+            className="min-w-[26rem]"
+            onSortChange={setSortDescriptor}
+            sortDescriptor={sortDescriptor}
+          >
+            <Table.Header>
+              <Table.Column allowsSorting id="name" isRowHeader>
+                {({ sortDirection }) => (
+                  <Table.SortableColumnHeader sortDirection={sortDirection}>
+                    {labels.column}
+                  </Table.SortableColumnHeader>
+                )}
+              </Table.Column>
+              <Table.Column allowsSorting id="population">
+                {({ sortDirection }) => (
+                  <Table.SortableColumnHeader sortDirection={sortDirection}>
+                    Population
+                  </Table.SortableColumnHeader>
+                )}
+              </Table.Column>
+              <Table.Column id="share">Share</Table.Column>
+              <Table.Column allowsSorting id="change">
+                {({ sortDirection }) => (
+                  <Table.SortableColumnHeader sortDirection={sortDirection}>
+                    Change
+                  </Table.SortableColumnHeader>
+                )}
+              </Table.Column>
+            </Table.Header>
+            <Table.Body>
+              {displayed.map((row) => {
+                const isFocused = row.name === focus;
                 return (
-                  <th
-                    className={cn(cellClass, TABLE_HEADER_CLASS, "text-muted")}
-                    key={header.key}
-                    scope="col"
+                  <Table.Row
+                    className={cn(isFocused && "bg-accent-soft-2")}
+                    id={row.name}
+                    key={row.name}
                   >
-                    {header.label}
-                  </th>
+                    <Table.Cell>
+                      <button
+                        aria-pressed={isFocused}
+                        className="flex min-w-0 cursor-pointer items-center gap-3 text-left"
+                        onClick={() => onSelect(isFocused ? null : row.name)}
+                        type="button"
+                      >
+                        <span
+                          aria-hidden
+                          className="size-3.5 shrink-0 rounded-full"
+                          style={{ background: row.colour }}
+                        />
+                        <span className="truncate font-bold text-base">
+                          {row.name}
+                        </span>
+                      </button>
+                    </Table.Cell>
+                    <Table.Cell className="text-right font-extrabold text-base tabular-nums">
+                      {numberFormatter.format(row.population)}
+                    </Table.Cell>
+                    <Table.Cell>
+                      <span className="flex items-center gap-2.5">
+                        <span className="h-2.5 w-16 shrink-0 overflow-hidden rounded-full bg-default sm:w-24">
+                          <span
+                            className="block h-full rounded-full"
+                            style={{
+                              background: row.colour,
+                              width: `${((row.population / largest) * 100).toFixed(1)}%`,
+                            }}
+                          />
+                        </span>
+                        <span className="w-11 text-right font-bold text-muted text-sm tabular-nums">
+                          {row.share.toFixed(1)}%
+                        </span>
+                      </span>
+                    </Table.Cell>
+                    <Table.Cell className="text-right">
+                      {row.change === null ? (
+                        <span className="font-semibold text-muted text-sm">
+                          —
+                        </span>
+                      ) : (
+                        <DeltaChip value={row.change * 100} />
+                      )}
+                    </Table.Cell>
+                  </Table.Row>
                 );
-              }
-
-              const columnKey = header.key;
-              const isActive = columnKey === sortKey;
-              return (
-                <th
-                  aria-sort={
-                    isActive
-                      ? sortDirection === "asc"
-                        ? "ascending"
-                        : "descending"
-                      : "none"
-                  }
-                  className={cellClass}
-                  key={columnKey}
-                  scope="col"
-                >
-                  <button
-                    className={cn(
-                      TABLE_HEADER_CLASS,
-                      "cursor-pointer",
-                      isActive ? "text-accent-strong" : "text-muted",
-                    )}
-                    onClick={() => toggleSort(columnKey)}
-                    type="button"
-                  >
-                    {header.label}
-                    {isActive ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
-                  </button>
-                </th>
-              );
-            })}
-          </tr>
-        </thead>
-        <tbody>
-          {displayed.map((row) => {
-            const isFocused = row.name === focus;
-            // Backgrounds sit on the cells rather than the row so the focused
-            // wash keeps the rounded ends the comp draws.
-            const cellTone = isFocused
-              ? "bg-accent-soft-2 group-hover:bg-accent-soft-2"
-              : "group-hover:bg-background";
-            return (
-              <tr className="group" key={row.name}>
-                <td className={cn(CELL_CLASS, cellTone, "rounded-l-field")}>
-                  <button
-                    aria-pressed={isFocused}
-                    className="flex min-w-0 cursor-pointer items-center gap-3 text-left"
-                    onClick={() => onSelect(isFocused ? null : row.name)}
-                    type="button"
-                  >
-                    <span
-                      aria-hidden
-                      className="size-3.5 shrink-0 rounded-full"
-                      style={{ background: row.colour }}
-                    />
-                    <span className="truncate font-bold text-base">
-                      {row.name}
-                    </span>
-                  </button>
-                </td>
-                <td
-                  className={cn(
-                    CELL_CLASS,
-                    cellTone,
-                    "text-right font-extrabold text-base tabular-nums",
-                  )}
-                >
-                  {numberFormatter.format(row.population)}
-                </td>
-                <td className={cn(CELL_CLASS, cellTone)}>
-                  <span className="flex items-center gap-2.5">
-                    <span className="h-2.5 flex-1 overflow-hidden rounded-full bg-default">
-                      <span
-                        className="block h-full rounded-full"
-                        style={{
-                          background: row.colour,
-                          width: `${((row.population / largest) * 100).toFixed(1)}%`,
-                        }}
-                      />
-                    </span>
-                    <span className="w-11 text-right font-bold text-muted text-sm tabular-nums">
-                      {row.share.toFixed(1)}%
-                    </span>
-                  </span>
-                </td>
-                <td
-                  className={cn(
-                    CELL_CLASS,
-                    cellTone,
-                    "rounded-r-field text-right",
-                  )}
-                >
-                  {row.change === null ? (
-                    <span className="font-semibold text-muted text-sm">—</span>
-                  ) : (
-                    <DeltaChip value={row.change * 100} />
-                  )}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+              })}
+            </Table.Body>
+          </Table.Content>
+        </Table.ScrollContainer>
+      </Table>
 
       {isTruncated ? (
         <button
@@ -283,7 +230,7 @@ export function PopulationTable({
         </button>
       ) : null}
 
-      <Typography.Paragraph color="muted" size="sm" className="px-4">
+      <Typography.Paragraph className="px-4" color="muted" size="sm">
         Population counts are taken at 31 December each year.
         {previousYear === null ? null : ` Change is against ${previousYear}.`}
       </Typography.Paragraph>

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/category/category-report.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/category/category-report.tsx
@@ -430,7 +430,9 @@ export async function CategoryReport({
           </div>
         </ReportSection>
 
-        <ReportNote title="How LTA classifies {config.singularLabel.toLowerCase()}s">
+        <ReportNote
+          title={`How LTA classifies ${config.singularLabel.toLowerCase()}s`}
+        >
           {config.notes.map((note) => (
             <Typography.Paragraph key={note}>{note}</Typography.Paragraph>
           ))}

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.test.tsx
@@ -37,12 +37,17 @@ const renderTable = (rowsToRender: DimensionStat[] = rows) =>
     />,
   );
 
-/** Row order as the reader sees it, header row excluded. */
+/**
+ * Row order as the reader sees it, header row excluded.
+ *
+ * A sortable HeroUI table is an ARIA grid, so the name column is the row's
+ * `rowheader` and the remaining columns are `gridcell` — there is no `cell`.
+ */
 const visibleNames = () =>
   screen
     .getAllByRole("row")
     .slice(1)
-    .map((row) => within(row).getAllByRole("cell")[0].textContent);
+    .map((row) => within(row).getAllByRole("rowheader")[0].textContent);
 
 const searchBox = () => screen.getByRole("searchbox", { name: "Search makes" });
 
@@ -55,10 +60,12 @@ describe("DimensionTable", () => {
       screen.getByText(/Year to date through October 2025 · 3 rows/),
     ).toBeVisible();
 
-    const cells = within(screen.getAllByRole("row")[1]).getAllByRole("cell");
-    expect(cells[0]).toHaveTextContent("1TOYOTA");
-    expect(cells[1]).toHaveTextContent("600");
-    expect(cells[2]).toHaveTextContent("60.0%");
+    const row = within(screen.getAllByRole("row")[1]);
+    expect(row.getAllByRole("rowheader")[0]).toHaveTextContent("1TOYOTA");
+
+    const cells = row.getAllByRole("gridcell");
+    expect(cells[0]).toHaveTextContent("600");
+    expect(cells[1]).toHaveTextContent("60.0%");
   });
 
   it("should filter rows by the search query", async () => {
@@ -89,7 +96,9 @@ describe("DimensionTable", () => {
 
     expect(visibleNames()).toEqual(["1TOYOTA", "2BMW", "3BYD"]);
 
-    await user.click(screen.getByRole("button", { name: /Registrations/ }));
+    await user.click(
+      screen.getByRole("columnheader", { name: /Registrations/ }),
+    );
 
     expect(visibleNames()).toEqual(["3BYD", "2BMW", "1TOYOTA"]);
     expect(
@@ -104,11 +113,7 @@ describe("DimensionTable", () => {
     const user = userEvent.setup();
     renderTable();
 
-    await user.click(
-      within(screen.getByRole("columnheader", { name: /^Make/ })).getByRole(
-        "button",
-      ),
-    );
+    await user.click(screen.getByRole("columnheader", { name: /^Make/ }));
 
     expect(visibleNames()).toEqual(["2BMW", "3BYD", "1TOYOTA"]);
   });
@@ -117,8 +122,8 @@ describe("DimensionTable", () => {
     const user = userEvent.setup();
     renderTable();
 
-    const tab = screen.getByRole("button", { name: "Fuel types" });
-    expect(tab).toHaveAttribute("aria-pressed", "false");
+    const tab = screen.getByRole("radio", { name: "Fuel types" });
+    expect(tab).not.toBeChecked();
 
     await user.click(tab);
 

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.tsx
@@ -20,6 +20,17 @@ type SortDirection = "asc" | "desc";
 /** Ranks past this share the last chart colour rather than wrapping around. */
 const CHART_COLOURS = 6;
 
+/**
+ * 26rem is wider than this card gets on a phone — the card is 294px there —
+ * which left the registrations column cut mid-figure and the share column off
+ * screen entirely. Below `sm` the floor comes off and the share column is
+ * dropped, which is what makes the remaining two fit without scrolling.
+ */
+const TABLE_MIN_WIDTH_CLASS = "min-w-0 sm:min-w-[26rem]";
+
+/** The share column restates the count, so it is the one to drop on a phone. */
+const SHARE_COLUMN_CLASS = "hidden sm:table-cell";
+
 /** Ranks up to this are picked out in the accent rather than the neutral. */
 const PODIUM = 3;
 
@@ -192,7 +203,7 @@ export function DimensionTable({
         <Table.ScrollContainer>
           <Table.Content
             aria-label={`${labels.title}, year to date through ${monthLabel}`}
-            className="min-w-[26rem]"
+            className={TABLE_MIN_WIDTH_CLASS}
             onSortChange={setSortDescriptor}
             sortDescriptor={sortDescriptor}
           >
@@ -207,13 +218,18 @@ export function DimensionTable({
               <Table.Column allowsSorting id="count">
                 {({ sortDirection }) => (
                   <Table.SortableColumnHeader sortDirection={sortDirection}>
-                    Registrations
+                    {/* The full word holds this column at 112px, which is the
+                        last 19px standing between the table and a phone. */}
+                    <span className="sm:hidden">Regs</span>
+                    <span className="hidden sm:inline">Registrations</span>
                   </Table.SortableColumnHeader>
                 )}
               </Table.Column>
               {/* `share` is derived from `count`, so sorting on it would only
                   duplicate the registrations column. */}
-              <Table.Column id="share">Share</Table.Column>
+              <Table.Column className={SHARE_COLUMN_CLASS} id="share">
+                Share
+              </Table.Column>
             </Table.Header>
             <Table.Body>
               {displayed.map((row) => (
@@ -238,7 +254,7 @@ export function DimensionTable({
                   <Table.Cell className="text-right font-extrabold text-base tabular-nums">
                     {numberFormatter.format(row.count)}
                   </Table.Cell>
-                  <Table.Cell>
+                  <Table.Cell className={SHARE_COLUMN_CLASS}>
                     <span className="flex items-center gap-2.5">
                       <span className="h-2.5 w-16 shrink-0 overflow-hidden rounded-full bg-default sm:w-24">
                         <span

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { cn, Typography } from "@heroui/react";
+import type { SortDescriptor } from "@heroui/react";
+import { cn, ScrollShadow, Table, Typography } from "@heroui/react";
+import { Segment } from "@heroui-pro/react";
 import {
   CAR_DIMENSIONS,
   DIMENSION_LABELS,
 } from "@web/app/(main)/(dashboard)/cars/components/dimensions";
 import { SurfaceCard } from "@web/components/shared/bento";
-import { TABLE_HEADER_CLASS } from "@web/components/shared/report-table";
 import type { CarDimension, DimensionStat } from "@web/queries/cars";
 import { ArrowRight, Car, Search } from "lucide-react";
 import Link from "next/link";
@@ -15,9 +16,6 @@ import { useMemo, useState, useTransition } from "react";
 
 type SortKey = "name" | "count";
 type SortDirection = "asc" | "desc";
-
-/** Shared padding and hover wash for every body cell. */
-const CELL_CLASS = "px-4 py-4 align-middle group-hover:bg-background";
 
 /** Ranks past this share the last chart colour rather than wrapping around. */
 const CHART_COLOURS = 6;
@@ -86,8 +84,10 @@ export function DimensionTable({
       .withOptions({ shallow: false, startTransition }),
   );
   const [query, setQuery] = useState("");
-  const [sortKey, setSortKey] = useState<SortKey>("count");
-  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>({
+    column: "count",
+    direction: "descending",
+  });
 
   const labels = DIMENSION_LABELS[dimension];
 
@@ -106,46 +106,22 @@ export function DimensionTable({
 
   const visible = useMemo(() => {
     const needle = query.trim().toLowerCase();
+    const sortKey = sortDescriptor.column as SortKey;
+    const sortDirection: SortDirection =
+      sortDescriptor.direction === "ascending" ? "asc" : "desc";
+
     return ranked
       .filter((row) => !needle || row.name.toLowerCase().includes(needle))
       .sort((first, second) =>
         compareStats(first, second, sortKey, sortDirection),
       );
-  }, [ranked, query, sortDirection, sortKey]);
+  }, [ranked, query, sortDescriptor]);
 
   // A search is already a narrowing, so matches are never truncated on top of
   // it — collapsing only applies to the unfiltered list.
   const isSearching = query.trim().length > 0;
   const isTruncated = !isSearching && visible.length > COLLAPSED_ROWS;
   const displayed = isTruncated ? visible.slice(0, COLLAPSED_ROWS) : visible;
-
-  const toggleSort = (key: SortKey) => {
-    if (key === sortKey) {
-      setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
-      return;
-    }
-    setSortKey(key);
-    setSortDirection(key === "name" ? "asc" : "desc");
-  };
-
-  // `share` is derived from `count`, so sorting on it would only duplicate the
-  // registrations column — it is a header, not a control.
-  const headers: {
-    align: "left" | "right";
-    key: SortKey | "share";
-    label: string;
-    /** Omitted on the name column, which takes whatever is left over. */
-    width?: string;
-  }[] = [
-    { align: "left", key: "name", label: labels.column },
-    {
-      align: "right",
-      key: "count",
-      label: "Registrations",
-      width: "w-[5.5rem]",
-    },
-    { align: "left", key: "share", label: "Share", width: "w-[11rem]" },
-  ];
 
   return (
     <SurfaceCard className="gap-5">
@@ -162,32 +138,31 @@ export function DimensionTable({
               : `${visible.length} ${visible.length === 1 ? "row" : "rows"}`}
           </Typography.Paragraph>
         </div>
-        <div className="ml-auto flex gap-1.5 rounded-full bg-default p-1.5">
-          {CAR_DIMENSIONS.map((option) => {
-            const isActive = option === dimension;
-            return (
-              <button
-                aria-pressed={isActive}
-                className={cn(
-                  "cursor-pointer whitespace-nowrap rounded-full px-4 py-2 text-sm transition-colors",
-                  isActive
-                    ? "bg-surface font-extrabold text-foreground shadow-surface"
-                    : "font-semibold text-muted hover:text-foreground",
-                )}
-                key={option}
-                onClick={() => {
-                  setQuery("");
-                  setSortKey("count");
-                  setSortDirection("desc");
-                  setDimension(option);
-                }}
-                type="button"
-              >
+        {/* The three labels run to 307px side by side, wider than a small
+            phone leaves this card, and a segmented track cannot wrap — so it
+            scrolls within its own width instead of stretching the page. */}
+        <ScrollShadow
+          className="ml-auto max-w-full"
+          hideScrollBar
+          orientation="horizontal"
+          size={24}
+        >
+          <Segment
+            aria-label="Dimension"
+            onSelectionChange={(key) => {
+              setQuery("");
+              setSortDescriptor({ column: "count", direction: "descending" });
+              setDimension(key as CarDimension);
+            }}
+            selectedKey={dimension}
+          >
+            {CAR_DIMENSIONS.map((option) => (
+              <Segment.Item id={option} key={option}>
                 {DIMENSION_LABELS[option].tab}
-              </button>
-            );
-          })}
-        </div>
+              </Segment.Item>
+            ))}
+          </Segment>
+        </ScrollShadow>
       </div>
 
       <div className="flex flex-wrap items-center gap-3">
@@ -203,123 +178,88 @@ export function DimensionTable({
           />
         </label>
         <span className="whitespace-nowrap font-semibold text-muted text-sm">
-          Sorted by {SORT_LABELS[sortKey]},{" "}
-          {sortDirection === "asc" ? "ascending" : "descending"}
+          Sorted by {SORT_LABELS[sortDescriptor.column as SortKey]},{" "}
+          {sortDescriptor.direction === "ascending"
+            ? "ascending"
+            : "descending"}
         </span>
       </div>
 
-      <table
-        className={cn(
-          "w-full table-fixed border-separate border-spacing-0 transition-opacity",
-          isPending && "opacity-60",
-        )}
+      <Table
+        className={cn("transition-opacity", isPending && "opacity-60")}
+        variant="secondary"
       >
-        <caption className="sr-only">
-          {labels.title}, year to date through {monthLabel}
-        </caption>
-        <thead>
-          <tr>
-            {headers.map((header) => {
-              const alignment =
-                header.align === "right" ? "text-right" : "text-left";
-              const cellClass = cn(
-                "border-border border-b px-4 pt-4 pb-3",
-                header.width,
-                alignment,
-              );
-
-              if (header.key === "share") {
-                return (
-                  <th
-                    className={cn(cellClass, TABLE_HEADER_CLASS, "text-muted")}
-                    key={header.key}
-                    scope="col"
-                  >
-                    {header.label}
-                  </th>
-                );
-              }
-
-              const columnKey = header.key;
-              const isActive = columnKey === sortKey;
-              return (
-                <th
-                  aria-sort={
-                    isActive
-                      ? sortDirection === "asc"
-                        ? "ascending"
-                        : "descending"
-                      : "none"
-                  }
-                  className={cellClass}
-                  key={columnKey}
-                  scope="col"
-                >
-                  <button
-                    className={cn(
-                      TABLE_HEADER_CLASS,
-                      "cursor-pointer",
-                      isActive ? "text-accent-strong" : "text-muted",
-                    )}
-                    onClick={() => toggleSort(columnKey)}
-                    type="button"
-                  >
-                    {header.label}
-                    {isActive ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
-                  </button>
-                </th>
-              );
-            })}
-          </tr>
-        </thead>
-        <tbody>
-          {displayed.map((row) => (
-            <tr className="group" key={row.name}>
-              <td className={cn(CELL_CLASS, "rounded-l-field")}>
-                <span className="flex min-w-0 items-center gap-3">
-                  <span
-                    className={cn(
-                      "inline-flex size-8 shrink-0 items-center justify-center rounded-full font-extrabold text-xs",
-                      row.rank <= PODIUM
-                        ? "bg-accent/15 text-accent-strong"
-                        : "bg-default text-muted",
-                    )}
-                  >
-                    {row.rank}
-                  </span>
-                  <span className="truncate font-bold text-base">
-                    {row.name}
-                  </span>
-                </span>
-              </td>
-              <td
-                className={cn(
-                  CELL_CLASS,
-                  "text-right font-extrabold text-base tabular-nums",
+        <Table.ScrollContainer>
+          <Table.Content
+            aria-label={`${labels.title}, year to date through ${monthLabel}`}
+            className="min-w-[26rem]"
+            onSortChange={setSortDescriptor}
+            sortDescriptor={sortDescriptor}
+          >
+            <Table.Header>
+              <Table.Column allowsSorting id="name" isRowHeader>
+                {({ sortDirection }) => (
+                  <Table.SortableColumnHeader sortDirection={sortDirection}>
+                    {labels.column}
+                  </Table.SortableColumnHeader>
                 )}
-              >
-                {numberFormatter.format(row.count)}
-              </td>
-              <td className={cn(CELL_CLASS, "rounded-r-field")}>
-                <span className="flex items-center gap-2.5">
-                  <span className="h-2.5 flex-1 overflow-hidden rounded-full bg-default">
-                    <span
-                      className="block h-full rounded-full"
-                      style={{
-                        background: `var(--chart-${Math.min(CHART_COLOURS, row.rank)})`,
-                        width: `${((row.count / largestCount) * 100).toFixed(1)}%`,
-                      }}
-                    />
-                  </span>
-                  <span className="w-11 text-right font-bold text-muted text-sm tabular-nums">
-                    {row.share.toFixed(1)}%
-                  </span>
-                </span>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+              </Table.Column>
+              <Table.Column allowsSorting id="count">
+                {({ sortDirection }) => (
+                  <Table.SortableColumnHeader sortDirection={sortDirection}>
+                    Registrations
+                  </Table.SortableColumnHeader>
+                )}
+              </Table.Column>
+              {/* `share` is derived from `count`, so sorting on it would only
+                  duplicate the registrations column. */}
+              <Table.Column id="share">Share</Table.Column>
+            </Table.Header>
+            <Table.Body>
+              {displayed.map((row) => (
+                <Table.Row id={row.name} key={row.name}>
+                  <Table.Cell>
+                    <span className="flex min-w-0 items-center gap-3">
+                      <span
+                        className={cn(
+                          "inline-flex size-8 shrink-0 items-center justify-center rounded-full font-extrabold text-xs",
+                          row.rank <= PODIUM
+                            ? "bg-accent/15 text-accent-strong"
+                            : "bg-default text-muted",
+                        )}
+                      >
+                        {row.rank}
+                      </span>
+                      <span className="truncate font-bold text-base">
+                        {row.name}
+                      </span>
+                    </span>
+                  </Table.Cell>
+                  <Table.Cell className="text-right font-extrabold text-base tabular-nums">
+                    {numberFormatter.format(row.count)}
+                  </Table.Cell>
+                  <Table.Cell>
+                    <span className="flex items-center gap-2.5">
+                      <span className="h-2.5 w-16 shrink-0 overflow-hidden rounded-full bg-default sm:w-24">
+                        <span
+                          className="block h-full rounded-full"
+                          style={{
+                            background: `var(--chart-${Math.min(CHART_COLOURS, row.rank)})`,
+                            width: `${((row.count / largestCount) * 100).toFixed(1)}%`,
+                          }}
+                        />
+                      </span>
+                      <span className="w-11 text-right font-bold text-muted text-sm tabular-nums">
+                        {row.share.toFixed(1)}%
+                      </span>
+                    </span>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table.Content>
+        </Table.ScrollContainer>
+      </Table>
 
       {visible.length === 0 ? (
         <Typography.Paragraph color="muted" size="sm" className="px-4 py-9">

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/coe-comparison-chart.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/coe-comparison-chart.tsx
@@ -9,6 +9,15 @@ interface CoeComparisonChartProps {
   data: MakeCoeComparisonData[];
 }
 
+/**
+ * Recharts calls a tick formatter as `(value, index)`, and `numberFormat`
+ * reads a second argument as its options — which for the zero tick renders
+ * "NaNundefined". Dropping the index is the whole fix.
+ */
+function formatPremiumTick(value: number): string {
+  return numberFormat(value);
+}
+
 export function CoeComparisonChart({ data }: CoeComparisonChartProps) {
   const chartData = data.map((item) => ({ ...item }));
 
@@ -51,7 +60,7 @@ export function CoeComparisonChart({ data }: CoeComparisonChartProps) {
             (dataMin: number) => Math.floor(dataMin / 10000) * 10000,
             (dataMax: number) => Math.ceil(dataMax / 10000) * 10000,
           ]}
-          tickFormatter={numberFormat}
+          tickFormatter={formatPremiumTick}
           label={{
             angle: 90,
             position: "insideRight",

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-search.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-search.tsx
@@ -26,9 +26,12 @@ export function MakeSearch({ makes }: MakeSearchProps) {
   return (
     <ComboBox onSelectionChange={handleSelectionChange}>
       <Label className="sr-only">Search make</Label>
-      <ComboBox.InputGroup>
-        <Search className="ml-3 size-4 text-muted" />
-        <Input placeholder="Search make..." />
+      <ComboBox.InputGroup className="relative">
+        <Search
+          aria-hidden
+          className="pointer-events-none absolute top-1/2 left-3.5 z-10 size-4 -translate-y-1/2 text-muted"
+        />
+        <Input className="pl-10" placeholder="Search make..." />
         <ComboBox.Trigger />
       </ComboBox.InputGroup>
       <ComboBox.Popover>

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-table.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-table.tsx
@@ -37,12 +37,34 @@ const COLUMNS: {
   align: "left" | "right";
   key: SortKey | null;
   label: string;
+  /** Shown below `sm`, where the full word is wider than its column. */
+  shortLabel?: string;
 }[] = [
   { align: "left", key: "make", label: "Make" },
-  { align: "right", key: "count", label: "Registrations" },
+  { align: "right", key: "count", label: "Registrations", shortLabel: "Regs" },
   { align: "left", key: null, label: "Share" },
-  { align: "right", key: "yoyChange", label: "Change" },
+  { align: "right", key: "yoyChange", label: "Change", shortLabel: "YoY" },
 ];
+
+/** The label pair a header cell renders, one per breakpoint. */
+function ColumnLabel({
+  label,
+  shortLabel,
+}: {
+  label: string;
+  shortLabel?: string;
+}) {
+  if (!shortLabel) {
+    return <>{label}</>;
+  }
+
+  return (
+    <>
+      <span className="sm:hidden">{shortLabel}</span>
+      <span className="hidden sm:inline">{label}</span>
+    </>
+  );
+}
 
 const SORT_LABELS: Record<SortKey, string> = {
   count: "registrations",
@@ -50,8 +72,14 @@ const SORT_LABELS: Record<SortKey, string> = {
   yoyChange: "change",
 };
 
+/**
+ * Below `sm` the share bar and the chevron are dropped and the remaining
+ * columns tighten, because the first column is what pays for them: at the
+ * desktop widths it was left with about 90px, all of which the rank badge and
+ * the logo took, and every make name truncated to nothing.
+ */
 const GRID_CLASS =
-  "grid grid-cols-[minmax(0,1fr)_84px_92px_18px] items-center gap-3 sm:grid-cols-[minmax(0,1fr)_100px_minmax(90px,1fr)_96px_18px]";
+  "grid grid-cols-[minmax(0,1fr)_56px_52px] items-center gap-2 sm:grid-cols-[minmax(0,1fr)_100px_minmax(90px,1fr)_96px_18px] sm:gap-3";
 
 /**
  * Keeps the funnel that used to be fed by the makes-page search autocomplete.
@@ -62,6 +90,36 @@ const GRID_CLASS =
  * fires on navigation, not on typing: the search box above is a local filter,
  * and capturing keystrokes would flood the funnel and change what it means.
  */
+/**
+ * The change figure as bare coloured text.
+ *
+ * `DeltaChip` is 86px of pill against a 52px column on a phone, and it was
+ * overrunning the registrations figure beside it. The chip returns from `sm`,
+ * where the row has the width for it.
+ */
+function ChangeText({
+  className,
+  value,
+}: {
+  className?: string;
+  value: number;
+}) {
+  return (
+    <span
+      className={cn(
+        "text-right font-bold text-xs tabular-nums",
+        value >= 0
+          ? "text-success-soft-foreground"
+          : "text-warning-soft-foreground",
+        className,
+      )}
+    >
+      {value >= 0 ? "+" : "−"}
+      {Math.abs(value).toFixed(1)}%
+    </span>
+  );
+}
+
 function trackMakeSelected(make: string) {
   posthog.capture("car_make_searched", { make });
 }
@@ -170,7 +228,7 @@ export function MakesTable({
       <div
         className={cn(
           GRID_CLASS,
-          "mt-3.5 border-border border-b px-4.5 pt-4 pb-3",
+          "mt-3.5 items-end border-border border-b px-4.5 pt-4 pb-3",
         )}
       >
         {COLUMNS.map((column) => {
@@ -185,7 +243,10 @@ export function MakesTable({
           if (column.key === null) {
             return (
               <span className={className} key={column.label}>
-                {column.label}
+                <ColumnLabel
+                  label={column.label}
+                  shortLabel={column.shortLabel}
+                />
               </span>
             );
           }
@@ -198,12 +259,15 @@ export function MakesTable({
               onClick={() => toggleSort(sortKeyForColumn)}
               type="button"
             >
-              {column.label}
+              <ColumnLabel
+                label={column.label}
+                shortLabel={column.shortLabel}
+              />
               {isActive ? (sortDirection === "asc" ? " ↑" : " ↓") : ""}
             </button>
           );
         })}
-        <span />
+        <span className="hidden sm:block" />
       </div>
 
       <div className="flex flex-col">
@@ -220,7 +284,7 @@ export function MakesTable({
             <span className="flex min-w-0 items-center gap-2.5">
               <span
                 className={cn(
-                  "inline-flex size-7.5 shrink-0 items-center justify-center rounded-full font-extrabold text-sm",
+                  "inline-flex size-6 shrink-0 items-center justify-center rounded-full font-extrabold text-xs sm:size-7.5 sm:text-sm",
                   row.rank <= 3
                     ? "bg-accent/15 text-accent-strong"
                     : "bg-default text-muted",
@@ -228,13 +292,15 @@ export function MakesTable({
               >
                 {row.rank}
               </span>
-              <MakeAvatar logoUrl={row.logoUrl} make={row.make} size={26} />
-              <span className="truncate font-bold text-base text-foreground">
+              <span className="hidden shrink-0 sm:block">
+                <MakeAvatar logoUrl={row.logoUrl} make={row.make} size={26} />
+              </span>
+              <span className="truncate font-bold text-foreground text-sm sm:text-base">
                 {row.make}
               </span>
             </span>
 
-            <span className="text-right font-extrabold text-base text-foreground tabular-nums">
+            <span className="text-right font-extrabold text-foreground text-sm tabular-nums sm:text-base">
               <NumberValue
                 locale="en-SG"
                 maximumFractionDigits={0}
@@ -269,12 +335,18 @@ export function MakesTable({
                 —
               </span>
             ) : (
-              <DeltaChip className="justify-self-end" value={row.yoyChange} />
+              <>
+                <ChangeText className="sm:hidden" value={row.yoyChange} />
+                <DeltaChip
+                  className="hidden justify-self-end sm:flex"
+                  value={row.yoyChange}
+                />
+              </>
             )}
 
             <ChevronRight
               aria-hidden
-              className="size-4.5 justify-self-end text-muted"
+              className="hidden size-4.5 justify-self-end text-muted sm:block"
             />
           </Link>
         ))}

--- a/apps/web/src/app/(main)/(dashboard)/coe/components/all-categories-table.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/components/all-categories-table.tsx
@@ -26,9 +26,13 @@ const COLUMNS: { align: "left" | "right"; label: string }[] = [
  * Fixed numeric columns so every row lines up — each row is its own grid, so
  * `auto` tracks would size independently and stagger. Kept narrow enough that
  * the category name still fits in the two-column layout below `2xl`.
+ *
+ * The narrowest step exists because the default tracks add up to 244px, which
+ * is wider than a 320px phone leaves this card once the page gutter and the
+ * card padding are taken out.
  */
 const GRID =
-  "grid grid-cols-[minmax(0,1fr)_5.5rem_4rem_4.75rem_1rem] gap-2 2xl:grid-cols-[minmax(0,1fr)_7rem_5rem_5.5rem_1.5rem] 2xl:gap-3";
+  "grid grid-cols-[minmax(0,1fr)_4.25rem_3.25rem_3.75rem_0.75rem] gap-1.5 sm:grid-cols-[minmax(0,1fr)_5.5rem_4rem_4.75rem_1rem] sm:gap-2 2xl:grid-cols-[minmax(0,1fr)_7rem_5rem_5.5rem_1.5rem] 2xl:gap-3";
 
 /**
  * The five-category table, always in category order.

--- a/apps/web/src/app/(main)/(dashboard)/coe/components/coe-controls.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/components/coe-controls.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { cn } from "@heroui/react";
+import { cn, ScrollShadow } from "@heroui/react";
+import { Segment } from "@heroui-pro/react";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
 import { type ReactNode, useTransition } from "react";
 import {
   CATEGORY_KEYS,
   type CategoryKey,
   EXERCISE_RANGES,
+  type ExerciseRange,
   RANGE_LABELS,
 } from "./search-params";
 
@@ -91,7 +93,14 @@ export function CategorySelect({
   );
 }
 
-/** The range pills beside the page title. */
+/**
+ * The range pills beside the page title.
+ *
+ * The three labels run to 452px laid out in full, which is wider than a phone,
+ * and a segmented control cannot wrap without breaking its track — so the
+ * `Segment` rides in a horizontal `ScrollShadow` and scrolls within its own
+ * width rather than pushing the page sideways.
+ */
 export function RangeTabs() {
   const [isPending, startTransition] = useTransition();
   const [range, setRange] = useQueryState(
@@ -102,32 +111,24 @@ export function RangeTabs() {
   );
 
   return (
-    <fieldset
-      className={cn(
-        "flex gap-1.5 rounded-full bg-default p-[5px]",
-        isPending && "opacity-70",
-      )}
+    <ScrollShadow
+      className="max-w-full"
+      hideScrollBar
+      orientation="horizontal"
+      size={24}
     >
-      <legend className="sr-only">Exercise range</legend>
-      {EXERCISE_RANGES.map((option) => {
-        const isActive = option === range;
-        return (
-          <button
-            aria-pressed={isActive}
-            className={cn(
-              "whitespace-nowrap rounded-full px-[18px] py-2.5 text-sm transition-colors",
-              isActive
-                ? "bg-surface font-extrabold text-foreground shadow-surface"
-                : "font-semibold text-muted hover:text-foreground",
-            )}
-            key={option}
-            onClick={() => setRange(option)}
-            type="button"
-          >
+      <Segment
+        aria-label="Exercise range"
+        className={cn(isPending && "opacity-70")}
+        onSelectionChange={(key) => setRange(key as ExerciseRange)}
+        selectedKey={range}
+      >
+        {EXERCISE_RANGES.map((option) => (
+          <Segment.Item id={option} key={option}>
             {RANGE_LABELS[option]}
-          </button>
-        );
-      })}
-    </fieldset>
+          </Segment.Item>
+        ))}
+      </Segment>
+    </ScrollShadow>
   );
 }

--- a/apps/web/src/app/(main)/(dashboard)/coe/components/premiums-chart.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/components/premiums-chart.tsx
@@ -63,7 +63,7 @@ export function PremiumsChart({
         </span>
       </div>
 
-      <div className="flex h-[300px] items-end gap-3">
+      <div className="flex h-[300px] items-end gap-1.5 sm:gap-3">
         {columns.map((column, index) => {
           const isLatest = index === columns.length - 1;
           const isHovered = hovered === column.key;
@@ -74,7 +74,11 @@ export function PremiumsChart({
           return (
             <button
               aria-label={`${column.label}: ${formatMoney(column.premium)}, ${formatChange(column.changeRatio)}`}
-              className="relative flex h-full flex-1 cursor-default flex-col items-center justify-end gap-2.5"
+              // `min-w-0` because a flex item will not shrink below its
+              // content, and every column carries a full-width tick label —
+              // the hidden ones are `invisible`, not unmounted, so without
+              // this the row is as wide as 12 or 24 labels laid end to end.
+              className="relative flex h-full min-w-0 flex-1 cursor-default flex-col items-center justify-end gap-2.5"
               key={column.key}
               onBlur={() => setHovered(null)}
               onFocus={() => setHovered(column.key)}

--- a/apps/web/src/app/(main)/(dashboard)/components/coe-premiums-card.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/coe-premiums-card.tsx
@@ -83,7 +83,10 @@ export function CoePremiumsCard({ series }: { series: CoeCategorySeries[] }) {
           </Typography.Paragraph>
         </div>
 
-        <div className="ml-auto flex items-center gap-2">
+        {/* Six 44px circles plus their gaps want 304px, which is wider than a
+            320px phone can give this card — so they wrap rather than push the
+            page sideways. */}
+        <div className="ml-auto flex flex-wrap items-center gap-2">
           {series.map((item) => {
             const isActive = item.category === active.category;
             return (

--- a/apps/web/src/components/app-nav.tsx
+++ b/apps/web/src/components/app-nav.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import type { Key } from "@heroui/react";
-
 import { Button, cn, Dropdown, Header, Label } from "@heroui/react";
+import { Navbar } from "@heroui-pro/react";
 import { BetaChip, NewChip } from "@web/components/shared/chips";
 import {
   MORE_NAV_ITEMS,
@@ -59,7 +59,9 @@ const menuGrid = (itemCount: number) =>
   cn("grid gap-x-2.5 gap-y-0.5", itemCount > 4 ? "grid-cols-2" : "grid-cols-1");
 
 const menuClassName = (itemCount: number) =>
-  cn(menuGrid(itemCount), "p-2.5", itemCount > 4 && "min-w-112");
+  // `md:` because 112 (448px) is wider than a phone, and these popovers only
+  // ever open from the desktop pills.
+  cn(menuGrid(itemCount), "p-2.5", itemCount > 4 && "md:min-w-112");
 
 // A section is a grid item of the menu, and re-declares the same columns so its
 // own rows line up with the ones outside it.
@@ -83,6 +85,31 @@ function NavMenuItems({ items }: { items: readonly NavigationItem[] }) {
   ));
 }
 
+/** One row of the phone menu. Pressing it closes the menu on its own. */
+function MobileMenuLink({
+  badge,
+  href,
+  isCurrent,
+  label,
+}: {
+  badge?: NavigationItem["badge"];
+  href: string;
+  isCurrent: boolean;
+  label: string;
+}) {
+  return (
+    <Navbar.MenuItem
+      className="flex items-center gap-2 py-2.5 font-semibold text-base"
+      href={href}
+      isCurrent={isCurrent}
+    >
+      {label}
+      {badge === "new" ? <NewChip /> : null}
+      {badge === "beta" ? <BetaChip /> : null}
+    </Navbar.MenuItem>
+  );
+}
+
 export function AppNav({
   moreNavItems = MORE_NAV_ITEMS,
   showSocialLinks = false,
@@ -100,17 +127,28 @@ export function AppNav({
   const handleNavigate = (key: Key) => router.push(String(key));
 
   return (
-    <nav aria-label="Main navigation">
-      <div className="flex flex-wrap items-center gap-4">
-        <Link
-          aria-label="MotorMetrics home"
-          className="flex size-13 shrink-0 items-center justify-center rounded-full bg-accent text-accent-foreground"
-          href="/"
-        >
-          <TrendingUp className="size-6" strokeWidth={2.5} />
-        </Link>
+    // `position="static"` and `maxWidth="full"` because the bar sits in flow
+    // inside the layout column, which already owns the page measure and gutter.
+    <Navbar
+      aria-label="Main navigation"
+      maxWidth="full"
+      navigate={(href) => router.push(href)}
+      position="static"
+    >
+      <Navbar.Header className="gap-4 px-0">
+        <Navbar.Brand>
+          <Link
+            aria-label="MotorMetrics home"
+            className="flex size-13 shrink-0 items-center justify-center rounded-full bg-accent text-accent-foreground"
+            href="/"
+          >
+            <TrendingUp className="size-6" strokeWidth={2.5} />
+          </Link>
+        </Navbar.Brand>
 
-        <div className="flex flex-wrap items-center gap-2">
+        {/* Laid out in full the pills wrap onto three rows on a phone and eat
+            half the first screen, so below `md` they move into the menu. */}
+        <Navbar.Content className="hidden flex-wrap items-center gap-2 md:flex">
           {PRIMARY_NAV_ITEMS.map(({ href, items, label, sectionLabel }) => {
             const isActive = href === activeHref;
 
@@ -197,11 +235,13 @@ export function AppNav({
               </Dropdown.Menu>
             </Dropdown.Popover>
           </Dropdown>
-        </div>
+        </Navbar.Content>
+
+        <Navbar.Spacer />
 
         {showSocialLinks ? (
           <Link
-            className="ml-auto rounded-full bg-foreground px-6 py-3.5 font-bold text-accent-foreground text-sm transition-colors hover:bg-muted"
+            className="hidden rounded-full bg-foreground px-6 py-3.5 font-bold text-accent-foreground text-sm transition-colors hover:bg-muted md:block"
             href={SOCIAL_URLS.telegram}
             rel="noopener noreferrer"
             target="_blank"
@@ -209,10 +249,72 @@ export function AppNav({
             Get updates
           </Link>
         ) : null}
-      </div>
 
-      {/* TODO: The comp's search field and notification bell are decorative —
-          neither is reproduced here because there is nothing to wire them to. */}
-    </nav>
+        <Navbar.MenuToggle className="md:hidden" />
+      </Navbar.Header>
+
+      <Navbar.Menu className="gap-1">
+        {PRIMARY_NAV_ITEMS.map(({ href, items, label, sectionLabel }) => {
+          if (!items) {
+            return (
+              <MobileMenuLink
+                href={href}
+                isCurrent={href === activeHref}
+                key={href}
+                label={label}
+              />
+            );
+          }
+
+          // The pill's own dropdown flattens into an eyebrow plus its rows, so
+          // the whole tree is reachable without a second level of tapping.
+          return (
+            <div className="flex flex-col gap-1" key={href}>
+              <Header className={menuHeaderClassName}>{sectionLabel}</Header>
+              <MobileMenuLink
+                href={href}
+                isCurrent={href === activeHref}
+                label={`${label} overview`}
+              />
+              {items.map(({ badge, title, url }) => (
+                <MobileMenuLink
+                  badge={badge}
+                  href={url}
+                  isCurrent={matchesPath(pathname, url)}
+                  key={url}
+                  label={title}
+                />
+              ))}
+            </div>
+          );
+        })}
+
+        <div className="flex flex-col gap-1">
+          <Header className={menuHeaderClassName}>
+            {MORE_NAV_SECTION_LABEL}
+          </Header>
+          {moreNavItems.map(({ badge, title, url }) => (
+            <MobileMenuLink
+              badge={badge}
+              href={url}
+              isCurrent={matchesPath(pathname, url)}
+              key={url}
+              label={title}
+            />
+          ))}
+        </div>
+
+        {showSocialLinks ? (
+          <Link
+            className="mt-4 rounded-full bg-foreground px-6 py-3.5 text-center font-bold text-accent-foreground text-sm transition-colors hover:bg-muted"
+            href={SOCIAL_URLS.telegram}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Get updates
+          </Link>
+        ) : null}
+      </Navbar.Menu>
+    </Navbar>
   );
 }

--- a/apps/web/src/components/shared/month-selector.tsx
+++ b/apps/web/src/components/shared/month-selector.tsx
@@ -54,9 +54,12 @@ export function MonthSelector({
       onSelectionChange={(key) => setMonth(key as string)}
     >
       <Label className="sr-only">Month</Label>
-      <ComboBox.InputGroup>
-        <Calendar className="ml-3 size-4 text-muted" />
-        <Input placeholder="Select Month" />
+      <ComboBox.InputGroup className="relative">
+        <Calendar
+          aria-hidden
+          className="pointer-events-none absolute top-1/2 left-3.5 z-10 size-4 -translate-y-1/2 text-muted"
+        />
+        <Input className="pl-10" placeholder="Select Month" />
         <ComboBox.Trigger />
       </ComboBox.InputGroup>
       <ComboBox.Popover>

--- a/apps/web/src/components/shared/page-head.tsx
+++ b/apps/web/src/components/shared/page-head.tsx
@@ -40,7 +40,7 @@ export function PageHead({
       {/* `min-w-0` so a control wider than the phone — the COE range tabs run
           to 452px — clips into its own scroll area instead of stretching the
           page. */}
-      <div className="ml-auto flex min-w-0 max-w-full flex-wrap items-center gap-3">
+      <div className="flex min-w-0 max-w-full flex-wrap items-center gap-3 sm:ml-auto">
         {controls}
         <SharePill title={title} />
       </div>

--- a/apps/web/src/components/shared/page-head.tsx
+++ b/apps/web/src/components/shared/page-head.tsx
@@ -37,7 +37,10 @@ export function PageHead({
           </Typography.Paragraph>
         ) : null}
       </div>
-      <div className="ml-auto flex flex-wrap items-center gap-3">
+      {/* `min-w-0` so a control wider than the phone — the COE range tabs run
+          to 452px — clips into its own scroll area instead of stretching the
+          page. */}
+      <div className="ml-auto flex min-w-0 max-w-full flex-wrap items-center gap-3">
         {controls}
         <SharePill title={title} />
       </div>

--- a/apps/web/src/components/shared/report-table.test.tsx
+++ b/apps/web/src/components/shared/report-table.test.tsx
@@ -43,7 +43,11 @@ describe("ReportTable", () => {
       </ReportTable>,
     );
 
-    expect(getByRole("columnheader")).toHaveStyle({ width: "30%" });
+    // The width is applied through a custom property and a `sm:` utility, so
+    // jsdom — which loads no Tailwind — only ever sees the variable.
+    expect(getByRole("columnheader")).toHaveStyle({
+      "--report-col-width": "30%",
+    });
   });
 });
 

--- a/apps/web/src/components/shared/report-table.tsx
+++ b/apps/web/src/components/shared/report-table.tsx
@@ -34,11 +34,15 @@ export function ReportTable({
     // wrapping "Petrol-Electric (Plug-In)" over five lines while still
     // clipping the columns that refuse to wrap. Sized to its content it
     // scrolls cleanly, and `ScrollShadow` is what says so.
+    //
+    // The widest of these run seven columns and 770px against a 358px phone,
+    // so the fade has to be unmissable rather than a hairline — hence 40px,
+    // and the tighter cell padding below `sm` that buys back another column.
     <ScrollShadow
       className="w-full"
       hideScrollBar
       orientation="horizontal"
-      size={24}
+      size={40}
     >
       <table className="w-full min-w-max border-collapse tabular-nums">
         <thead>
@@ -46,7 +50,7 @@ export function ReportTable({
             {columns.map(({ align, label, width }) => (
               <th
                 className={cn(
-                  "border-border border-b px-3.5 pb-3",
+                  "border-border border-b px-2 pb-3 sm:px-3.5",
                   TABLE_HEADER_CLASS,
                   align === "end" ? "text-right" : "text-left",
                   // The widths callers pass size the share bars on a desktop
@@ -110,7 +114,7 @@ export function ReportCell({
   return (
     <td
       className={cn(
-        "border-border border-b px-3.5 py-4",
+        "border-border border-b px-2 py-4 sm:px-3.5",
         align === "end" && "text-right",
         className,
       )}

--- a/apps/web/src/components/shared/report-table.tsx
+++ b/apps/web/src/components/shared/report-table.tsx
@@ -1,6 +1,6 @@
-import { cn } from "@heroui/react";
+import { cn, ScrollShadow } from "@heroui/react";
 import { NumberValue } from "@heroui-pro/react";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 /**
  * The column-header treatment shared by every table in the app.
@@ -29,8 +29,18 @@ export function ReportTable({
   columns: { align?: "end"; label: string; width?: string }[];
 }) {
   return (
-    <div className="w-full overflow-x-auto">
-      <table className="w-full border-collapse tabular-nums">
+    // `min-w-max` is what keeps the columns readable on a phone: with `w-full`
+    // alone the table is pinned to the container and compresses instead,
+    // wrapping "Petrol-Electric (Plug-In)" over five lines while still
+    // clipping the columns that refuse to wrap. Sized to its content it
+    // scrolls cleanly, and `ScrollShadow` is what says so.
+    <ScrollShadow
+      className="w-full"
+      hideScrollBar
+      orientation="horizontal"
+      size={24}
+    >
+      <table className="w-full min-w-max border-collapse tabular-nums">
         <thead>
           <tr>
             {columns.map(({ align, label, width }) => (
@@ -39,10 +49,23 @@ export function ReportTable({
                   "border-border border-b px-3.5 pb-3",
                   TABLE_HEADER_CLASS,
                   align === "end" ? "text-right" : "text-left",
+                  // The widths callers pass size the share bars on a desktop
+                  // and run to 300px, which on a phone is a third of the
+                  // scroll for a column that only restates the percentage
+                  // beside it. Below `sm` the column takes its content width
+                  // instead.
+                  // `min-w-16` keeps the bar visible once the explicit
+                  // width stops applying; the bar itself has no intrinsic
+                  // width, so the column would otherwise collapse.
+                  width && "min-w-16 sm:w-(--report-col-width)",
                 )}
                 key={label || width}
                 scope="col"
-                style={width ? { width } : undefined}
+                style={
+                  width
+                    ? ({ "--report-col-width": width } as CSSProperties)
+                    : undefined
+                }
               >
                 {label}
               </th>
@@ -51,7 +74,7 @@ export function ReportTable({
         </thead>
         <tbody>{children}</tbody>
       </table>
-    </div>
+    </ScrollShadow>
   );
 }
 

--- a/apps/web/src/components/shared/report.tsx
+++ b/apps/web/src/components/shared/report.tsx
@@ -49,17 +49,24 @@ export function ReportFilterBar({
   trailing?: ReactNode;
   trailingLabel?: string;
 }) {
+  // Below `sm` each label stacks over its own controls. As one wrapping row
+  // the two groups fell differently — a wide primary control pushed its pills
+  // onto the next line and left its label stranded above them, while a narrow
+  // trailing control stayed beside its own label. Binding each label to its
+  // controls is what makes the two read the same.
   return (
     <div
       className={cn(
-        "flex flex-wrap items-center gap-4 border-border border-y py-4",
+        "flex flex-col gap-4 border-border border-y py-4 sm:flex-row sm:flex-wrap sm:items-center",
         className,
       )}
     >
-      <ReportEyebrow>{label}</ReportEyebrow>
-      <div className="flex flex-wrap items-center gap-2">{children}</div>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+        <ReportEyebrow>{label}</ReportEyebrow>
+        <div className="flex flex-wrap items-center gap-2">{children}</div>
+      </div>
       {trailing ? (
-        <div className="ml-auto flex flex-wrap items-center gap-3">
+        <div className="flex flex-col gap-2 sm:ml-auto sm:flex-row sm:items-center sm:gap-3">
           {trailingLabel ? (
             <ReportEyebrow>{trailingLabel}</ReportEyebrow>
           ) : null}
@@ -140,7 +147,15 @@ export function ReportHeadline({
           </Typography.Paragraph>
         ) : null}
       </div>
-      {stats ? <div className="ml-auto flex flex-wrap">{stats}</div> : null}
+      {/* Below `sm` the cells become a two-column grid. Wrapping a gapless
+          flex row stacked them flush — a cell's note ran straight into the
+          next cell's label — and left the rule that divides them dangling at
+          the start of every wrapped row. */}
+      {stats ? (
+        <div className="ml-auto grid w-full grid-cols-2 gap-x-6 gap-y-5 sm:flex sm:w-auto sm:flex-wrap sm:gap-0">
+          {stats}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -156,7 +171,7 @@ export function ReportStat({
   value: ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-1.5 border-border border-l px-6">
+    <div className="flex flex-col gap-1.5 border-border sm:border-l sm:px-6">
       <span className="font-semibold text-muted text-sm">{label}</span>
       <span className="font-extrabold text-2xl tabular-nums tracking-tight">
         {value}

--- a/apps/web/src/components/shared/report.tsx
+++ b/apps/web/src/components/shared/report.tsx
@@ -119,11 +119,16 @@ export function ReportHeadline({
 }) {
   return (
     <div className={cn("flex flex-wrap items-end gap-12", className)}>
-      <div className="flex flex-col gap-2">
+      {/* `min-w-0` so the label wraps instead of holding the column open —
+          a flex item will not shrink below its content otherwise, and the
+          longer labels run past a small phone. */}
+      <div className="flex min-w-0 flex-col gap-2">
         <Typography.Paragraph className="text-muted-strong">
           {label}
         </Typography.Paragraph>
-        <div className="flex items-center gap-4">
+        {/* Wraps only when the figure and its pill will not sit side by side,
+            which on these headlines is below about 360px. */}
+        <div className="flex flex-wrap items-center gap-4">
           <span className="font-extrabold text-6xl tabular-nums leading-none tracking-tight lg:text-7xl">
             {value}
           </span>

--- a/apps/web/src/components/shared/year-selector.tsx
+++ b/apps/web/src/components/shared/year-selector.tsx
@@ -40,9 +40,12 @@ export function YearSelector({
       onSelectionChange={(key) => setYear(key ? Number(key) : null)}
     >
       <Label className="sr-only">Year</Label>
-      <ComboBox.InputGroup>
-        <Calendar className="ml-3 size-4 text-muted" />
-        <Input placeholder="Select Year" />
+      <ComboBox.InputGroup className="relative">
+        <Calendar
+          aria-hidden
+          className="pointer-events-none absolute top-1/2 left-3.5 z-10 size-4 -translate-y-1/2 text-muted"
+        />
+        <Input className="pl-10" placeholder="Select Year" />
         <ComboBox.Trigger />
       </ComboBox.InputGroup>
       <ComboBox.Popover>

--- a/apps/web/src/components/trends-comparison.tsx
+++ b/apps/web/src/components/trends-comparison.tsx
@@ -98,9 +98,12 @@ export function TrendsComparison({
       onSelectionChange={(key) => key && onChange(key as string)}
     >
       <Label>{label}</Label>
-      <ComboBox.InputGroup>
-        <Calendar className="ml-3 size-4 text-muted" />
-        <Input placeholder={label} />
+      <ComboBox.InputGroup className="relative">
+        <Calendar
+          aria-hidden
+          className="pointer-events-none absolute top-1/2 left-3.5 z-10 size-4 -translate-y-1/2 text-muted"
+        />
+        <Input className="pl-10" placeholder={label} />
         <ComboBox.Trigger />
       </ComboBox.InputGroup>
       <ComboBox.Popover>


### PR DESCRIPTION
Swept all 27 routes under `app/(main)/` at 390, 375 and 320px. Every page now reports `scrollWidth === clientWidth` at all three widths, and content starts 176px down instead of 356–416px.

- Rebuild `app-nav.tsx` on Pro `Navbar` — below `md` the bar collapses to logo plus `Navbar.MenuToggle`, with the nav tree in `Navbar.Menu`; the desktop pill row is unchanged. Previously six pills wrapped onto three rows and ate half the first screen
- Rebuild the `/cars/annual` population table and the `/cars` dimension table on HeroUI `Table`. Both used `table-fixed` with fixed column widths wider than the viewport, which collapsed the name column to zero — on `/cars` no make name was visible at all, and on `/cars/annual` the figures overlapped the names. `Table.ScrollContainer` supplies the scroll wrapper they lacked, and `allowsSorting` gives real `aria-sort`, replacing the hand-rolled sort state
- Replace the COE range tabs and the Cars dimension tabs with Pro `Segment` in a horizontal `ScrollShadow` — both were hand-rolled segmented controls that could neither wrap nor scroll, so they pushed the page to 520px
- Let the `premiums-chart` columns shrink below their tick labels, which are `invisible` rather than unmounted and so blocked `flex-1` from shrinking
- Narrow the COE category grid tracks and wrap the A–E circle row, which both wanted more width than a 320px phone allows

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790672833&installation_model_id=21947&pr_number=940&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F940&signature=97a2147c5ee7ae0721116e021c95706ed7aca7f5413b2ef8e631e49cdb99f801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->