### PR TITLE
Upgrade Workflow SDK to v5 and pin runs to Singapore

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -83,7 +83,7 @@
     "tailwind-merge": "3.6.0",
     "tailwind-variants": "3.2.2",
     "twitter-api-v2": "1.29.0",
-    "workflow": "4.8.1",
+    "workflow": "5.0.0-beta.46",
     "zod": "catalog:",
     "zustand": "5.0.13"
   },
@@ -109,7 +109,7 @@
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "6.0.1",
     "@vitest/coverage-v8": "catalog:",
-    "@workflow/vitest": "4.0.17",
+    "@workflow/vitest": "5.0.0-beta.46",
     "babel-plugin-react-compiler": "1.0.0",
     "jsdom": "26.1.0",
     "postcss": "8.5.23",

--- a/apps/web/src/app/api/workflows/car-costs/route.ts
+++ b/apps/web/src/app/api/workflows/car-costs/route.ts
@@ -1,3 +1,4 @@
+import { WORKFLOW_REGION } from "@web/config/workflow";
 import { carCostsWorkflow } from "@web/workflows/car-costs";
 import { start } from "workflow/api";
 
@@ -7,12 +8,10 @@ export async function GET(request: Request) {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const run = await start(carCostsWorkflow, []);
+  const run = await start(carCostsWorkflow, { region: WORKFLOW_REGION });
 
-  return new Response(run.getReadable(), {
-    headers: {
-      "Content-Type": "application/x-ndjson",
-      "X-Run-Id": run.runId,
-    },
-  });
+  return Response.json(
+    { message: "Workflow started", runId: run.runId },
+    { headers: { "X-Run-Id": run.runId } },
+  );
 }

--- a/apps/web/src/app/api/workflows/car-population/route.ts
+++ b/apps/web/src/app/api/workflows/car-population/route.ts
@@ -1,3 +1,4 @@
+import { WORKFLOW_REGION } from "@web/config/workflow";
 import { carPopulationWorkflow } from "@web/workflows/car-population";
 import { start } from "workflow/api";
 
@@ -7,12 +8,10 @@ export async function GET(request: Request) {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const run = await start(carPopulationWorkflow, []);
+  const run = await start(carPopulationWorkflow, { region: WORKFLOW_REGION });
 
-  return new Response(run.getReadable(), {
-    headers: {
-      "Content-Type": "application/x-ndjson",
-      "X-Run-Id": run.runId,
-    },
-  });
+  return Response.json(
+    { message: "Workflow started", runId: run.runId },
+    { headers: { "X-Run-Id": run.runId } },
+  );
 }

--- a/apps/web/src/app/api/workflows/cars/route.ts
+++ b/apps/web/src/app/api/workflows/cars/route.ts
@@ -1,3 +1,4 @@
+import { WORKFLOW_REGION } from "@web/config/workflow";
 import { carsWorkflow } from "@web/workflows/cars";
 import { start } from "workflow/api";
 
@@ -7,12 +8,10 @@ export async function GET(request: Request) {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const run = await start(carsWorkflow, [{}]);
+  const run = await start(carsWorkflow, { region: WORKFLOW_REGION });
 
-  return new Response(run.getReadable(), {
-    headers: {
-      "Content-Type": "application/x-ndjson",
-      "X-Run-Id": run.runId,
-    },
-  });
+  return Response.json(
+    { message: "Workflow started", runId: run.runId },
+    { headers: { "X-Run-Id": run.runId } },
+  );
 }

--- a/apps/web/src/app/api/workflows/coe/route.ts
+++ b/apps/web/src/app/api/workflows/coe/route.ts
@@ -1,3 +1,4 @@
+import { WORKFLOW_REGION } from "@web/config/workflow";
 import { coeWorkflow } from "@web/workflows/coe";
 import { start } from "workflow/api";
 
@@ -7,12 +8,10 @@ export async function GET(request: Request) {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const run = await start(coeWorkflow, [{}]);
+  const run = await start(coeWorkflow, { region: WORKFLOW_REGION });
 
-  return new Response(run.getReadable(), {
-    headers: {
-      "Content-Type": "application/x-ndjson",
-      "X-Run-Id": run.runId,
-    },
-  });
+  return Response.json(
+    { message: "Workflow started", runId: run.runId },
+    { headers: { "X-Run-Id": run.runId } },
+  );
 }

--- a/apps/web/src/app/api/workflows/deregistrations/route.ts
+++ b/apps/web/src/app/api/workflows/deregistrations/route.ts
@@ -1,3 +1,4 @@
+import { WORKFLOW_REGION } from "@web/config/workflow";
 import { deregistrationsWorkflow } from "@web/workflows/deregistrations";
 import { start } from "workflow/api";
 
@@ -7,12 +8,10 @@ export async function GET(request: Request) {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const run = await start(deregistrationsWorkflow, [{}]);
+  const run = await start(deregistrationsWorkflow, { region: WORKFLOW_REGION });
 
-  return new Response(run.getReadable(), {
-    headers: {
-      "Content-Type": "application/x-ndjson",
-      "X-Run-Id": run.runId,
-    },
-  });
+  return Response.json(
+    { message: "Workflow started", runId: run.runId },
+    { headers: { "X-Run-Id": run.runId } },
+  );
 }

--- a/apps/web/src/app/api/workflows/electric-vehicles/route.ts
+++ b/apps/web/src/app/api/workflows/electric-vehicles/route.ts
@@ -1,3 +1,4 @@
+import { WORKFLOW_REGION } from "@web/config/workflow";
 import { electricVehiclesWorkflow } from "@web/workflows/electric-vehicles";
 import { start } from "workflow/api";
 
