### PR TITLE
Classify AI errors with provider guards

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "vercel-build": "turbo run @motormetrics/database#migrate && next build"
   },
   "dependencies": {
+    "@ai-sdk/gateway": "catalog:",
     "@ai-sdk/otel": "catalog:",
     "@better-auth/drizzle-adapter": "catalog:",
     "@flags-sdk/vercel": "1.4.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,6 @@
     "vercel-build": "turbo run @motormetrics/database#migrate && next build"
   },
   "dependencies": {
-    "@ai-sdk/gateway": "catalog:",
     "@ai-sdk/otel": "catalog:",
     "@better-auth/drizzle-adapter": "catalog:",
     "@flags-sdk/vercel": "1.4.6",

--- a/apps/web/src/workflows/cars/cars.test.ts
+++ b/apps/web/src/workflows/cars/cars.test.ts
@@ -1,11 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@motormetrics/ai", () => ({
-  generateBlogContent: vi.fn(),
-  generateHeroImage: vi.fn(),
-  getCarsAggregatedByMonth: vi.fn(),
-  updatePostHeroImage: vi.fn(),
-}));
+vi.mock("@motormetrics/ai", async () => {
+  // classifyAIError is pure; use the real one so these keep covering the
+  // whole path from a provider error to the WDK error type.
+  const { classifyAIError } = await vi.importActual<
+    typeof import("@motormetrics/ai/src/errors")
+  >("@motormetrics/ai/src/errors");
+
+  return {
+    classifyAIError,
+    generateBlogContent: vi.fn(),
+    generateHeroImage: vi.fn(),
+    getCarsAggregatedByMonth: vi.fn(),
+    updatePostHeroImage: vi.fn(),
+  };
+});
 
 vi.mock("@motormetrics/utils", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@motormetrics/utils")>()),

--- a/apps/web/src/workflows/coe/coe.test.ts
+++ b/apps/web/src/workflows/coe/coe.test.ts
@@ -1,11 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@motormetrics/ai", () => ({
-  generateBlogContent: vi.fn(),
-  generateHeroImage: vi.fn(),
-  getCoeForMonth: vi.fn(),
-  updatePostHeroImage: vi.fn(),
-}));
+vi.mock("@motormetrics/ai", async () => {
+  // classifyAIError is pure; use the real one so these keep covering the
+  // whole path from a provider error to the WDK error type.
+  const { classifyAIError } = await vi.importActual<
+    typeof import("@motormetrics/ai/src/errors")
+  >("@motormetrics/ai/src/errors");
+
+  return {
+    classifyAIError,
+    generateBlogContent: vi.fn(),
+    generateHeroImage: vi.fn(),
+    getCoeForMonth: vi.fn(),
+    updatePostHeroImage: vi.fn(),
+  };
+});
 
 vi.mock("@motormetrics/utils", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@motormetrics/utils")>()),

--- a/apps/web/src/workflows/deregistrations/deregistrations.test.ts
+++ b/apps/web/src/workflows/deregistrations/deregistrations.test.ts
@@ -1,11 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@motormetrics/ai", () => ({
-  generateBlogContent: vi.fn(),
-  generateHeroImage: vi.fn(),
-  getDeregistrationsForMonth: vi.fn(),
-  updatePostHeroImage: vi.fn(),
-}));
+vi.mock("@motormetrics/ai", async () => {
+  // classifyAIError is pure; use the real one so these keep covering the
+  // whole path from a provider error to the WDK error type.
+  const { classifyAIError } = await vi.importActual<
+    typeof import("@motormetrics/ai/src/errors")
+  >("@motormetrics/ai/src/errors");
+
+  return {
+    classifyAIError,
+    generateBlogContent: vi.fn(),
+    generateHeroImage: vi.fn(),
+    getDeregistrationsForMonth: vi.fn(),
+    updatePostHeroImage: vi.fn(),
+  };
+});
 
 vi.mock("@motormetrics/utils", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@motormetrics/utils")>()),

--- a/apps/web/src/workflows/electric-vehicles/electric-vehicles.test.ts
+++ b/apps/web/src/workflows/electric-vehicles/electric-vehicles.test.ts
@@ -1,11 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@motormetrics/ai", () => ({
-  generateBlogContent: vi.fn(),
-  generateHeroImage: vi.fn(),
-  getEvDataForMonth: vi.fn(),
-  updatePostHeroImage: vi.fn(),
-}));
+vi.mock("@motormetrics/ai", async () => {
+  // classifyAIError is pure; use the real one so these keep covering the
+  // whole path from a provider error to the WDK error type.
+  const { classifyAIError } = await vi.importActual<
+    typeof import("@motormetrics/ai/src/errors")
+  >("@motormetrics/ai/src/errors");
+
+  return {
+    classifyAIError,
+    generateBlogContent: vi.fn(),
+    generateHeroImage: vi.fn(),
+    getEvDataForMonth: vi.fn(),
+    updatePostHeroImage: vi.fn(),
+  };
+});
 
 vi.mock("@web/queries/cars/latest-month", () => ({
   getCarsLatestMonth: vi.fn(),

--- a/apps/web/src/workflows/regenerate-post/regenerate-post.test.ts
+++ b/apps/web/src/workflows/regenerate-post/regenerate-post.test.ts
@@ -1,12 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@motormetrics/ai", () => ({
-  generateHeroImage: vi.fn(),
-  getCarsAggregatedByMonth: vi.fn(),
-  getCoeForMonth: vi.fn(),
-  regenerateBlogContent: vi.fn(),
-  updatePostHeroImage: vi.fn(),
-}));
+vi.mock("@motormetrics/ai", async () => {
+  // classifyAIError is pure; use the real one so these keep covering the
+  // whole path from a provider error to the WDK error type.
+  const { classifyAIError } = await vi.importActual<
+    typeof import("@motormetrics/ai/src/errors")
+  >("@motormetrics/ai/src/errors");
+
+  return {
+    classifyAIError,
+    generateHeroImage: vi.fn(),
+    getCarsAggregatedByMonth: vi.fn(),
+    getCoeForMonth: vi.fn(),
+    regenerateBlogContent: vi.fn(),
+    updatePostHeroImage: vi.fn(),
+  };
+});
 
 vi.mock("workflow", () => ({
   fetch: vi.fn(),

--- a/apps/web/src/workflows/shared/index.ts
+++ b/apps/web/src/workflows/shared/index.ts
@@ -71,23 +71,47 @@ export async function generatePostHero(params: {
 }
 
 /**
+ * HTTP status carried by AI SDK and AI Gateway errors. Both put it on
+ * `statusCode`; the message often does not mention the code at all, so
+ * classifying on the message alone misses them.
+ */
+function getStatusCode(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+
+  const { statusCode } = error as { statusCode?: unknown };
+  return typeof statusCode === "number" ? statusCode : undefined;
+}
+
+/**
  * Handle AI generation errors with appropriate WDK error types.
  * - 429 (rate limit) → RetryableError with 1 minute delay
- * - 401/403 (auth) → FatalError (cannot recover)
- * - Other errors → rethrown as-is
+ * - 401/403 (auth, incl. gateway tier restrictions) → FatalError (cannot recover)
+ * - Other errors → logged and rethrown as-is
+ *
+ * The status code is checked before the message: a Gateway 403 reads
+ * "Free tier users do not have access to this model" with no code in the
+ * text, so a message-only check retried it three times and surfaced
+ * nothing but `USER_ERROR`.
  */
 export function handleAIError(error: unknown): never {
   const message = error instanceof Error ? error.message : String(error);
+  const statusCode = getStatusCode(error);
 
-  if (message.includes("429")) {
+  if (statusCode === 429 || message.includes("429")) {
     console.log("[WORKFLOW] AI rate limited, scheduling retry in 1m");
     throw new RetryableError("AI rate limited", { retryAfter: "1m" });
   }
 
-  if (message.includes("401") || message.includes("403")) {
-    console.log("[WORKFLOW] AI authentication failed");
+  if (
+    statusCode === 401 ||
+    statusCode === 403 ||
+    message.includes("401") ||
+    message.includes("403")
+  ) {
+    console.error(`[WORKFLOW] AI authentication failed — ${message}`);
     throw new FatalError("AI authentication failed");
   }
 
+  console.error(`[WORKFLOW] AI generation failed — ${message}`);
   throw error;
 }

--- a/apps/web/src/workflows/shared/index.ts
+++ b/apps/web/src/workflows/shared/index.ts
@@ -1,8 +1,10 @@
-import { GatewayError } from "@ai-sdk/gateway";
-import { generateHeroImage, updatePostHeroImage } from "@motormetrics/ai";
+import {
+  classifyAIError,
+  generateHeroImage,
+  updatePostHeroImage,
+} from "@motormetrics/ai";
 import { slugify } from "@motormetrics/utils";
 import { getPostsWorkflowRevalidationTags } from "@web/lib/cache-tags";
-import { APICallError } from "ai";
 import { revalidateTag } from "next/cache";
 import { FatalError, getWritable, RetryableError } from "workflow";
 
@@ -73,37 +75,33 @@ export async function generatePostHero(params: {
 }
 
 /**
- * Handle AI generation errors with appropriate WDK error types.
+ * Map an AI failure onto the WDK error types.
  *
- * The Gateway and the AI SDK classify retryability themselves, so prefer
- * their own `isRetryable` over inspecting status codes: a Gateway 403 for a
- * free-tier model carries `statusCode`, while a GatewayAuthenticationError
- * does not, and neither puts the code in the message text.
- *
- * The message checks remain as a fallback for provider errors that arrive as
- * plain Errors.
+ * The classification itself lives in `@motormetrics/ai`, next to the code that
+ * chooses the provider — which errors are possible follows from that choice.
+ * This function only owns the WDK mapping.
  */
 export function handleAIError(error: unknown): never {
-  const message = error instanceof Error ? error.message : String(error);
+  const { classification, reason, message } = classifyAIError(error);
 
-  if (GatewayError.isInstance(error) || APICallError.isInstance(error)) {
-    if (error.isRetryable) {
-      console.log(`[WORKFLOW] AI call retryable — ${message}`);
-      throw new RetryableError("AI call failed", { retryAfter: "1m" });
-    }
-
-    console.error(`[WORKFLOW] AI call failed fatally — ${message}`);
-    throw new FatalError("AI call failed");
-  }
-
-  if (message.includes("429")) {
+  if (reason === "rate-limited") {
     console.log("[WORKFLOW] AI rate limited, scheduling retry in 1m");
     throw new RetryableError("AI rate limited", { retryAfter: "1m" });
   }
 
-  if (message.includes("401") || message.includes("403")) {
+  if (reason === "authentication") {
     console.error(`[WORKFLOW] AI authentication failed — ${message}`);
     throw new FatalError("AI authentication failed");
+  }
+
+  if (classification === "retryable") {
+    console.log(`[WORKFLOW] AI call retryable — ${message}`);
+    throw new RetryableError("AI call failed", { retryAfter: "1m" });
+  }
+
+  if (classification === "fatal") {
+    console.error(`[WORKFLOW] AI call failed fatally — ${message}`);
+    throw new FatalError("AI call failed");
   }
 
   console.error(`[WORKFLOW] AI generation failed — ${message}`);

--- a/apps/web/src/workflows/shared/index.ts
+++ b/apps/web/src/workflows/shared/index.ts
@@ -1,6 +1,8 @@
+import { GatewayError } from "@ai-sdk/gateway";
 import { generateHeroImage, updatePostHeroImage } from "@motormetrics/ai";
 import { slugify } from "@motormetrics/utils";
 import { getPostsWorkflowRevalidationTags } from "@web/lib/cache-tags";
+import { APICallError } from "ai";
 import { revalidateTag } from "next/cache";
 import { FatalError, getWritable, RetryableError } from "workflow";
 
@@ -71,43 +73,35 @@ export async function generatePostHero(params: {
 }
 
 /**
- * HTTP status carried by AI SDK and AI Gateway errors. Both put it on
- * `statusCode`; the message often does not mention the code at all, so
- * classifying on the message alone misses them.
- */
-function getStatusCode(error: unknown): number | undefined {
-  if (typeof error !== "object" || error === null) return undefined;
-
-  const { statusCode } = error as { statusCode?: unknown };
-  return typeof statusCode === "number" ? statusCode : undefined;
-}
-
-/**
  * Handle AI generation errors with appropriate WDK error types.
- * - 429 (rate limit) → RetryableError with 1 minute delay
- * - 401/403 (auth, incl. gateway tier restrictions) → FatalError (cannot recover)
- * - Other errors → logged and rethrown as-is
  *
- * The status code is checked before the message: a Gateway 403 reads
- * "Free tier users do not have access to this model" with no code in the
- * text, so a message-only check retried it three times and surfaced
- * nothing but `USER_ERROR`.
+ * The Gateway and the AI SDK classify retryability themselves, so prefer
+ * their own `isRetryable` over inspecting status codes: a Gateway 403 for a
+ * free-tier model carries `statusCode`, while a GatewayAuthenticationError
+ * does not, and neither puts the code in the message text.
+ *
+ * The message checks remain as a fallback for provider errors that arrive as
+ * plain Errors.
  */
 export function handleAIError(error: unknown): never {
   const message = error instanceof Error ? error.message : String(error);
-  const statusCode = getStatusCode(error);
 
-  if (statusCode === 429 || message.includes("429")) {
+  if (GatewayError.isInstance(error) || APICallError.isInstance(error)) {
+    if (error.isRetryable) {
+      console.log(`[WORKFLOW] AI call retryable — ${message}`);
+      throw new RetryableError("AI call failed", { retryAfter: "1m" });
+    }
+
+    console.error(`[WORKFLOW] AI call failed fatally — ${message}`);
+    throw new FatalError("AI call failed");
+  }
+
+  if (message.includes("429")) {
     console.log("[WORKFLOW] AI rate limited, scheduling retry in 1m");
     throw new RetryableError("AI rate limited", { retryAfter: "1m" });
   }
 
-  if (
-    statusCode === 401 ||
-    statusCode === 403 ||
-    message.includes("401") ||
-    message.includes("403")
-  ) {
+  if (message.includes("401") || message.includes("403")) {
     console.error(`[WORKFLOW] AI authentication failed — ${message}`);
     throw new FatalError("AI authentication failed");
   }

--- a/apps/web/src/workflows/shared/shared.test.ts
+++ b/apps/web/src/workflows/shared/shared.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@motormetrics/ai", () => ({
+  classifyAIError: vi.fn(),
   generateHeroImage: vi.fn(),
   updatePostHeroImage: vi.fn(),
 }));
@@ -47,10 +48,10 @@ vi.mock("workflow", () => ({
 }));
 
 import {
-  GatewayInternalServerError,
-  GatewayRateLimitError,
-} from "@ai-sdk/gateway";
-import { generateHeroImage, updatePostHeroImage } from "@motormetrics/ai";
+  classifyAIError,
+  generateHeroImage,
+  updatePostHeroImage,
+} from "@motormetrics/ai";
 import {
   emitEvent,
   generatePostHero,
@@ -176,18 +177,26 @@ describe("generatePostHero", () => {
 });
 
 describe("handleAIError", () => {
+  // Classification itself is covered in @motormetrics/ai; these cover the
+  // mapping from a verdict onto the WDK error types.
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should throw RetryableError for 429 rate limit", () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const error = new Error("Request failed with status 429");
+  const verdict = (
+    classification: "retryable" | "fatal" | "unknown",
+    reason: "rate-limited" | "authentication" | "provider" | "unknown",
+    message = "boom",
+  ) => ({ classification, reason, message });
 
-    expect(() => handleAIError(error)).toThrow(MockRetryableError);
+  it("should throw RetryableError with a 1m delay when rate limited", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(classifyAIError).mockReturnValue(
+      verdict("retryable", "rate-limited"),
+    );
 
     try {
-      handleAIError(error);
+      handleAIError(new Error("ignored"));
     } catch (e) {
       expect(e).toBeInstanceOf(MockRetryableError);
       expect((e as InstanceType<typeof MockRetryableError>).message).toBe(
@@ -201,80 +210,54 @@ describe("handleAIError", () => {
     consoleSpy.mockRestore();
   });
 
-  it("should throw FatalError for 401 auth error", () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const error = new Error("Request failed with status 401");
-
-    expect(() => handleAIError(error)).toThrow(MockFatalError);
-
-    try {
-      handleAIError(error);
-    } catch (e) {
-      expect(e).toBeInstanceOf(MockFatalError);
-      expect((e as InstanceType<typeof MockFatalError>).message).toBe(
-        "AI authentication failed",
-      );
-    }
-
-    consoleSpy.mockRestore();
-  });
-
-  it("should throw FatalError for 403 auth error", () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const error = new Error("Request failed with status 403");
-
-    expect(() => handleAIError(error)).toThrow(MockFatalError);
-
-    try {
-      handleAIError(error);
-    } catch (e) {
-      expect(e).toBeInstanceOf(MockFatalError);
-      expect((e as InstanceType<typeof MockFatalError>).message).toBe(
-        "AI authentication failed",
-      );
-    }
-
-    consoleSpy.mockRestore();
-  });
-
-  it("should throw FatalError for a non-retryable Gateway error", () => {
+  it("should throw FatalError when authentication fails", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    // The free-tier restriction arrives as a 403 with no code in the message.
-    const error = new GatewayInternalServerError({
-      message: "Free tier users do not have access to this model.",
-      statusCode: 403,
-    });
+    vi.mocked(classifyAIError).mockReturnValue(
+      verdict("fatal", "authentication"),
+    );
 
-    expect(error.isRetryable).toBe(false);
-    expect(() => handleAIError(error)).toThrow(MockFatalError);
-
-    consoleSpy.mockRestore();
-  });
-
-  it("should throw RetryableError for a retryable Gateway error", () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const error = new GatewayRateLimitError({});
-
-    expect(error.isRetryable).toBe(true);
-    expect(() => handleAIError(error)).toThrow(MockRetryableError);
+    try {
+      handleAIError(new Error("ignored"));
+    } catch (e) {
+      expect(e).toBeInstanceOf(MockFatalError);
+      expect((e as InstanceType<typeof MockFatalError>).message).toBe(
+        "AI authentication failed",
+      );
+    }
 
     consoleSpy.mockRestore();
   });
 
-  it("should rethrow other errors unchanged", () => {
+  it("should throw FatalError for a fatal provider error", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(classifyAIError).mockReturnValue(verdict("fatal", "provider"));
+
+    expect(() => handleAIError(new Error("ignored"))).toThrow(MockFatalError);
+
+    consoleSpy.mockRestore();
+  });
+
+  it("should throw RetryableError for a retryable provider error", () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(classifyAIError).mockReturnValue(
+      verdict("retryable", "provider"),
+    );
+
+    expect(() => handleAIError(new Error("ignored"))).toThrow(
+      MockRetryableError,
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it("should rethrow unclassified errors unchanged", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const originalError = new Error("Some other error");
+    vi.mocked(classifyAIError).mockReturnValue(
+      verdict("unknown", "unknown", "Some other error"),
+    );
 
     expect(() => handleAIError(originalError)).toThrow(originalError);
-
-    consoleSpy.mockRestore();
-  });
-
-  it("should handle non-Error objects", () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
-    expect(() => handleAIError("string error")).toThrow("string error");
-    expect(() => handleAIError("error with 429")).toThrow(MockRetryableError);
 
     consoleSpy.mockRestore();
   });

--- a/apps/web/src/workflows/shared/shared.test.ts
+++ b/apps/web/src/workflows/shared/shared.test.ts
@@ -233,6 +233,31 @@ describe("handleAIError", () => {
     consoleSpy.mockRestore();
   });
 
+  it("should throw FatalError for a 403 carried on statusCode only", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = Object.assign(
+      new Error(
+        "Free tier users do not have access to this model. Upgrade to paid credits.",
+      ),
+      { statusCode: 403 },
+    );
+
+    expect(() => handleAIError(error)).toThrow(MockFatalError);
+
+    consoleSpy.mockRestore();
+  });
+
+  it("should throw RetryableError for a 429 carried on statusCode only", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = Object.assign(new Error("Too many requests"), {
+      statusCode: 429,
+    });
+
+    expect(() => handleAIError(error)).toThrow(MockRetryableError);
+
+    consoleSpy.mockRestore();
+  });
+
   it("should rethrow other errors unchanged", () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const originalError = new Error("Some other error");

--- a/apps/web/src/workflows/shared/shared.test.ts
+++ b/apps/web/src/workflows/shared/shared.test.ts
@@ -46,6 +46,10 @@ vi.mock("workflow", () => ({
   })),
 }));
 
+import {
+  GatewayInternalServerError,
+  GatewayRateLimitError,
+} from "@ai-sdk/gateway";
 import { generateHeroImage, updatePostHeroImage } from "@motormetrics/ai";
 import {
   emitEvent,
@@ -233,26 +237,25 @@ describe("handleAIError", () => {
     consoleSpy.mockRestore();
   });
 
-  it("should throw FatalError for a 403 carried on statusCode only", () => {
+  it("should throw FatalError for a non-retryable Gateway error", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const error = Object.assign(
-      new Error(
-        "Free tier users do not have access to this model. Upgrade to paid credits.",
-      ),
-      { statusCode: 403 },
-    );
+    // The free-tier restriction arrives as a 403 with no code in the message.
+    const error = new GatewayInternalServerError({
+      message: "Free tier users do not have access to this model.",
+      statusCode: 403,
+    });
 
+    expect(error.isRetryable).toBe(false);
     expect(() => handleAIError(error)).toThrow(MockFatalError);
 
     consoleSpy.mockRestore();
   });
 
-  it("should throw RetryableError for a 429 carried on statusCode only", () => {
+  it("should throw RetryableError for a retryable Gateway error", () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const error = Object.assign(new Error("Too many requests"), {
-      statusCode: 429,
-    });
+    const error = new GatewayRateLimitError({});
 
+    expect(error.isRetryable).toBe(true);
     expect(() => handleAIError(error)).toThrow(MockRetryableError);
 
     consoleSpy.mockRestore();

--- a/packages/ai/src/errors.test.ts
+++ b/packages/ai/src/errors.test.ts
@@ -1,0 +1,63 @@
+import {
+  GatewayAuthenticationError,
+  GatewayInternalServerError,
+  GatewayRateLimitError,
+} from "@ai-sdk/gateway";
+import { describe, expect, it } from "vitest";
+import { classifyAIError } from "./errors";
+
+describe("classifyAIError", () => {
+  it("should treat the free-tier restriction as fatal", () => {
+    // Delivered as a 500-class error carrying a 403, with no code in the text.
+    const error = new GatewayInternalServerError({
+      message: "Free tier users do not have access to this model.",
+      statusCode: 403,
+    });
+
+    expect(error.isRetryable).toBe(false);
+    expect(classifyAIError(error)).toEqual({
+      classification: "fatal",
+      reason: "provider",
+      message: "Free tier users do not have access to this model.",
+    });
+  });
+
+  it("should treat a credential failure as fatal", () => {
+    // Observed with an expired OIDC token, where statusCode came back
+    // undefined; isRetryable is the reliable signal either way.
+    const error = new GatewayAuthenticationError({});
+
+    expect(error.isRetryable).toBe(false);
+    expect(classifyAIError(error).classification).toBe("fatal");
+  });
+
+  it("should treat a rate limit as retryable", () => {
+    const error = new GatewayRateLimitError({});
+
+    expect(classifyAIError(error).classification).toBe("retryable");
+  });
+
+  it("should fall back to the message for a plain Error", () => {
+    expect(
+      classifyAIError(new Error("Request failed with status 429")),
+    ).toEqual({
+      classification: "retryable",
+      reason: "rate-limited",
+      message: "Request failed with status 429",
+    });
+
+    expect(
+      classifyAIError(new Error("Request failed with status 403")).reason,
+    ).toBe("authentication");
+  });
+
+  it("should report anything else as unknown", () => {
+    expect(classifyAIError(new Error("Some other error"))).toEqual({
+      classification: "unknown",
+      reason: "unknown",
+      message: "Some other error",
+    });
+
+    expect(classifyAIError("string error").classification).toBe("unknown");
+  });
+});

--- a/packages/ai/src/errors.ts
+++ b/packages/ai/src/errors.ts
@@ -1,0 +1,59 @@
+import { GatewayError } from "@ai-sdk/gateway";
+import { APICallError } from "ai";
+
+/**
+ * Whether the caller should retry the AI call.
+ * - `retryable` — transient; retrying may succeed
+ * - `fatal` — retrying cannot help (auth, permissions, unknown model)
+ * - `unknown` — not an AI provider error; the caller should rethrow as-is
+ */
+export type AIErrorClassification = "retryable" | "fatal" | "unknown";
+
+/** Why the call failed, for callers that surface a specific message. */
+export type AIErrorReason =
+  | "rate-limited"
+  | "authentication"
+  | "provider"
+  | "unknown";
+
+export interface ClassifiedAIError {
+  classification: AIErrorClassification;
+  reason: AIErrorReason;
+  message: string;
+}
+
+/**
+ * Classify an error thrown by a Gateway or provider call.
+ *
+ * The Gateway and the AI SDK derive `isRetryable` from the response status, so
+ * prefer it over inspecting status codes here: the free-tier restriction
+ * arrives as a GatewayInternalServerError with `statusCode: 403` and no code in
+ * the message, while GatewayAuthenticationError carries no `statusCode` at all.
+ *
+ * The message checks are a fallback for providers that surface plain Errors.
+ *
+ * This deliberately returns a verdict rather than throwing: the workflow layer
+ * owns the mapping onto WDK's FatalError / RetryableError, and this package
+ * does not depend on `workflow`.
+ */
+export function classifyAIError(error: unknown): ClassifiedAIError {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (GatewayError.isInstance(error) || APICallError.isInstance(error)) {
+    return {
+      classification: error.isRetryable ? "retryable" : "fatal",
+      reason: "provider",
+      message,
+    };
+  }
+
+  if (message.includes("429")) {
+    return { classification: "retryable", reason: "rate-limited", message };
+  }
+
+  if (message.includes("401") || message.includes("403")) {
+    return { classification: "fatal", reason: "authentication", message };
+  }
+
+  return { classification: "unknown", reason: "unknown", message };
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -2,6 +2,7 @@ export type { LanguageModelUsage } from "ai";
 
 export * from "./config";
 export * from "./embedding";
+export * from "./errors";
 export * from "./generate-hero-image";
 export * from "./generate-post";
 export * from "./queries";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,22 +115,22 @@ importers:
         version: 21.0.1
       '@semantic-release/changelog':
         specifier: 6.0.3
-        version: 6.0.3(semantic-release@25.0.3(typescript@7.0.2))
+        version: 6.0.3(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
       '@semantic-release/commit-analyzer':
         specifier: 13.0.1
-        version: 13.0.1(semantic-release@25.0.3(typescript@7.0.2))
+        version: 13.0.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
       '@semantic-release/exec':
         specifier: 7.1.0
-        version: 7.1.0(semantic-release@25.0.3(typescript@7.0.2))
+        version: 7.1.0(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))(supports-color@8.1.1)
       '@semantic-release/git':
         specifier: 10.0.1
-        version: 10.0.1(semantic-release@25.0.3(typescript@7.0.2))
+        version: 10.0.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))(supports-color@8.1.1)
       '@semantic-release/github':
         specifier: 12.0.8
-        version: 12.0.8(semantic-release@25.0.3(typescript@7.0.2))
+        version: 12.0.8(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
       '@semantic-release/release-notes-generator':
         specifier: 14.1.1
-        version: 14.1.1(semantic-release@25.0.3(typescript@7.0.2))
+        version: 14.1.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -154,7 +154,7 @@ importers:
         version: 0.15.5
       semantic-release:
         specifier: 25.0.3
-        version: 25.0.3(typescript@7.0.2)
+        version: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
       turbo:
         specifier: 2.10.9
         version: 2.10.9
@@ -238,6 +238,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@ai-sdk/gateway':
+        specifier: 'catalog:'
+        version: 4.0.46(zod@4.4.3)
       '@ai-sdk/otel':
         specifier: 'catalog:'
         version: 1.0.58(zod@4.4.3)
@@ -246,7 +249,7 @@ importers:
         version: 1.7.0-rc.4(@better-auth/core@1.7.0-rc.4(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3))
       '@flags-sdk/vercel':
         specifier: 1.4.6
-        version: 1.4.6(@aws-sdk/credential-provider-web-identity@3.972.49)(flags@4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 1.4.6(@aws-sdk/credential-provider-web-identity@3.972.49)(flags@4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       '@gravity-ui/icons':
         specifier: 2.18.0
         version: 2.18.0(react@19.2.6)
@@ -303,7 +306,7 @@ importers:
         version: 1.38.0
       '@vercel/analytics':
         specifier: 1.6.1
-        version: 1.6.1(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.6.1(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@vercel/config':
         specifier: 0.0.30
         version: 0.0.30
@@ -315,7 +318,7 @@ importers:
         version: 1.1.0
       '@vercel/speed-insights':
         specifier: 1.3.1
-        version: 1.3.1(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.3.1(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       adm-zip:
         specifier: 0.6.0
         version: 0.6.0
@@ -324,10 +327,10 @@ importers:
         version: 7.0.58(zod@4.4.3)
       better-auth:
         specifier: 'catalog:'
-        version: 1.7.0-rc.4(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3))(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6)
+        version: 1.7.0-rc.4(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3))(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6)
       botid:
         specifier: 1.5.11
-        version: 1.5.11(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.5.11(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       date-fns:
         specifier: 'catalog:'
         version: 4.1.0
@@ -345,7 +348,7 @@ importers:
         version: 4.4.0
       flags:
         specifier: 4.3.0
-        version: 4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       framer-motion:
         specifier: 12.38.0
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -360,16 +363,16 @@ importers:
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: 'catalog:'
-        version: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl:
         specifier: 4.12.0
-        version: 4.12.0(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
+        version: 4.12.0(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       next-mdx-remote:
         specifier: 6.0.0
         version: 6.0.0(@types/react@19.2.14)(react@19.2.6)
       nuqs:
         specifier: 2.8.9
-        version: 2.8.9(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.8.9(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       papaparse:
         specifier: 5.5.3
         version: 5.5.3
@@ -423,7 +426,7 @@ importers:
         version: 1.29.0
       workflow:
         specifier: 5.0.0-beta.46
-        version: 5.0.0-beta.46(@aws-sdk/credential-provider-web-identity@3.972.49)(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.2)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2)(ws@8.20.0)
+        version: 5.0.0-beta.46(@aws-sdk/credential-provider-web-identity@3.972.49)(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.2)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2)(ws@8.20.0)
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -433,13 +436,13 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: 7.29.6
-        version: 7.29.6
+        version: 7.29.6(supports-color@8.1.1)
       '@babel/preset-env':
         specifier: 7.29.5
-        version: 7.29.5(@babel/core@7.29.6)
+        version: 7.29.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/preset-typescript':
         specifier: 7.28.5
-        version: 7.28.5(@babel/core@7.29.6)
+        version: 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
       '@next/playwright':
         specifier: 16.3.0
         version: 16.3.0(@playwright/test@1.60.0)
@@ -451,7 +454,7 @@ importers:
         version: 2.0.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@rolldown/plugin-babel':
         specifier: 0.2.3
-        version: 0.2.3(@babel/core@7.29.6)(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+        version: 0.2.3(@babel/core@7.29.6(supports-color@8.1.1))(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       '@tailwindcss/forms':
         specifier: 0.5.11
         version: 0.5.11(tailwindcss@4.3.0)
@@ -490,7 +493,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6)(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6(supports-color@8.1.1))(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.6(vitest@4.1.6)
@@ -502,7 +505,7 @@ importers:
         version: 1.0.0
       jsdom:
         specifier: 26.1.0
-        version: 26.1.0
+        version: 26.1.0(supports-color@8.1.1)
       postcss:
         specifier: 8.5.23
         version: 8.5.23
@@ -9587,16 +9590,16 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.6':
+  '@babel/core@7.29.6(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -9635,29 +9638,29 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.6)':
+  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.6)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.6)':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.6)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -9672,31 +9675,31 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.6)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9706,27 +9709,27 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.6)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.6)':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -9744,7 +9747,7 @@ snapshots:
   '@babel/helper-wrap-function@7.28.6':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -9758,515 +9761,515 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.6)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.6)':
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.6)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.6)':
+  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6)
-      '@babel/traverse': 7.29.7
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.6)':
-    dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.6)
-      '@babel/traverse': 7.29.7
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.29.7
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.6)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.6)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.6)':
-    dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.6)':
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.6(supports-color@8.1.1))':
+    dependencies:
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.6)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6)
-      '@babel/traverse': 7.29.7
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/traverse': 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.6)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.6)':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.6)':
+  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.6)':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.6)':
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.5(@babel/core@7.29.6)':
+  '@babel/preset-env@7.29.5(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       '@babel/compat-data': 7.29.3
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.6)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.6)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6)
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.6)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.6)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.6)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.6)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.6)
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.6)
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.6)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.6)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.6)
-      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.6)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.6)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.6(supports-color@8.1.1))
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.6(supports-color@8.1.1))
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.6(supports-color@8.1.1))
       core-js-compat: 3.49.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.6)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.7
       esutils: 2.0.3
 
