### PR TITLE
Remove Upstash AI tracking from the web proxy

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,7 +40,6 @@
     "@opentelemetry/sdk-trace-node": "2.7.1",
     "@ruchernchong/number-format": "2.3.5",
     "@tanstack/react-table": "8.21.3",
-    "@upstash/agent-analytics": "0.1.3",
     "@upstash/ratelimit": "2.0.8",
     "@upstash/redis": "catalog:",
     "@vercel/analytics": "1.6.1",

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,24 +1,17 @@
 import crypto from "node:crypto";
 import { and, db, eq, gt, sessions } from "@motormetrics/database";
 import { redis } from "@motormetrics/utils";
-import { AgentAnalytics } from "@upstash/agent-analytics";
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import { auth } from "@web/app/admin/lib/auth";
 import { headers } from "next/headers";
-import {
-  type NextFetchEvent,
-  type NextRequest,
-  NextResponse,
-} from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 
 // Rate limiter for Developer API (60 requests per minute)
 const ratelimit = new Ratelimit({
   redis: Redis.fromEnv(),
   limiter: Ratelimit.slidingWindow(60, "1 m"),
 });
-
-const analytics = new AgentAnalytics({ redis: Redis.fromEnv() });
 
 interface AppConfig {
   maintenance: {
@@ -27,10 +20,8 @@ interface AppConfig {
   };
 }
 
-export async function proxy(request: NextRequest, event: NextFetchEvent) {
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
-
-  event.waitUntil(analytics.track(request));
 
   if (pathname.startsWith("/api/v1")) {
     const ip = request.headers.get("x-forwarded-for") ?? "127.0.0.1";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,9 +292,6 @@ importers:
       '@tanstack/react-table':
         specifier: 8.21.3
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@upstash/agent-analytics':
-        specifier: 0.1.3
-        version: 0.1.3(@upstash/redis@1.38.0)(typescript@7.0.2)
       '@upstash/ratelimit':
         specifier: 2.0.8
         version: 2.0.8(@upstash/redis@1.38.0)
@@ -4344,12 +4341,6 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
-
-  '@upstash/agent-analytics@0.1.3':
-    resolution: {integrity: sha512-ujoA3SIl/89ZiijuyJQpd6sGhBcHfwaugvG/VnTFH9/jYPkDfL2rmqCx1lnFMh6GdirWCWEKYTLxA0aW8QS9Rg==}
-    peerDependencies:
-      '@upstash/redis': ^1.38.0
-      typescript: '>=5'
 
   '@upstash/core-analytics@0.0.10':
     resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
@@ -12915,11 +12906,6 @@ snapshots:
     optional: true
 
   '@ungap/structured-clone@1.3.1': {}
-
-  '@upstash/agent-analytics@0.1.3(@upstash/redis@1.38.0)(typescript@7.0.2)':
-    dependencies:
-      '@upstash/redis': 1.38.0
-      typescript: 7.0.2
 
   '@upstash/core-analytics@0.0.10':
     dependencies:


### PR DESCRIPTION
- Drop `@upstash/agent-analytics` and its `analytics.track(request)` call from `apps/web/src/proxy.ts`, along with the `NextFetchEvent` parameter it was the only consumer of
- Remove the dependency from `apps/web/package.json` and prune it from the lockfile
- Keep `@upstash/ratelimit` (guards `/api/v1`) and `@upstash/redis` (rate limiter, checksum cache, maintenance config) untouched
- Leave the catalog `@upstash/redis` at 1.38.0 — the bump came in with this feature but `@upstash/ratelimit` resolves against it fine, so downgrading would be needless churn
- No Redis cleanup needed: tracked event hashes carry a 28-day TTL and expire on their own

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790870323&installation_model_id=21947&pr_number=952&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F952&signature=f315d346c70253aa2bf0fe4f2e1905af5fcce63dcc3294f8812a063ec842ca85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->