### PR TITLE
Run lint, typecheck and test as parallel steps in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,10 +32,13 @@ jobs:
       UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
       BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
       BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
+      # PRs only check what the diff touches. The merge queue is the last gate
+      # before main, so it runs the full suite.
+      AFFECTED: ${{ github.event_name == 'pull_request' && '--affected' || '' }}
       # --affected defaults to a local `main` branch, which does not exist on a
-      # PR or merge queue checkout. Pin the range to the event payload instead.
-      TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-      TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+      # PR checkout. Pin the range to the event payload instead.
+      TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
+      TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha }}
 
     steps:
       - name: Checkout
@@ -63,15 +66,12 @@ jobs:
       # Parallel steps (GitHub Actions, 2026-06-25): one checkout + install, then
       # lint, typecheck and test run concurrently.
       # https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/
-      # 33% each so the three turbo processes together roughly saturate the
-      # 4 vCPU runner rather than oversubscribing it. Unmeasured -- retune if
-      # the job gets slower than the single `turbo run test lint` it replaced.
       - parallel:
           - name: Lint
-            run: pnpm turbo run lint --affected --concurrency=33%
+            run: pnpm turbo run lint $AFFECTED
 
           - name: Typecheck
-            run: pnpm turbo run typecheck --affected --concurrency=33%
+            run: pnpm turbo run typecheck $AFFECTED
 
           - name: Test
-            run: pnpm turbo run test --affected --concurrency=33%
+            run: pnpm turbo run test $AFFECTED

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -60,5 +60,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run affected checks
-        run: pnpm turbo run test lint --affected --concurrency=100%
+      # Parallel steps (GitHub Actions, 2026-06-25): one checkout + install, then
+      # lint, typecheck and test run concurrently.
+      # https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/
+      # 33% each so the three turbo processes together roughly saturate the
+      # 4 vCPU runner rather than oversubscribing it. Unmeasured -- retune if
+      # the job gets slower than the single `turbo run test lint` it replaced.
+      - parallel:
+          - name: Lint
+            run: pnpm turbo run lint --affected --concurrency=33%
+
+          - name: Typecheck
+            run: pnpm turbo run typecheck --affected --concurrency=33%
+
+          - name: Test
+            run: pnpm turbo run test --affected --concurrency=33%


### PR DESCRIPTION
- Split the single `turbo run test lint` invocation in `checks.yml` into a `parallel:` step group, using the [GitHub Actions parallel steps](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/) syntax shipped 2026-06-25
- Add `typecheck` to the job, which it never ran despite the task existing in `turbo.json`
- Scope `--affected` to pull requests via a job-level `AFFECTED` env var; the merge queue is the last gate before main, so it now runs the full suite. `TURBO_SCM_BASE`/`HEAD` drop their merge-group fallbacks accordingly
- Safe to split because `lint` has no `dependsOn` and `test` only `^test`, so the processes share no dependency tasks and duplicate no work