-  '@babel/preset-typescript@7.28.5(@babel/core@7.29.6)':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.6(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.6)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.6)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.6(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -10278,7 +10281,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -10834,10 +10837,10 @@ snapshots:
       lodash.isundefined: 3.0.1
       lodash.uniq: 4.5.0
 
-  '@flags-sdk/vercel@1.4.6(@aws-sdk/credential-provider-web-identity@3.972.49)(flags@4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@flags-sdk/vercel@1.4.6(@aws-sdk/credential-provider-web-identity@3.972.49)(flags@4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
-      '@vercel/flags-core': 1.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
-      flags: 4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@vercel/flags-core': 1.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+      flags: 4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
       - '@openfeature/server-sdk'
@@ -12280,9 +12283,9 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6)(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6(supports-color@8.1.1))(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
       picomatch: 4.0.4
       rolldown: 1.0.0
     optionalDependencies:
@@ -12306,15 +12309,15 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
-  '@semantic-release/changelog@6.0.3(semantic-release@25.0.3(typescript@7.0.2))':
+  '@semantic-release/changelog@6.0.3(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
       fs-extra: 11.3.5
       lodash: 4.18.1
-      semantic-release: 25.0.3(typescript@7.0.2)
+      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
 
-  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.3(typescript@7.0.2))':
+  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))':
     dependencies:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-writer: 8.4.0