@@ -7,12 +8,12 @@ export async function GET(request: Request) {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const run = await start(electricVehiclesWorkflow, [{}]);
-
-  return new Response(run.getReadable(), {
-    headers: {
-      "Content-Type": "application/x-ndjson",
-      "X-Run-Id": run.runId,
-    },
+  const run = await start(electricVehiclesWorkflow, {
+    region: WORKFLOW_REGION,
   });
+
+  return Response.json(
+    { message: "Workflow started", runId: run.runId },
+    { headers: { "X-Run-Id": run.runId } },
+  );
 }

--- a/apps/web/src/app/api/workflows/vehicle-population/route.ts
+++ b/apps/web/src/app/api/workflows/vehicle-population/route.ts
@@ -1,3 +1,4 @@
+import { WORKFLOW_REGION } from "@web/config/workflow";
 import { vehiclePopulationWorkflow } from "@web/workflows/vehicle-population";
 import { start } from "workflow/api";
 
@@ -7,12 +8,12 @@ export async function GET(request: Request) {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  const run = await start(vehiclePopulationWorkflow, []);
-
-  return new Response(run.getReadable(), {
-    headers: {
-      "Content-Type": "application/x-ndjson",
-      "X-Run-Id": run.runId,
-    },
+  const run = await start(vehiclePopulationWorkflow, {
+    region: WORKFLOW_REGION,
   });
+
+  return Response.json(
+    { message: "Workflow started", runId: run.runId },
+    { headers: { "X-Run-Id": run.runId } },
+  );
 }

--- a/apps/web/src/config/workflow.ts
+++ b/apps/web/src/config/workflow.ts
@@ -5,3 +5,8 @@ export const CACHE_TTL = 24 * 60 * 60;
 export const WORKFLOW_TEMP_DIR = "/tmp";
 export const LTA_DATAMALL_BASE_URL =
   "https://datamall.lta.gov.sg/content/dam/datamall/datasets/Facts_Figures/Vehicle Registration";
+
+// Pins each workflow run's storage, queueing, and streams to Singapore. v5 already
+// defaults to the compute region, so this only guarantees the pin survives a future
+// change to `regions` in vercel.ts.
+export const WORKFLOW_REGION = "sin1";

--- a/apps/web/src/workflows/car-population/index.ts
+++ b/apps/web/src/workflows/car-population/index.ts
@@ -22,7 +22,7 @@ export async function carPopulationWorkflow(): Promise<{
     return { message: "No car population records processed." };
   }
 
-  const latestYear = await getLatestYear();
+  const latestYear = await getCarPopulationLatestYear();
   if (!latestYear) {
     return { message: "No car population data found." };
   }
@@ -49,7 +49,7 @@ async function processCarPopulationData(): Promise<UpdaterResult> {
   }
   return result;
 }
-async function getLatestYear(): Promise<string | null> {
+async function getCarPopulationLatestYear(): Promise<string | null> {
   "use step";
   const years = await getCarPopulationYears();
   return years[0]?.year ?? null;

--- a/apps/web/src/workflows/cars/index.ts
+++ b/apps/web/src/workflows/cars/index.ts
@@ -32,7 +32,7 @@ interface CarsWorkflowResult {
  * Processes car registration data and generates blog posts.
  */
 export async function carsWorkflow(
-  payload: CarsWorkflowPayload,
+  payload?: CarsWorkflowPayload,
 ): Promise<CarsWorkflowResult> {
   "use workflow";
 
@@ -57,7 +57,7 @@ export async function carsWorkflow(
   await syncMakesSortedSet();
   await emitEvent({ type: "step:complete", step: "syncMakesSortedSet" });
 
-  const month = payload.month ?? (await getLatestMonth());
+  const month = payload?.month ?? (await getCarsLatestRegistrationMonth());
   if (!month) {
     return { message: "[CARS] No car records found" };
   }
@@ -134,7 +134,7 @@ async function syncMakesSortedSet(): Promise<void> {
   await populateMakesSortedSet();
 }
 
-async function getLatestMonth(): Promise<string | null> {
+async function getCarsLatestRegistrationMonth(): Promise<string | null> {
   "use step";
   return getCarsLatestMonth();
 }

--- a/apps/web/src/workflows/coe/index.ts
+++ b/apps/web/src/workflows/coe/index.ts
@@ -28,7 +28,7 @@ interface CoeWorkflowResult {
  * Processes COE bidding data and generates blog posts.
  */
 export async function coeWorkflow(
-  payload: CoeWorkflowPayload,
+  payload?: CoeWorkflowPayload,
 ): Promise<CoeWorkflowResult> {
   "use workflow";
 
@@ -50,9 +50,9 @@ export async function coeWorkflow(
 
   let month: string;
 
-  if (payload.month) {
+  if (payload?.month) {
     // When month is explicitly provided, use it directly and skip biddingNo guard
-    month = payload.month;
+    month = payload?.month;
   } else {
     const record = await getLatestRecord();
     if (!record) {

--- a/apps/web/src/workflows/deregistrations/index.ts
+++ b/apps/web/src/workflows/deregistrations/index.ts
@@ -31,7 +31,7 @@ interface DeregistrationsWorkflowResult {
  * Processes vehicle deregistration data, generates blog posts, and revalidates cache.
  */
 export async function deregistrationsWorkflow(
-  payload: DeregistrationsWorkflowPayload,
+  payload?: DeregistrationsWorkflowPayload,
 ): Promise<DeregistrationsWorkflowResult> {
   "use workflow";
 
@@ -49,7 +49,7 @@ export async function deregistrationsWorkflow(
     return { message: "No deregistration records processed." };
   }
 
-  const latestMonth = payload.month ?? (await getLatestMonth());
+  const latestMonth = payload?.month ?? (await getLatestDeregistrationMonth());
   if (!latestMonth) {
     return { message: "No deregistration data found." };
   }
@@ -130,7 +130,7 @@ async function processDeregistrationsData(): Promise<UpdaterResult> {
 
   return result;
 }
-async function getLatestMonth(): Promise<string | null> {
+async function getLatestDeregistrationMonth(): Promise<string | null> {
   "use step";
 
   const { month } = await getDeregistrationsLatestMonth();

--- a/apps/web/src/workflows/electric-vehicles/index.ts
+++ b/apps/web/src/workflows/electric-vehicles/index.ts
@@ -24,13 +24,13 @@ interface ElectricVehiclesWorkflowResult {
  * Generates blog posts from EV registration data.
  */
 export async function electricVehiclesWorkflow(
-  payload: ElectricVehiclesWorkflowPayload,
+  payload?: ElectricVehiclesWorkflowPayload,
 ): Promise<ElectricVehiclesWorkflowResult> {
   "use workflow";
 
   globalThis.fetch = fetch;
 
-  const month = payload.month ?? (await getLatestMonth());
+  const month = payload?.month ?? (await getElectricVehiclesLatestMonth());
   if (!month) {
     return { message: "[EV] No car data found." };
   }
@@ -90,7 +90,7 @@ export async function electricVehiclesWorkflow(
   };
 }
 
-async function getLatestMonth(): Promise<string | null> {
+async function getElectricVehiclesLatestMonth(): Promise<string | null> {
   "use step";
   return getCarsLatestMonth();
 }

--- a/apps/web/src/workflows/vehicle-population/index.ts
+++ b/apps/web/src/workflows/vehicle-population/index.ts
@@ -22,7 +22,7 @@ export async function vehiclePopulationWorkflow(): Promise<{
     return { message: "No vehicle population records processed." };
   }
 
-  const latestYear = await getLatestYear();
+  const latestYear = await getVehiclePopulationLatestYear();
   if (!latestYear) {
     return { message: "No vehicle population data found." };
   }
@@ -52,7 +52,7 @@ async function processVehiclePopulationData(): Promise<UpdaterResult> {
   }
   return result;
 }
-async function getLatestYear(): Promise<string | null> {
+async function getVehiclePopulationLatestYear(): Promise<string | null> {
   "use step";
   const years = await getVehiclePopulationYears();
   return years[0]?.year ?? null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,22 +115,22 @@ importers:
         version: 21.0.1
       '@semantic-release/changelog':
         specifier: 6.0.3
-        version: 6.0.3(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
+        version: 6.0.3(semantic-release@25.0.3(typescript@7.0.2))
       '@semantic-release/commit-analyzer':
         specifier: 13.0.1
-        version: 13.0.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
+        version: 13.0.1(semantic-release@25.0.3(typescript@7.0.2))
       '@semantic-release/exec':
         specifier: 7.1.0
-        version: 7.1.0(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))(supports-color@8.1.1)
+        version: 7.1.0(semantic-release@25.0.3(typescript@7.0.2))
       '@semantic-release/git':
         specifier: 10.0.1
-        version: 10.0.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))(supports-color@8.1.1)
+        version: 10.0.1(semantic-release@25.0.3(typescript@7.0.2))
       '@semantic-release/github':
         specifier: 12.0.8
-        version: 12.0.8(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
+        version: 12.0.8(semantic-release@25.0.3(typescript@7.0.2))
       '@semantic-release/release-notes-generator':
         specifier: 14.1.1
-        version: 14.1.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
+        version: 14.1.1(semantic-release@25.0.3(typescript@7.0.2))
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -154,7 +154,7 @@ importers:
         version: 0.15.5
       semantic-release:
         specifier: 25.0.3
-        version: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
+        version: 25.0.3(typescript@7.0.2)
       turbo:
         specifier: 2.10.9
         version: 2.10.9
@@ -221,7 +221,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
-        version: 1.29.0(supports-color@8.1.1)(zod@4.4.3)
+        version: 1.29.0(zod@4.4.3)
       '@vercel/related-projects':
         specifier: 'catalog:'
         version: 1.1.0
@@ -246,7 +246,7 @@ importers:
         version: 1.7.0-rc.4(@better-auth/core@1.7.0-rc.4(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3))
       '@flags-sdk/vercel':
         specifier: 1.4.6
-        version: 1.4.6(@aws-sdk/credential-provider-web-identity@3.972.49)(flags@4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 1.4.6(@aws-sdk/credential-provider-web-identity@3.972.49)(flags@4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@gravity-ui/icons':
         specifier: 2.18.0
         version: 2.18.0(react@19.2.6)
@@ -303,7 +303,7 @@ importers:
         version: 1.38.0
       '@vercel/analytics':
         specifier: 1.6.1
-        version: 1.6.1(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.6.1(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@vercel/config':
         specifier: 0.0.30
         version: 0.0.30
@@ -315,7 +315,7 @@ importers:
         version: 1.1.0
       '@vercel/speed-insights':
         specifier: 1.3.1
-        version: 1.3.1(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.3.1(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       adm-zip:
         specifier: 0.6.0
         version: 0.6.0
@@ -324,10 +324,10 @@ importers:
         version: 7.0.58(zod@4.4.3)
       better-auth:
         specifier: 'catalog:'
-        version: 1.7.0-rc.4(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3))(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6)
+        version: 1.7.0-rc.4(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3))(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6)
       botid:
         specifier: 1.5.11
-        version: 1.5.11(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.5.11(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       date-fns:
         specifier: 'catalog:'
         version: 4.1.0
@@ -345,7 +345,7 @@ importers:
         version: 4.4.0
       flags:
         specifier: 4.3.0
-        version: 4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       framer-motion:
         specifier: 12.38.0
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -360,16 +360,16 @@ importers:
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: 'catalog:'
-        version: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl:
         specifier: 4.12.0
-        version: 4.12.0(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
+        version: 4.12.0(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       next-mdx-remote:
         specifier: 6.0.0
         version: 6.0.0(@types/react@19.2.14)(react@19.2.6)
       nuqs:
         specifier: 2.8.9
-        version: 2.8.9(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.8.9(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       papaparse:
         specifier: 5.5.3
         version: 5.5.3
@@ -422,8 +422,8 @@ importers:
         specifier: 1.29.0
         version: 1.29.0
       workflow:
-        specifier: 4.8.1
-        version: 4.8.1(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.2)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@7.0.2)
+        specifier: 5.0.0-beta.46
+        version: 5.0.0-beta.46(@aws-sdk/credential-provider-web-identity@3.972.49)(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.2)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2)(ws@8.20.0)
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -433,13 +433,13 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: 7.29.6
-        version: 7.29.6(supports-color@8.1.1)
+        version: 7.29.6
       '@babel/preset-env':
         specifier: 7.29.5
-        version: 7.29.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 7.29.5(@babel/core@7.29.6)
       '@babel/preset-typescript':
         specifier: 7.28.5
-        version: 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+        version: 7.28.5(@babel/core@7.29.6)
       '@next/playwright':
         specifier: 16.3.0
         version: 16.3.0(@playwright/test@1.60.0)
@@ -451,7 +451,7 @@ importers:
         version: 2.0.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@rolldown/plugin-babel':
         specifier: 0.2.3
-        version: 0.2.3(@babel/core@7.29.6(supports-color@8.1.1))(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.2.3(@babel/core@7.29.6)(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       '@tailwindcss/forms':
         specifier: 0.5.11
         version: 0.5.11(tailwindcss@4.3.0)
@@ -490,13 +490,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6(supports-color@8.1.1))(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6)(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.6(vitest@4.1.6)
       '@workflow/vitest':
-        specifier: 4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(supports-color@8.1.1)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))(vitest@4.1.6)
+        specifier: 5.0.0-beta.46
+        version: 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))(vitest@4.1.6)(ws@8.20.0)
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
@@ -2318,26 +2318,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@internationalized/date@3.12.1':
-    resolution: {integrity: sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==}
-
   '@internationalized/date@3.12.3':
     resolution: {integrity: sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==}
 
   '@internationalized/message@3.1.9':
     resolution: {integrity: sha512-x03MSVTaB/4JHtW1VAYaY/2cCuBrHbWM6ZvlgpKdnSdW28tZbqpR673RJrVJyXWRw1bpgYN89Tz7ohX5tgNgPA==}
 
-  '@internationalized/number@3.6.6':
-    resolution: {integrity: sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==}
-
   '@internationalized/number@3.6.7':
     resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
 
   '@internationalized/string@3.2.10':
     resolution: {integrity: sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==}
-
-  '@internationalized/string@3.2.8':
-    resolution: {integrity: sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -2645,10 +2636,6 @@ packages:
 
   '@oclif/core@4.11.4':
     resolution: {integrity: sha512-URwiQ5ALx/sJ2iH4vzXEd+H4K6NAI7LRs6Jag3hrgKEpGmaE6alfRC8qjO4GIgb6A3ACaJumqP9twi/M9ywdHQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@oclif/core@4.8.1':
-    resolution: {integrity: sha512-07mq0vKCWNsB85ZHeBMlTAiO0KLFqHyAeRK3bD2K8CI1tX3tiwkWw1lZQZkiw8MUBrhxdROhMkYMY4Q0l7JHqA==}
     engines: {node: '>=18.0.0'}
 
   '@oclif/plugin-help@6.2.37':
@@ -3852,6 +3839,10 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
+  '@sveltejs/load-config@0.2.3':
+    resolution: {integrity: sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ==}
+    engines: {node: '>= 18.0.0'}
+
   '@swc/cli@0.8.1':
     resolution: {integrity: sha512-L+ACCGHCiS0VqHVep/INLVnvRvJ2XooQFLZq4L8snhxw1jsqz+XRcY313UsyPVturPPE1shW3jic7rt3qEQTSQ==}
     engines: {node: '>= 20.19.0'}
@@ -4405,6 +4396,13 @@ packages:
   '@vercel/cli-auth@0.0.1':
     resolution: {integrity: sha512-CnqiuMlZ4pjs2LCPYiR6aLKPPd3Xb8SBI1Y7eotXKgpx6qgrGNY+E7EIyUt5ErGHJGIrCZyGG5WEo4bHtVmz2Q==}
 
+  '@vercel/cli-config@0.2.4':
+    resolution: {integrity: sha512-kZ5SojbrV06GHoU6QIWGwDXLov+s9rWZ7QqdqKfJfBGCNUieGfgaCjeeenNy8Y+QC0bwC0dZ2B4l5Hvdmrgpdw==}
+
+  '@vercel/cli-exec@1.0.1':
+    resolution: {integrity: sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==}
+    engines: {node: '>= 18'}
+
   '@vercel/config@0.0.30':
     resolution: {integrity: sha512-XJcWJKkJzu9MRmm1s08QnlPEKJ+TjWVPzqsV9i72Bnn+EqnEsT6vt26IbiufbMEEbsT6kVzm2XZvtp3ocwyZrQ==}
     hasBin: true
@@ -4429,6 +4427,18 @@ packages:
       '@aws-sdk/credential-provider-web-identity':
         optional: true
 
+  '@vercel/functions@3.9.5':
+    resolution: {integrity: sha512-EUfqlb7AzoEh7URlMNAO4jbJiLWz9grDBHvfjKTDvEP9c8y3DqX3SWPvfaQkUjtkm3b83flhaUUMuewdHa+qmw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+      ws: '>=8'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+      ws:
+        optional: true
+
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
@@ -4441,9 +4451,18 @@ packages:
     resolution: {integrity: sha512-jo7GgeJx2YMkjg9A28pFM5p88n5SnSHvDeNlf9898bRWiG9jPxwedj/gn/2XTw4UOTyQ50uHlrTGSlf/XU5tgw==}
     engines: {node: '>= 20'}
 
-  '@vercel/queue@0.3.1':
-    resolution: {integrity: sha512-6pjdXyNfdCQnj1nyeB1rPtll/XUhmciyeZJD0rpIUUwmcIfR+utDl6+iFvlHvsBdqAVT8UC6ydObT0v+xldfUQ==}
+  '@vercel/oidc@3.8.5':
+    resolution: {integrity: sha512-RwXYtnt6za+5UO4IaLywN/6B95AlLqynPRUWRJxeJ/qufwkcLUbZNUxYtzT0uMpuraWhlNcGqPNGkTnZr4BGBw==}
+    engines: {node: '>= 20'}
+
+  '@vercel/queue@0.5.0':
+    resolution: {integrity: sha512-TqvoMuhZK9Hw2yal6ee6EZ+wQw55+qPrpev6O6jJrpJMC1myrCrt7bLZvb9GQDIR35h40EiETVaMZT4eFWBVpA==}
     engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@vercel/related-projects@1.1.0':
     resolution: {integrity: sha512-4YjXj8rL9UVX444vaKuSmXgZD0ABOEgQNd6BR75vACaeAcuwU8powNyKDoAM9JIPfVhx7/zHCum5z+7lx2Mp9g==}
@@ -4527,29 +4546,29 @@ packages:
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
-  '@workflow/astro@4.0.16':
-    resolution: {integrity: sha512-nXYpCoaCu9Xrom8wV69hWLrRp220JdZiJ72jgCzZMo8lv4yl6Ql9eLHzOKh7L/JhfLPDyHqInnfbnrN2WFdHzw==}
+  '@workflow/astro@5.0.0-beta.46':
+    resolution: {integrity: sha512-gDjsYb6tFmNlHFHxfKHI+3sOutWZVn8V/P602akXUxAi3BwPKvGrRTvKaaQh6nb0Z+yJUFr0Au1yT+9ixuJ92g==}
 
-  '@workflow/builders@4.1.6':
-    resolution: {integrity: sha512-cho5QsiclvE868dbjCodtpEsxovnub5K7/P5BX3PvWYz9an1sx3hZ9VZo7P3ZvLmeRTdWSi/qW11Hgxmyd34Dg==}
+  '@workflow/builders@5.0.0-beta.46':
+    resolution: {integrity: sha512-JfR4insHWteCbQDfkpiGKDrquup9Tj2KgqRdWZkTeNez8CbHZzZqGeh6eUXZq5fcIir+iypK2OWbRmp22PYn/g==}
 
-  '@workflow/cli@4.3.5':
-    resolution: {integrity: sha512-pe2FXcx62u7DlFIP1K51JXiCTSjo08FZCXayz9GSTj2/5G7D5IxF6bxUnTBG0rMmXDSvP/VJ2laA21IvUQIWGw==}
+  '@workflow/cli@5.0.0-beta.46':
+    resolution: {integrity: sha512-1QtMLG+EemBOwcuuMhW9vRqjhUJ2hE+LJW5jEt/I2xj4FS/sA4x/3PjdBwl0saFiHKzi+NQ9iQWAZdrfto9VuA==}
     hasBin: true
 
-  '@workflow/core@4.8.1':
-    resolution: {integrity: sha512-w/vJps6UyKzqXJyTs930iq+YTQdjw9U4l9UykCTPaS9zbACESiDKPniNZyVrIlixYgqevrOrjo9eLpUqd6CZAw==}
+  '@workflow/core@5.0.0-beta.46':
+    resolution: {integrity: sha512-MIp2OxOaqkY+z/4/bxhEqaqZXZmk690VPyyDvVBmAWka1e2rG0PMd+REEPqArmBVc80v52e8cZbiYBOqJ3IgHQ==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
 
-  '@workflow/errors@4.2.1':
-    resolution: {integrity: sha512-gIe3vf2POUw2DV4Mi6BGiYGQdUZ4YMcWhDahVT9xI1W1NSsqifX73Hvk/68x/haPnDOr7/VnWN8/YAgeEVYE4A==}
+  '@workflow/errors@5.0.0-beta.18':
+    resolution: {integrity: sha512-Q2J0dz/yJJv6JNH7hyyqQ6ERc/Xpup7HNelFL+cNE0zU5We1c6GgV37bAoc2qsmyJO8Is5wSo4phlkorEQNfTA==}
 
-  '@workflow/nest@4.0.17':
-    resolution: {integrity: sha512-y9wGsnMXbKGanyrBqq5+fBJNS5l57n4+rJ1zo/zB/jp1h53Z3DYu4QFNstSvFx+ygfdWQrWnm3y/U9fWOpqraQ==}
+  '@workflow/nest@5.0.0-beta.46':
+    resolution: {integrity: sha512-yD7VUncDmGuOGXAFd1ybwAKT94+lCo3bo6LS6afIH8bMA571iXvNxhHQxEgvi6/Z3IGwZB7vS7P5PGk2owibxQ==}
     hasBin: true
     peerDependencies:
       '@nestjs/common': '>=10.0.0'
@@ -4557,50 +4576,53 @@ packages:
       '@swc/cli': '>=0.4.0'
       '@swc/core': '>=1.5.0'
 
-  '@workflow/next@4.1.5':
-    resolution: {integrity: sha512-siOO1M5fCL/klSOvesYQghjBbN+e4I0dfknglT4W+sknoaHHNNAaTWz1w/7YUcjMSw46Z+0N/GXyGo+lgJ826g==}
+  '@workflow/next@5.0.0-beta.46':
+    resolution: {integrity: sha512-/jQxg/zwDIe7A3KaHjSN8Ca/zUMezq9j5eym4Vif1H+AGxNuAk8i3lc4C7zuhiBJi3GYxzj07jfwL+DPQe7VOg==}
     peerDependencies:
       next: '>13'
     peerDependenciesMeta:
       next:
         optional: true
 
-  '@workflow/nitro@4.1.7':
-    resolution: {integrity: sha512-+5IJrQy8uoQMGblj/LxHKgjW2x2hAv345Mwunrq2ElnCXL9vBqqNntN7khGIBe1cHwMuckOcw3mYBjJfvFysqA==}
+  '@workflow/nitro@5.0.0-beta.46':
+    resolution: {integrity: sha512-s/JlH4KvUMGWt0Km4vJ2jKp/mI1+iVuB9ZsGLYPn1Y47r0CSX77pyo9x0fBLyRAYcREDoiqVBSs0tn+WQhXoXw==}
 
-  '@workflow/nuxt@4.0.17':
-    resolution: {integrity: sha512-psi9xeUzEZxtrY1Ggv7QSAzHtdUIscKsSfSFLv8DoJviUdhcn4nIDplrJE5KzN8VcCpvBkegN+0wUwMJFN3CiQ==}
+  '@workflow/nuxt@5.0.0-beta.46':
+    resolution: {integrity: sha512-3IZxD7oqnM19JTc2XdaFYZwXkvqjHA/mQXulYTRQLs7xIK39k+c+Ms/2D1Q3SW1r8hz/kc6wOA5SasUcgPar4Q==}
 
-  '@workflow/rollup@4.0.16':
-    resolution: {integrity: sha512-iBnRnkkaIXySBH4oz2NrNJTVQwsFqmnZk/ElYav59hGHlMRGv/mN8lIX0yk9qB8ITcVJC4DCVIYAJ+JereY8Ww==}
+  '@workflow/rollup@5.0.0-beta.46':
+    resolution: {integrity: sha512-6Fe/5B3OrROp9qyPtz1gN+fErqSl2SOELVdquALFL/KouFmb8EW3kz2HKTY9j66HOD7CXFSmhQNa41L1ln+5Uw==}
 
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
-  '@workflow/serde@4.1.2':
-    resolution: {integrity: sha512-KkkSUddEcaIvW7/QfVUk2PR93117HkDum45cXQEGkoxEmHOmqfOLJ4T1m4a1QABVC7O9TIqPxsBtDPgKIO+LOw==}
+  '@workflow/serde@5.0.0-beta.2':
+    resolution: {integrity: sha512-INB+FcEKQkkFZa+s53sEMTNRFiBa2g9vzjsNuEDagvWxtI0t/cnCyoc57i7kS7nj+3/vGeRjO4Yn5ccbT0hyBQ==}
 
-  '@workflow/sveltekit@4.0.16':
-    resolution: {integrity: sha512-BY7lB4pch1WAMa8dwcEmQlnNaB5fpOLyCfg7u4cfVMV300UFCsXbrlkfInmy7nE4jmbNQFzD2qwPGA3LZzypjg==}
+  '@workflow/sveltekit@5.0.0-beta.46':
+    resolution: {integrity: sha512-kNZob4mAtjJhEgF+VVAY0bjjh79Irl7lgjkRjmoifYK0ZRjf3mWYkpd1eGF0fxVzEbLQLslEwoqE5u2I0zBNDg==}
 
-  '@workflow/swc-plugin@4.1.2':
-    resolution: {integrity: sha512-oSd+fSXtcrHMJ82OwEqyfhYpqr1EsSQY5IEpntkKSlzzkdTFV4hcAj0vlafgIfI3WfhqxrXUoHfp/S1XE49jcA==}
+  '@workflow/swc-plugin@5.0.0-beta.5':
+    resolution: {integrity: sha512-Xk2UQePkuxTrgqU0EWZPRWM9Ttj9bcMAY+x700yg/0TQnD3MSxjY6/yC3e8wGr2dfzXik5zuH+Ixrog1CdBqeg==}
     peerDependencies:
       '@swc/core': 1.15.3
 
-  '@workflow/typescript-plugin@4.0.3':
-    resolution: {integrity: sha512-QJ7hmPHrrudgSsOFMML6AbHQpOzAThcQL9AKS06QWX96ZGba+bfsjq/czlyAVXtoluBfN4fw0pSfz/itUB7XVQ==}
+  '@workflow/typescript-plugin@5.0.0-beta.5':
+    resolution: {integrity: sha512-IcP+tMktxXT02H60+Or+0rSKcydhg3CMM5CWTzpnnXlhW3rqBniA/FheWYvtR7HTM7x+Xht1W1eFm8PsaGQpxg==}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@workflow/utils@4.1.4':
-    resolution: {integrity: sha512-2zGTa0vCJJczErE8oI7JPKpGmXNbhgnGW7JWcz3qTTs5TKibtaAxha5DLq3WTTbwsgvuuxcnvtWqQ5hFxhWATg==}
+  '@workflow/utils@5.0.0-beta.9':
+    resolution: {integrity: sha512-EvwbO41RiiuFZlGuAt4f10BkrhfNmz7YKgqUm2VmL6Ib5WFcfIpoaLStCML91LeGgMyO5bwsf1m7Zm8IPprSdQ==}
 
-  '@workflow/vite@4.0.16':
-    resolution: {integrity: sha512-conV22HD0YAR+B91nUyt8+uD99LbbcRGLjjusoPoCt+v5oypJYDFgJPV2qNXD3zSMpTemR6vXZJl/gbpUA6MIQ==}
+  '@workflow/vite@5.0.0-beta.46':
+    resolution: {integrity: sha512-m++6Xd0qECTYUE/hkV8oN+WkJ8KQTlO8naajcCs2DAQyZF5eMUuT1agj3NSKNjoAZUXkwpqSm3LT2Kq9x56ibQ==}
 
-  '@workflow/vitest@4.0.17':
-    resolution: {integrity: sha512-sgAoAWYPgrPYlhGBfrH1qv2/UaVAfxTQf00VUMnBzKDBWp+L2ZD0eKqKn4BS8ETW+4nuMhLTcg8WCCQcKhnxfg==}
+  '@workflow/vitest@5.0.0-beta.46':
+    resolution: {integrity: sha512-IsZbZPZ56O0mqPjhaKZBLqpwrhZlp2w90ZhDMIPx19+xocDrmkq3BiPeTrugkGDaJiZNleuIfoSB4pFw8r0OZw==}
     peerDependencies:
       vite: '>=6.0.0'
       vitest: '>=3.1.0'
@@ -4608,27 +4630,27 @@ packages:
       vite:
         optional: true
 
-  '@workflow/web@4.1.17':
-    resolution: {integrity: sha512-6wn8SUqqTmTmaoG8+KqN0vWYHAITbnmptv5Cw7p7Ca1kPKtFqmQdeVrCKbmMekexkM/LA8tmOYD+oYDT4U6VKg==}
+  '@workflow/web@5.0.0-beta.46':
+    resolution: {integrity: sha512-AZcHC6MQ8eYKFTO/Zu8jvgZ7ycrf7VC/G/uHIBrSGHaGcIBEpYO87MFl0vbImMnG7jpmAminuG58Pi4eZNjggA==}
 
-  '@workflow/world-local@4.2.4':
-    resolution: {integrity: sha512-MCsoTTNyPp6cTV8z3wqniTaJUdwlcggMjKRMadU4jHjX5UOhEFrUE9EeOBnJY2eFUyEGW//Z/WpRFm2b982lcg==}
+  '@workflow/world-local@5.0.0-beta.40':
+    resolution: {integrity: sha512-6nquVqHyjbIHJI6+GzjRKa5DsNIILNhpLGoou7ZaQr07iLaX0dQ/c4cfjCqiVDi5cGskMg6Rwm8ILeGLP1AM7g==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
 
-  '@workflow/world-vercel@4.6.2':
-    resolution: {integrity: sha512-wkhYRgR8SOyYHNFt6Ns4MN9pWQFugDpV0GFIMcbzD9lkPx5rh7qgUWJNnHdNKVmmS4p25uWDBcLu8h6t42Yp3g==}
+  '@workflow/world-vercel@5.0.0-beta.42':
+    resolution: {integrity: sha512-irTlWijQ9QrC43Gqc7p9HBeYl1NZB+3jICZ4Ki1AoOq/0YeJu4FtTEmWoI9nRtIwZG2ui50wW2+KESbiB0RVeg==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
 
-  '@workflow/world@4.3.1':
-    resolution: {integrity: sha512-gT67yCzMsm6SS5+2ho+b6dSd8qknTlDkfHvKnuWWt9fwkvpRr0WLWFOPvzILj3IY/mptDj3pFNDS9a6RWxEqQQ==}
+  '@workflow/world@5.0.0-beta.31':
+    resolution: {integrity: sha512-+aYkb841BpJmZ9I4Ivx7924xzb+yau+u5JcpXIs4eTOwFZaAuJpEEdAdtM/+7r6ku0wS/MLUQaWm2O16ZyU46w==}
 
   '@xhmikosr/archive-type@8.1.0':
     resolution: {integrity: sha512-EXOjEbnZFE5c/nFMf4FOrEURVanzHpnkPYmnmr78u02/8hAhE0FMq8p9TK1IM0/bFr5VcyBUY0gfLm8f7dKy+Q==}
@@ -5494,8 +5516,8 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
-  devalue@5.8.1:
-    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
+  devalue@5.9.0:
+    resolution: {integrity: sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -6264,9 +6286,6 @@ packages:
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
-
-  glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -7959,6 +7978,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -7991,6 +8013,9 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  quickjs-wasi@3.4.0:
+    resolution: {integrity: sha512-ttKaBD8u0RXhz2UqDU8wOEruhxADt0WWHfMfnNR8aO0UyhlifFS6NvPYFbyhASjqIp2/1dpneoP1IzBUxION1w==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -8288,6 +8313,10 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -8687,6 +8716,11 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  swr@2.5.1:
+    resolution: {integrity: sha512-BRw55e8r0B7SpDN20CAzoQAHl7y1yP7/Zt7oqUjMv0vSt2u2Xnkm88Ws+VypbV9BXHQVuSuyVq7zMjO16wSExw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -9194,10 +9228,6 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  watchpack@2.5.1:
-    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
-    engines: {node: '>=10.13.0'}
-
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -9251,8 +9281,8 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
-  workflow@4.8.1:
-    resolution: {integrity: sha512-iBNbykkuK3+qXlP+Kgac7MS4OhGl3SRyZRBYs9TkXPmf8WisUd4DPDn5+0NivgFPgETZS4LZY7U9in5YR9Bh5A==}
+  workflow@5.0.0-beta.46:
+    resolution: {integrity: sha512-RwRn7RfQMIwb4PRtaLDfBu2bzp/1kUeVaLlEXNzRQ5xA44Nj5c6dsPtU2SwyitdK+nW9g/HCFcdBO6mJ/aJQGg==}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': '1'
@@ -9432,7 +9462,7 @@ snapshots:
 
   '@adobe/react-spectrum@3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@internationalized/date': 3.12.1
+      '@internationalized/date': 3.12.3
       '@react-types/shared': 3.36.1(react@19.2.6)
       '@spectrum-icons/ui': 3.7.0(@adobe/react-spectrum@3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@spectrum-icons/workflow': 4.3.0(@adobe/react-spectrum@3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -9557,16 +9587,16 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.6(supports-color@8.1.1)':
+  '@babel/core@7.29.6':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -9605,29 +9635,29 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.6)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -9642,31 +9672,31 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9676,27 +9706,27 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.6
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -9714,7 +9744,7 @@ snapshots:
   '@babel/helper-wrap-function@7.28.6':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -9728,515 +9758,515 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.6)':
+    dependencies:
+      '@babel/core': 7.29.6
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.6)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.29.7
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
-    dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.6)':
+    dependencies:
+      '@babel/core': 7.29.6
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/core': 7.29.6
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/preset-env@7.29.5(@babel/core@7.29.6)':
     dependencies:
       '@babel/compat-data': 7.29.3
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.6(supports-color@8.1.1))
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
-      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.6(supports-color@8.1.1))
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.6)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.6)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.6)
+      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.6)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.6)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.6)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.6)
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.6)
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.6)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.6)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.6)
+      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.6)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.6)
       core-js-compat: 3.49.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.7
       esutils: 2.0.3
 
-  '@babel/preset-typescript@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.6)':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -10248,7 +10278,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7(supports-color@8.1.1)':
+  '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -10804,10 +10834,10 @@ snapshots:
       lodash.isundefined: 3.0.1
       lodash.uniq: 4.5.0
 
-  '@flags-sdk/vercel@1.4.6(@aws-sdk/credential-provider-web-identity@3.972.49)(flags@4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@flags-sdk/vercel@1.4.6(@aws-sdk/credential-provider-web-identity@3.972.49)(flags@4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
-      '@vercel/flags-core': 1.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      flags: 4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@vercel/flags-core': 1.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      flags: 4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
       - '@openfeature/server-sdk'
@@ -11038,10 +11068,6 @@ snapshots:
   '@img/sharp-win32-x64@0.35.3':
     optional: true
 
-  '@internationalized/date@3.12.1':
-    dependencies:
-      '@swc/helpers': 0.5.23
-
   '@internationalized/date@3.12.3':
     dependencies:
       '@swc/helpers': 0.5.23
@@ -11051,19 +11077,11 @@ snapshots:
       '@swc/helpers': 0.5.23
       intl-messageformat: 10.7.18
 
-  '@internationalized/number@3.6.6':
-    dependencies:
-      '@swc/helpers': 0.5.23
-
   '@internationalized/number@3.6.7':
     dependencies:
       '@swc/helpers': 0.5.23
 
   '@internationalized/string@3.2.10':
-    dependencies:
-      '@swc/helpers': 0.5.23
-
-  '@internationalized/string@3.2.8':
     dependencies:
       '@swc/helpers': 0.5.23
 
@@ -11146,7 +11164,7 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.6
 
-  '@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
       ajv: 8.20.0
@@ -11156,8 +11174,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.8
-      express: 5.2.1(supports-color@8.1.1)
-      express-rate-limit: 8.5.1(express@5.2.1(supports-color@8.1.1))
+      express: 5.2.1
+      express-rate-limit: 8.5.1(express@5.2.1)
       hono: 4.12.18
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -11364,30 +11382,9 @@ snapshots:
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
 
-  '@oclif/core@4.8.1':
-    dependencies:
-      ansi-escapes: 4.3.2
-      ansis: 3.17.0
-      clean-stack: 3.0.1
-      cli-spinners: 2.9.2
-      debug: 4.4.3(supports-color@8.1.1)
-      ejs: 3.1.10
-      get-package-type: 0.1.0
-      indent-string: 4.0.0
-      is-wsl: 2.2.0
-      lilconfig: 3.1.3
-      minimatch: 10.2.5
-      semver: 7.8.5
-      string-width: 4.2.3
-      supports-color: 8.1.1
-      tinyglobby: 0.2.17
-      widest-line: 3.1.0
-      wordwrap: 1.0.0
-      wrap-ansi: 7.0.0
-
   '@oclif/plugin-help@6.2.37':
     dependencies:
-      '@oclif/core': 4.8.1
+      '@oclif/core': 4.11.4
 
   '@octokit/auth-token@6.0.0': {}
 
@@ -12101,9 +12098,9 @@ snapshots:
 
   '@react-aria/i18n@3.13.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@internationalized/date': 3.12.1
+      '@internationalized/date': 3.12.3
       '@internationalized/message': 3.1.9
-      '@internationalized/string': 3.2.8
+      '@internationalized/string': 3.2.10
       '@swc/helpers': 0.5.23
       react: 19.2.6
       react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -12283,9 +12280,9 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6(supports-color@8.1.1))(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6)(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
       picomatch: 4.0.4
       rolldown: 1.0.0
     optionalDependencies:
@@ -12309,15 +12306,15 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
-  '@semantic-release/changelog@6.0.3(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))':
+  '@semantic-release/changelog@6.0.3(semantic-release@25.0.3(typescript@7.0.2))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
       fs-extra: 11.3.5
       lodash: 4.18.1
-      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
+      semantic-release: 25.0.3(typescript@7.0.2)
 
-  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))':
+  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.3(typescript@7.0.2))':
     dependencies:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-writer: 8.4.0
@@ -12327,7 +12324,7 @@ snapshots:
       import-from-esm: 2.0.0
       lodash-es: 4.18.1
       micromatch: 4.0.8
-      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
+      semantic-release: 25.0.3(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12335,7 +12332,7 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/exec@7.1.0(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))(supports-color@8.1.1)':
+  '@semantic-release/exec@7.1.0(semantic-release@25.0.3(typescript@7.0.2))':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 3.1.0
@@ -12343,11 +12340,11 @@ snapshots:
       execa: 9.6.1
       lodash-es: 4.18.1
       parse-json: 8.3.0
-      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
+      semantic-release: 25.0.3(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/git@10.0.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))(supports-color@8.1.1)':
+  '@semantic-release/git@10.0.1(semantic-release@25.0.3(typescript@7.0.2))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -12357,11 +12354,11 @@ snapshots:
       lodash: 4.18.1
       micromatch: 4.0.8
       p-reduce: 2.1.0
-      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
+      semantic-release: 25.0.3(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@12.0.8(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))':
+  '@semantic-release/github@12.0.8(semantic-release@25.0.3(typescript@7.0.2))':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
@@ -12377,14 +12374,14 @@ snapshots:
       lodash-es: 4.18.1
       mime: 4.1.0
       p-filter: 4.1.0
-      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
+      semantic-release: 25.0.3(typescript@7.0.2)
       tinyglobby: 0.2.16
       undici: 7.29.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/npm@13.1.5(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))':
+  '@semantic-release/npm@13.1.5(semantic-release@25.0.3(typescript@7.0.2))':
     dependencies:
       '@actions/core': 3.0.1
       '@semantic-release/error': 4.0.0
@@ -12399,11 +12396,11 @@ snapshots:
       rc: 1.2.8
       read-pkg: 10.1.0
       registry-auth-token: 5.1.1
-      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
+      semantic-release: 25.0.3(typescript@7.0.2)
       semver: 7.8.0
       tempy: 3.2.0
 
-  '@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))':
+  '@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.3(typescript@7.0.2))':
     dependencies:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-writer: 8.4.0
@@ -12413,7 +12410,7 @@ snapshots:
       import-from-esm: 2.0.0
       lodash-es: 4.18.1
       read-package-up: 11.0.0
-      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
+      semantic-release: 25.0.3(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12525,6 +12522,8 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@sveltejs/load-config@0.2.3': {}
 
   '@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0)':
     dependencies:
@@ -12935,9 +12934,9 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@1.6.1(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@1.6.1(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@vercel/blob@2.3.3':
@@ -12955,19 +12954,28 @@ snapshots:
       xdg-app-paths: 5.1.0
       zod: 4.1.11
 
+  '@vercel/cli-config@0.2.4':
+    dependencies:
+      xdg-app-paths: 5.1.0
+      zod: 4.1.11
+
+  '@vercel/cli-exec@1.0.1':
+    dependencies:
+      execa: 5.1.1
+
   '@vercel/config@0.0.30':
     dependencies:
       pretty-cache-header: 1.0.0
       zod: 3.25.76
 
-  '@vercel/flags-core@1.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@vercel/flags-core@1.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@vercel/functions': 3.5.1(@aws-sdk/credential-provider-web-identity@3.972.49)
       '@vercel/oidc': 3.5.0
       jose: 5.2.1
       js-xxhash: 4.0.0
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
 
@@ -12977,34 +12985,49 @@ snapshots:
     optionalDependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
 
+  '@vercel/functions@3.9.5(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.20.0)':
+    dependencies:
+      '@vercel/oidc': 3.8.5
+    optionalDependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.49
+      ws: 8.20.0
+
   '@vercel/oidc@3.2.0': {}
 
   '@vercel/oidc@3.4.1': {}
 
   '@vercel/oidc@3.5.0': {}
 
-  '@vercel/queue@0.3.1':
+  '@vercel/oidc@3.8.5':
     dependencies:
-      '@vercel/oidc': 3.4.1
+      '@vercel/cli-config': 0.2.4
+      '@vercel/cli-exec': 1.0.1
+      jose: 5.10.0
+
+  '@vercel/queue@0.5.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@vercel/oidc': 3.5.0
       minimatch: 10.2.5
       mixpart: 0.0.6
       picocolors: 1.1.1
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
 
   '@vercel/related-projects@1.1.0':
     optionalDependencies:
       ajv: 6.15.0
 
-  '@vercel/speed-insights@1.3.1(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/speed-insights@1.3.1(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
-  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6(supports-color@8.1.1))(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6)(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.6(supports-color@8.1.1))(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.6)(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler: 1.0.0
 
   '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
@@ -13073,27 +13096,30 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@workflow/astro@4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)':
+  '@workflow/astro@5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/rollup': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
-      '@workflow/vite': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
+      '@workflow/builders': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/rollup': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.23))
+      '@workflow/vite': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - bufferutil
       - supports-color
+      - utf-8-validate
+      - ws
 
-  '@workflow/builders@4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)':
+  '@workflow/builders@5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
-      '@workflow/errors': 4.2.1
-      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
-      '@workflow/utils': 4.1.4
+      '@workflow/core': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(ws@8.20.0)
+      '@workflow/errors': 5.0.0-beta.18
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.23))
+      '@workflow/utils': 5.0.0-beta.9
       builtin-modules: 5.0.0
       chalk: 5.6.2
       enhanced-resolve: 5.19.0
@@ -13104,23 +13130,26 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - bufferutil
       - supports-color
+      - utf-8-validate
+      - ws
 
-  '@workflow/cli@4.3.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)':
+  '@workflow/cli@5.0.0-beta.46(@aws-sdk/credential-provider-web-identity@3.972.49)(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(react@19.2.6)(ws@8.20.0)':
     dependencies:
       '@oclif/core': 4.11.4
       '@oclif/plugin-help': 6.2.37
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
       '@vercel/cli-auth': 0.0.1
-      '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
-      '@workflow/errors': 4.2.1
-      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
-      '@workflow/utils': 4.1.4
-      '@workflow/web': 4.1.17
-      '@workflow/world': 4.3.1
-      '@workflow/world-local': 4.2.4(@opentelemetry/api@1.9.1)
-      '@workflow/world-vercel': 4.6.2(@opentelemetry/api@1.9.1)
+      '@workflow/builders': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/core': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(ws@8.20.0)
+      '@workflow/errors': 5.0.0-beta.18
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.23))
+      '@workflow/utils': 5.0.0-beta.9
+      '@workflow/web': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(react@19.2.6)
+      '@workflow/world': 5.0.0-beta.31
+      '@workflow/world-local': 5.0.0-beta.40(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.49)(@opentelemetry/api@1.9.1)
       boxen: 8.0.1
       builtin-modules: 5.0.0
       chalk: 5.6.2
@@ -13139,27 +13168,33 @@ snapshots:
       xdg-app-paths: 5.1.0
       zod: 4.3.6
     transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-web-identity'
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - bufferutil
+      - react
       - supports-color
+      - utf-8-validate
+      - ws
 
-  '@workflow/core@4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
+  '@workflow/core@5.0.0-beta.46(@opentelemetry/api@1.9.1)(ws@8.20.0)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       '@jridgewell/trace-mapping': 0.3.31
       '@standard-schema/spec': 1.0.0
       '@types/ms': 2.1.0
-      '@vercel/functions': 3.5.1(@aws-sdk/credential-provider-web-identity@3.972.49)
-      '@workflow/errors': 4.2.1
-      '@workflow/serde': 4.1.2
-      '@workflow/utils': 4.1.4
-      '@workflow/world': 4.3.1
-      '@workflow/world-local': 4.2.4(@opentelemetry/api@1.9.1)
-      '@workflow/world-vercel': 4.6.2(@opentelemetry/api@1.9.1)
+      '@vercel/functions': 3.9.5(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.20.0)
+      '@workflow/errors': 5.0.0-beta.18
+      '@workflow/serde': 5.0.0-beta.2
+      '@workflow/utils': 5.0.0-beta.9
+      '@workflow/world': 5.0.0-beta.31
+      '@workflow/world-local': 5.0.0-beta.40(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.49)(@opentelemetry/api@1.9.1)
       debug: 4.4.3(supports-color@8.1.1)
-      devalue: 5.8.1
+      devalue: 5.9.0
       ms: 2.1.3
       nanoid: 5.1.6
+      quickjs-wasi: 3.4.0
       seedrandom: 3.0.5
       semver: 7.7.4
       ulid: 3.0.2
@@ -13167,165 +13202,211 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
+      - ws
 
-  '@workflow/errors@4.2.1':
+  '@workflow/errors@5.0.0-beta.18':
     dependencies:
-      '@workflow/utils': 4.1.4
+      '@workflow/utils': 5.0.0-beta.9
       ms: 2.1.3
 
-  '@workflow/nest@4.0.17(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)':
+  '@workflow/nest@5.0.0-beta.46(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(ws@8.20.0)':
     dependencies:
       '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@swc/cli': 0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0)
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
+      '@workflow/builders': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.23))
+      '@workflow/utils': 5.0.0-beta.9
+      esbuild: 0.28.1
       pathe: 2.0.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - bufferutil
       - supports-color
+      - utf-8-validate
+      - ws
 
-  '@workflow/next@4.1.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@workflow/next@5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(ws@8.20.0)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
-      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
+      '@workflow/builders': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/core': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(ws@8.20.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.23))
+      chokidar: 4.0.3
+      ignore: 7.0.5
       semver: 7.7.4
-      watchpack: 2.5.1
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - bufferutil
       - supports-color
+      - utf-8-validate
+      - ws
 
-  '@workflow/nitro@4.1.7(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)':
+  '@workflow/nitro@5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(react@19.2.6)(ws@8.20.0)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
-      '@workflow/rollup': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
-      '@workflow/vite': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/web': 4.1.17
+      '@workflow/builders': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/core': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(ws@8.20.0)
+      '@workflow/rollup': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.23))
+      '@workflow/vite': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/web': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(react@19.2.6)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - bufferutil
+      - react
       - supports-color
+      - utf-8-validate
+      - ws
 
-  '@workflow/nuxt@4.0.17(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(magicast@0.5.2)':
+  '@workflow/nuxt@5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(magicast@0.5.2)(react@19.2.6)(ws@8.20.0)':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.2)
-      '@workflow/nitro': 4.1.7(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
+      '@workflow/nitro': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(react@19.2.6)(ws@8.20.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - bufferutil
       - magicast
+      - react
       - supports-color
+      - utf-8-validate
+      - ws
 
-  '@workflow/rollup@4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)':
+  '@workflow/rollup@5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
+      '@workflow/builders': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.23))
       exsolve: 1.0.7
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - bufferutil
       - supports-color
+      - utf-8-validate
+      - ws
 
   '@workflow/serde@4.1.0': {}
 
-  '@workflow/serde@4.1.2': {}
+  '@workflow/serde@5.0.0-beta.2': {}
 
-  '@workflow/sveltekit@4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)':
+  '@workflow/sveltekit@5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)':
     dependencies:
+      '@sveltejs/load-config': 0.2.3
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/rollup': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
-      '@workflow/vite': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
+      '@workflow/builders': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/rollup': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.23))
+      '@workflow/vite': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
       exsolve: 1.0.8
       fs-extra: 11.3.5
       pathe: 2.0.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - bufferutil
       - supports-color
+      - utf-8-validate
+      - ws
 
-  '@workflow/swc-plugin@4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))':
+  '@workflow/swc-plugin@5.0.0-beta.5(@swc/core@1.15.3(@swc/helpers@0.5.23))':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
 
-  '@workflow/typescript-plugin@4.0.3(typescript@7.0.2)':
-    dependencies:
+  '@workflow/typescript-plugin@5.0.0-beta.5(typescript@7.0.2)':
+    optionalDependencies:
       typescript: 7.0.2
 
-  '@workflow/utils@4.1.4':
+  '@workflow/utils@5.0.0-beta.9':
     dependencies:
       ms: 2.1.3
 
-  '@workflow/vite@4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)':
+  '@workflow/vite@5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)':
     dependencies:
-      '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
+      '@workflow/builders': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - bufferutil
       - supports-color
+      - utf-8-validate
+      - ws
 
-  '@workflow/vitest@4.0.17(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(supports-color@8.1.1)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))(vitest@4.1.6)':
+  '@workflow/vitest@5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))(vitest@4.1.6)(ws@8.20.0)':
     dependencies:
-      '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
-      '@workflow/rollup': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/world': 4.3.1
-      '@workflow/world-local': 4.2.4(@opentelemetry/api@1.9.1)
+      '@workflow/builders': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/core': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(ws@8.20.0)
+      '@workflow/rollup': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/world': 5.0.0-beta.31
+      '@workflow/world-local': 5.0.0-beta.40(@opentelemetry/api@1.9.1)
       vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
     optionalDependencies:
       vite: 8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - bufferutil
       - supports-color
+      - utf-8-validate
+      - ws
 
-  '@workflow/web@4.1.17':
+  '@workflow/web@5.0.0-beta.46(@opentelemetry/api@1.9.1)(react@19.2.6)':
     dependencies:
-      express: 5.2.1(supports-color@8.1.1)
+      '@workflow/world-local': 5.0.0-beta.40(@opentelemetry/api@1.9.1)
+      express: 5.2.1
+      swr: 2.5.1(react@19.2.6)
     transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - react
       - supports-color
 
-  '@workflow/world-local@4.2.4(@opentelemetry/api@1.9.1)':
+  '@workflow/world-local@5.0.0-beta.40(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@vercel/queue': 0.3.1
-      '@workflow/errors': 4.2.1
-      '@workflow/utils': 4.1.4
-      '@workflow/world': 4.3.1
+      '@vercel/queue': 0.5.0(@opentelemetry/api@1.9.1)
+      '@workflow/errors': 5.0.0-beta.18
+      '@workflow/utils': 5.0.0-beta.9
+      '@workflow/world': 5.0.0-beta.31
       async-sema: 3.1.1
+      proper-lockfile: 4.1.2
       ulid: 3.0.2
       undici: 7.29.0
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@workflow/world-vercel@4.6.2(@opentelemetry/api@1.9.1)':
+  '@workflow/world-vercel@5.0.0-beta.42(@aws-sdk/credential-provider-web-identity@3.972.49)(@opentelemetry/api@1.9.1)':
     dependencies:
+      '@vercel/functions': 3.9.5(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.20.0)
       '@vercel/oidc': 3.2.0
-      '@vercel/queue': 0.3.1
-      '@workflow/errors': 4.2.1
-      '@workflow/world': 4.3.1
+      '@vercel/queue': 0.5.0(@opentelemetry/api@1.9.1)
+      '@workflow/errors': 5.0.0-beta.18
+      '@workflow/utils': 5.0.0-beta.9
+      '@workflow/world': 5.0.0-beta.31
       cbor-x: 1.6.0
+      ulid: 3.0.2
       undici: 7.29.0
+      ws: 8.20.0
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-web-identity'
+      - bufferutil
+      - utf-8-validate
 
-  '@workflow/world@4.3.1':
+  '@workflow/world@5.0.0-beta.31':
     dependencies:
       ulid: 3.0.2
       zod: 4.3.6
@@ -13585,27 +13666,27 @@ snapshots:
 
   b4a@1.8.1: {}
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.6):
     dependencies:
       '@babel/compat-data': 7.29.3
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.6)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.6(supports-color@8.1.1)):
+  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.6):
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.6)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.6(supports-color@8.1.1)):
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.6):
     dependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/core': 7.29.6
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -13627,7 +13708,7 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.7.0-rc.4(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3))(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6):
+  better-auth@1.7.0-rc.4(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3))(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6):
     dependencies:
       '@better-auth/core': 1.7.0-rc.4(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.7.0-rc.4(@better-auth/core@1.7.0-rc.4(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3))
@@ -13649,7 +13730,7 @@ snapshots:
     optionalDependencies:
       drizzle-kit: 1.0.0-rc.4
       drizzle-orm: 1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3)
