### PR TITLE
Remove the leftover impeccable config

### DIFF
--- a/apps/web/.impeccable/live/config.json
+++ b/apps/web/.impeccable/live/config.json
@@ -1,6 +1,0 @@
-{
-  "files": ["src/app/layout.tsx"],
-  "insertBefore": "</body>",
-  "commentSyntax": "jsx",
-  "cspChecked": true
-}


### PR DESCRIPTION
- Delete `apps/web/.impeccable/live/config.json`, left behind when the impeccable skill was removed in 6f16e3b4

Two other references to the removed skill are still tracked and now point at paths that no longer exist — `.github/hooks/impeccable.json` (`.github/skills/impeccable/scripts/hook.mjs`) and `.codex/hooks.json` (`.agents/skills/impeccable/scripts/hook.mjs`). Left alone here to keep this scoped; worth a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790690737&installation_model_id=21947&pr_number=943&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F943&signature=dedfd307f061505d5b8515aca57951dfaec62dc7bf61d3adbdf45c25fb3c79f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->