@@ -12324,7 +12327,7 @@ snapshots:
       import-from-esm: 2.0.0
       lodash-es: 4.18.1
       micromatch: 4.0.8
-      semantic-release: 25.0.3(typescript@7.0.2)
+      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12332,7 +12335,7 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/exec@7.1.0(semantic-release@25.0.3(typescript@7.0.2))':
+  '@semantic-release/exec@7.1.0(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))(supports-color@8.1.1)':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 3.1.0
@@ -12340,11 +12343,11 @@ snapshots:
       execa: 9.6.1
       lodash-es: 4.18.1
       parse-json: 8.3.0
-      semantic-release: 25.0.3(typescript@7.0.2)
+      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/git@10.0.1(semantic-release@25.0.3(typescript@7.0.2))':
+  '@semantic-release/git@10.0.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))(supports-color@8.1.1)':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -12354,11 +12357,11 @@ snapshots:
       lodash: 4.18.1
       micromatch: 4.0.8
       p-reduce: 2.1.0
-      semantic-release: 25.0.3(typescript@7.0.2)
+      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@12.0.8(semantic-release@25.0.3(typescript@7.0.2))':
+  '@semantic-release/github@12.0.8(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
@@ -12374,14 +12377,14 @@ snapshots:
       lodash-es: 4.18.1
       mime: 4.1.0
       p-filter: 4.1.0