-      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -13692,7 +13773,7 @@ snapshots:
 
   bluebird@3.4.7: {}
 
-  body-parser@2.2.2(supports-color@8.1.1):
+  body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -13706,9 +13787,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  botid@1.5.11(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  botid@1.5.11(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   bottleneck@2.19.5: {}
@@ -14183,7 +14264,7 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
-  devalue@5.8.1: {}
+  devalue@5.9.0: {}
 
   devlop@1.1.0:
     dependencies:
@@ -14559,15 +14640,15 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.5.1(express@5.2.1(supports-color@8.1.1)):
+  express-rate-limit@8.5.1(express@5.2.1):
     dependencies:
-      express: 5.2.1(supports-color@8.1.1)
+      express: 5.2.1
       ip-address: 10.2.0
 
-  express@5.2.1(supports-color@8.1.1):
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2(supports-color@8.1.1)
+      body-parser: 2.2.2
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -14577,7 +14658,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@8.1.1)
+      finalhandler: 2.1.1
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -14588,8 +14669,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.1
       range-parser: 1.2.1
-      router: 2.2.0(supports-color@8.1.1)
-      send: 1.2.1(supports-color@8.1.1)
+      router: 2.2.0
+      send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
@@ -14673,7 +14754,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1(supports-color@8.1.1):
+  finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -14701,13 +14782,13 @@ snapshots:
       semver-regex: 4.0.5
       super-regex: 1.1.0
 
-  flags@4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  flags@4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@edge-runtime/cookies': 5.0.2
       jose: 5.10.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -14915,8 +14996,6 @@ snapshots:
       - conventional-commits-parser
 
   github-slugger@2.0.0: {}
-
-  glob-to-regexp@0.4.1: {}
 
   glob@7.2.3:
     dependencies:
@@ -16255,14 +16334,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.12.0: {}
 
-  next-intl@4.12.0(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2):
+  next-intl@4.12.0(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.7
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
       icu-minify: 4.12.0
       negotiator: 1.0.0
-      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl-swc-plugin-extractor: 4.12.0
       po-parser: 2.1.1
       react: 19.2.6
@@ -16291,7 +16370,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -16300,7 +16379,7 @@ snapshots:
       postcss: 8.5.23
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(@babel/core@7.29.6(supports-color@8.1.1))(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.6)(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.3.0
       '@next/swc-darwin-x64': 16.3.0
@@ -16328,7 +16407,7 @@ snapshots:
       postcss: 8.5.23
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(@babel/core@7.29.6(supports-color@8.1.1))(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.6)(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.3.0
       '@next/swc-darwin-x64': 16.3.0
@@ -16402,12 +16481,12 @@ snapshots:
     dependencies:
       esm-env: 1.2.2
 
-  nuqs@2.8.9(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  nuqs@2.8.9(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.6
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   nwsapi@2.2.23: {}
 
@@ -16700,6 +16779,12 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   property-information@7.1.0: {}
 
   proto-list@1.2.4: {}
@@ -16749,6 +16834,8 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
+  quickjs-wasi@3.4.0: {}
+
   range-parser@1.2.1: {}
 
   raw-body@3.0.2:
@@ -16772,7 +16859,7 @@ snapshots:
 
   react-aria-components@1.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@internationalized/date': 3.12.1
+      '@internationalized/date': 3.12.3
       '@react-types/shared': 3.36.1(react@19.2.6)
       '@swc/helpers': 0.5.23
       client-only: 0.0.1
@@ -16795,9 +16882,9 @@ snapshots:
 
   react-aria@3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@internationalized/date': 3.12.1
-      '@internationalized/number': 3.6.6
-      '@internationalized/string': 3.2.8
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.10
       '@react-types/shared': 3.36.1(react@19.2.6)
       '@swc/helpers': 0.5.23
       aria-hidden: 1.2.6
@@ -16865,9 +16952,9 @@ snapshots:
 
   react-stately@3.46.0(react@19.2.6):
     dependencies:
-      '@internationalized/date': 3.12.1
-      '@internationalized/number': 3.6.6
-      '@internationalized/string': 3.2.8
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.10
       '@react-types/shared': 3.36.1(react@19.2.6)
       '@swc/helpers': 0.5.23
       react: 19.2.6
@@ -17171,6 +17258,8 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  retry@0.12.0: {}
+
   retry@0.13.1: {}
 
   rfdc@1.4.1: {}
@@ -17223,7 +17312,7 @@ snapshots:
 
   rou3@0.7.12: {}
 
-  router@2.2.0(supports-color@8.1.1):
+  router@2.2.0:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
@@ -17283,13 +17372,13 @@ snapshots:
     dependencies:
       parseley: 0.12.1
 
-  semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2):
+  semantic-release@25.0.3(typescript@7.0.2):
     dependencies:
-      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.3(typescript@7.0.2))
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 12.0.8(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
-      '@semantic-release/npm': 13.1.5(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
-      '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
+      '@semantic-release/github': 12.0.8(semantic-release@25.0.3(typescript@7.0.2))
+      '@semantic-release/npm': 13.1.5(semantic-release@25.0.3(typescript@7.0.2))
+      '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.3(typescript@7.0.2))
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.1(typescript@7.0.2)
       debug: 4.4.3(supports-color@8.1.1)
@@ -17335,7 +17424,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1(supports-color@8.1.1):
+  send@1.2.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -17356,7 +17445,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@8.1.1)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -17649,12 +17738,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.6(supports-color@8.1.1))(react@19.2.6):
+  styled-jsx@5.1.6(@babel/core@7.29.6)(react@19.2.6):
     dependencies:
       client-only: 0.0.1
       react: 19.2.6
     optionalDependencies:
-      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/core': 7.29.6
 
   super-regex@1.1.0:
     dependencies:
@@ -17687,6 +17776,12 @@ snapshots:
       supports-color: 10.2.2
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swr@2.5.1(react@19.2.6):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)
 
   symbol-tree@3.2.4: {}
 
@@ -18201,11 +18296,6 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  watchpack@2.5.1:
-    dependencies:
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
@@ -18251,33 +18341,38 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.8.1(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.2)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@7.0.2):
+  workflow@5.0.0-beta.46(@aws-sdk/credential-provider-web-identity@3.972.49)(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.2)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2)(ws@8.20.0):
     dependencies:
-      '@workflow/astro': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/cli': 4.3.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
-      '@workflow/errors': 4.2.1
-      '@workflow/nest': 4.0.17(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)
-      '@workflow/next': 4.1.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      '@workflow/nitro': 4.1.7(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/nuxt': 4.0.17(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(magicast@0.5.2)
-      '@workflow/rollup': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/sveltekit': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/typescript-plugin': 4.0.3(typescript@7.0.2)
-      '@workflow/utils': 4.1.4
+      '@workflow/astro': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/cli': 5.0.0-beta.46(@aws-sdk/credential-provider-web-identity@3.972.49)(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(react@19.2.6)(ws@8.20.0)
+      '@workflow/core': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(ws@8.20.0)
+      '@workflow/errors': 5.0.0-beta.18
+      '@workflow/nest': 5.0.0-beta.46(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/next': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(ws@8.20.0)
+      '@workflow/nitro': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(react@19.2.6)(ws@8.20.0)
+      '@workflow/nuxt': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(magicast@0.5.2)(react@19.2.6)(ws@8.20.0)
+      '@workflow/rollup': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/sveltekit': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
+      '@workflow/typescript-plugin': 5.0.0-beta.5(typescript@7.0.2)
+      '@workflow/utils': 5.0.0-beta.9
       ms: 2.1.3
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
     transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-web-identity'
       - '@nestjs/common'
       - '@nestjs/core'
       - '@swc/cli'
       - '@swc/core'
       - '@swc/helpers'
+      - bufferutil
       - magicast
       - next
+      - react
       - supports-color
       - typescript
+      - utf-8-validate
+      - ws
 
   wrap-ansi@10.0.0:
     dependencies:


### PR DESCRIPTION
- Bump `workflow` and `@workflow/vitest` to 5.0.0-beta.46. The 4.x line has no regional dimension, so every run's data and queue messages lived in `iad1` regardless of `regions: ["sin1"]` in `vercel.ts` — v5 tags run IDs with the creation region and adds a `region` option to `start()`
- Rename the five colliding step functions (`getLatestMonth` ×3, `getLatestYear` ×2); v5 fails the build on duplicate step IDs where v4 resolved them last-write-wins
- Make the workflow payloads optional so all seven routes use `start()`'s `(workflow, options)` overload, matching the SDK docs
- Return JSON with the run ID instead of piping `run.getReadable()`, which threw `ERR_INVALID_ARG_TYPE` behind a 200 on every run because the stream carries objects rather than bytes, losing all `emitEvent` output and burning ~8–15s of compute per run

Verified with `tsc --noEmit`, `next build`, Biome, and `workflow validate` (no serde issues). Not yet exercised end to end — the workflows need a real run against the preview deployment before this merges, e.g. `workflow start carCostsWorkflow -b vercel -e preview`. Note that a real run writes to the staging Neon branch and, for `cars`/`coe`, generates AI content.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790688650&installation_model_id=21947&pr_number=942&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F942&signature=56bcdedc1f2538135ba2ad1e44e6325204443a5014c3e98d139ba56543eaf9d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->