-      semantic-release: 25.0.3(typescript@7.0.2)
+      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
       tinyglobby: 0.2.16
       undici: 7.29.0
       url-join: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/npm@13.1.5(semantic-release@25.0.3(typescript@7.0.2))':
+  '@semantic-release/npm@13.1.5(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))':
     dependencies:
       '@actions/core': 3.0.1
       '@semantic-release/error': 4.0.0
@@ -12396,11 +12399,11 @@ snapshots:
       rc: 1.2.8
       read-pkg: 10.1.0
       registry-auth-token: 5.1.1
-      semantic-release: 25.0.3(typescript@7.0.2)
+      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
       semver: 7.8.0
       tempy: 3.2.0
 
-  '@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.3(typescript@7.0.2))':
+  '@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))':
     dependencies:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-writer: 8.4.0
@@ -12410,7 +12413,7 @@ snapshots:
       import-from-esm: 2.0.0
       lodash-es: 4.18.1
       read-package-up: 11.0.0
-      semantic-release: 25.0.3(typescript@7.0.2)
+      semantic-release: 25.0.3(supports-color@8.1.1)(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12934,9 +12937,9 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@1.6.1(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@1.6.1(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@vercel/blob@2.3.3':
@@ -12968,14 +12971,14 @@ snapshots:
       pretty-cache-header: 1.0.0
       zod: 3.25.76
 
-  '@vercel/flags-core@1.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
+  '@vercel/flags-core@1.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
       '@vercel/functions': 3.5.1(@aws-sdk/credential-provider-web-identity@3.972.49)
       '@vercel/oidc': 3.5.0
       jose: 5.2.1
       js-xxhash: 4.0.0
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
 
@@ -13006,7 +13009,7 @@ snapshots:
 
   '@vercel/queue@0.5.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@vercel/oidc': 3.5.0
+      '@vercel/oidc': 3.8.5
       minimatch: 10.2.5
       mixpart: 0.0.6
       picocolors: 1.1.1
@@ -13017,17 +13020,17 @@ snapshots:
     optionalDependencies:
       ajv: 6.15.0
 
-  '@vercel/speed-insights@1.3.1(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/speed-insights@1.3.1(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
-  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6)(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.6(supports-color@8.1.1))(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.6)(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.6(supports-color@8.1.1))(@babel/runtime@7.29.2)(rolldown@1.0.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       babel-plugin-react-compiler: 1.0.0
 
   '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
@@ -13231,7 +13234,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@workflow/next@5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(ws@8.20.0)':
+  '@workflow/next@5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(ws@8.20.0)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
       '@workflow/builders': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
@@ -13241,7 +13244,7 @@ snapshots:
       ignore: 7.0.5
       semver: 7.7.4
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -13666,27 +13669,27 @@ snapshots:
 
   b4a@1.8.1: {}
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.6):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@babel/compat-data': 7.29.3
-      '@babel/core': 7.29.6
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.6):
+  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.6(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.6):
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.6(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.29.6
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.6)
+      '@babel/core': 7.29.6(supports-color@8.1.1)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.6(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13708,7 +13711,7 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.7.0-rc.4(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3))(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6):
+  better-auth@1.7.0-rc.4(@opentelemetry/api@1.9.1)(drizzle-kit@1.0.0-rc.4)(drizzle-orm@1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3))(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.6):
     dependencies:
       '@better-auth/core': 1.7.0-rc.4(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.7.0-rc.4(@better-auth/core@1.7.0-rc.4(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3))
@@ -13730,7 +13733,7 @@ snapshots:
     optionalDependencies:
       drizzle-kit: 1.0.0-rc.4
       drizzle-orm: 1.0.0-rc.4(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(zod@4.4.3)
-      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(jsdom@26.1.0)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
@@ -13787,9 +13790,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  botid@1.5.11(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  botid@1.5.11(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   bottleneck@2.19.5: {}
@@ -14782,13 +14785,13 @@ snapshots:
       semver-regex: 4.0.5
       super-regex: 1.1.0
 
-  flags@4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  flags@4.3.0(@opentelemetry/api@1.9.1)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@edge-runtime/cookies': 5.0.2
       jose: 5.10.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -15234,7 +15237,7 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -15253,7 +15256,7 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -15491,14 +15494,14 @@ snapshots:
 
   jsbi@4.3.2: {}
 
-  jsdom@26.1.0:
+  jsdom@26.1.0(supports-color@8.1.1):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -16334,14 +16337,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.12.0: {}
 
-  next-intl@4.12.0(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2):
+  next-intl@4.12.0(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.7
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
       icu-minify: 4.12.0
       negotiator: 1.0.0
-      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-intl-swc-plugin-extractor: 4.12.0
       po-parser: 2.1.1
       react: 19.2.6
@@ -16370,7 +16373,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -16379,7 +16382,7 @@ snapshots:
       postcss: 8.5.23
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(@babel/core@7.29.6)(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.6(supports-color@8.1.1))(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.3.0
       '@next/swc-darwin-x64': 16.3.0
@@ -16407,7 +16410,7 @@ snapshots:
       postcss: 8.5.23
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(@babel/core@7.29.6)(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.6(supports-color@8.1.1))(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.3.0
       '@next/swc-darwin-x64': 16.3.0
@@ -16481,12 +16484,12 @@ snapshots:
     dependencies:
       esm-env: 1.2.2
 
-  nuqs@2.8.9(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  nuqs@2.8.9(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.6
     optionalDependencies:
-      next: 16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   nwsapi@2.2.23: {}
 
@@ -17372,13 +17375,13 @@ snapshots:
     dependencies:
       parseley: 0.12.1
 
-  semantic-release@25.0.3(typescript@7.0.2):
+  semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2):
     dependencies:
-      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.3(typescript@7.0.2))
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 12.0.8(semantic-release@25.0.3(typescript@7.0.2))
-      '@semantic-release/npm': 13.1.5(semantic-release@25.0.3(typescript@7.0.2))
-      '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.3(typescript@7.0.2))
+      '@semantic-release/github': 12.0.8(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
+      '@semantic-release/npm': 13.1.5(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
+      '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.3(supports-color@8.1.1)(typescript@7.0.2))
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.1(typescript@7.0.2)
       debug: 4.4.3(supports-color@8.1.1)
@@ -17738,12 +17741,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.6)(react@19.2.6):
+  styled-jsx@5.1.6(@babel/core@7.29.6(supports-color@8.1.1))(react@19.2.6):
     dependencies:
       client-only: 0.0.1
       react: 19.2.6
     optionalDependencies:
-      '@babel/core': 7.29.6
+      '@babel/core': 7.29.6(supports-color@8.1.1)
 
   super-regex@1.1.0:
     dependencies:
@@ -18288,7 +18291,7 @@ snapshots:
       '@types/node': 24.13.2
       '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
       '@vitest/ui': 4.1.6(vitest@4.1.6)
-      jsdom: 26.1.0
+      jsdom: 26.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - msw
 
@@ -18341,14 +18344,14 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@5.0.0-beta.46(@aws-sdk/credential-provider-web-identity@3.972.49)(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.2)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2)(ws@8.20.0):
+  workflow@5.0.0-beta.46(@aws-sdk/credential-provider-web-identity@3.972.49)(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.2)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(typescript@7.0.2)(ws@8.20.0):
     dependencies:
       '@workflow/astro': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)
       '@workflow/cli': 5.0.0-beta.46(@aws-sdk/credential-provider-web-identity@3.972.49)(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(react@19.2.6)(ws@8.20.0)
       '@workflow/core': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(ws@8.20.0)
       '@workflow/errors': 5.0.0-beta.18
       '@workflow/nest': 5.0.0-beta.46(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(ws@8.20.0)
-      '@workflow/next': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(ws@8.20.0)
+      '@workflow/next': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(ws@8.20.0)
       '@workflow/nitro': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(react@19.2.6)(ws@8.20.0)
       '@workflow/nuxt': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(magicast@0.5.2)(react@19.2.6)(ws@8.20.0)
       '@workflow/rollup': 5.0.0-beta.46(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.20.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,7 +221,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
-        version: 1.29.0(zod@4.4.3)
+        version: 1.29.0(supports-color@8.1.1)(zod@4.4.3)
       '@vercel/related-projects':
         specifier: 'catalog:'
         version: 1.1.0
@@ -238,9 +238,6 @@ importers:
 
   apps/web:
     dependencies:
-      '@ai-sdk/gateway':
-        specifier: 'catalog:'
-        version: 4.0.46(zod@4.4.3)
       '@ai-sdk/otel':
         specifier: 'catalog:'
         version: 1.0.58(zod@4.4.3)
@@ -505,7 +502,7 @@ importers:
         version: 1.0.0
       jsdom:
         specifier: 26.1.0
-        version: 26.1.0(supports-color@8.1.1)
+        version: 26.1.0
       postcss:
         specifier: 8.5.23
         version: 8.5.23
@@ -11167,7 +11164,7 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.6
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
       ajv: 8.20.0
@@ -11177,8 +11174,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.8
-      express: 5.2.1
-      express-rate-limit: 8.5.1(express@5.2.1)
+      express: 5.2.1(supports-color@8.1.1)
+      express-rate-limit: 8.5.1(express@5.2.1(supports-color@8.1.1))
       hono: 4.12.18
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -13368,7 +13365,7 @@ snapshots:
   '@workflow/web@5.0.0-beta.46(@opentelemetry/api@1.9.1)(react@19.2.6)':
     dependencies:
       '@workflow/world-local': 5.0.0-beta.40(@opentelemetry/api@1.9.1)
-      express: 5.2.1
+      express: 5.2.1(supports-color@8.1.1)
       swr: 2.5.1(react@19.2.6)
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -13776,7 +13773,7 @@ snapshots:
 
   bluebird@3.4.7: {}
 
-  body-parser@2.2.2:
+  body-parser@2.2.2(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -14643,15 +14640,15 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.5.1(express@5.2.1):
+  express-rate-limit@8.5.1(express@5.2.1(supports-color@8.1.1)):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@8.1.1)
       ip-address: 10.2.0
 
-  express@5.2.1:
+  express@5.2.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.2.2(supports-color@8.1.1)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -14661,7 +14658,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -14672,8 +14669,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.1
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.1(supports-color@8.1.1)
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
@@ -14757,7 +14754,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -15237,7 +15234,7 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2(supports-color@8.1.1):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -15256,7 +15253,7 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@7.0.6(supports-color@8.1.1):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -15494,14 +15491,14 @@ snapshots:
 
   jsbi@4.3.2: {}
 
-  jsdom@26.1.0(supports-color@8.1.1):
+  jsdom@26.1.0:
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -17315,7 +17312,7 @@ snapshots:
 
   rou3@0.7.12: {}
 
-  router@2.2.0:
+  router@2.2.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
@@ -17427,7 +17424,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -17448,7 +17445,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18291,7 +18288,7 @@ snapshots:
       '@types/node': 24.13.2
       '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
       '@vitest/ui': 4.1.6(vitest@4.1.6)
-      jsdom: 26.1.0(supports-color@8.1.1)
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
- Add `classifyAIError` to `@motormetrics/ai`, next to the code that chooses the provider — which errors are possible follows from that choice
- Classify with the providers' own guards (`GatewayError.isInstance`, `APICallError.isInstance`) and their computed `isRetryable`, rather than reading status codes by hand
- Keep the WDK mapping in `handleAIError`, so `packages/ai` stays free of the `workflow` runtime and `apps/web` needs no new dependency
- Log the underlying message on every path, including the rethrow, so the cause reaches the runtime logs instead of collapsing to `USER_ERROR`

Found while running `coeWorkflow` on a preview deployment. The AI Gateway rejects `openai/gpt-5.6-luna` with the message "Free tier users do not have access to this model" — no code in the text — so the previous message-only check fell through to the rethrow, WDK retried a fatal error three times, and nothing but `USER_ERROR` was ever logged.

Neither matching on the message nor reading `statusCode` is reliable here. The free-tier rejection arrives as a `GatewayInternalServerError` carrying `statusCode: 403`, and a credential failure arrives as `GatewayAuthenticationError` — which reported no `statusCode` at all in the run I observed. Both have `isRetryable: false`, which `GatewayError` derives from the status, so the free-tier error is fatal while a genuine 500 still retries.

Tests split along the same seam: classification against real gateway error instances in `packages/ai`, the verdict-to-WDK mapping in `apps/web`.

The underlying gateway free-tier restriction is separate and still open — this only makes it diagnosable and stops it burning three retries.