### PR TITLE
Ingest LTA DataMall's EV charging points dataset

### DIFF
--- a/apps/web/src/app/api/workflows/ev-charging/route.ts
+++ b/apps/web/src/app/api/workflows/ev-charging/route.ts
@@ -1,0 +1,17 @@
+import { WORKFLOW_REGION } from "@web/config/workflow";
+import { evChargingWorkflow } from "@web/workflows/ev-charging";
+import { start } from "workflow/api";
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const run = await start(evChargingWorkflow, { region: WORKFLOW_REGION });
+
+  return Response.json(
+    { message: "Workflow started", runId: run.runId },
+    { headers: { "X-Run-Id": run.runId } },
+  );
+}

--- a/apps/web/src/lib/cache-tags/ev-charging.ts
+++ b/apps/web/src/lib/cache-tags/ev-charging.ts
@@ -1,0 +1,2 @@
+/** Every EV charging query shares one tag; the source refreshes quarterly. */
+export const EV_CHARGING_CACHE_TAG = "ev-charging";

--- a/apps/web/src/lib/cache-tags/index.ts
+++ b/apps/web/src/lib/cache-tags/index.ts
@@ -1,4 +1,5 @@
 export * from "./cars";
 export * from "./coe";
 export * from "./deregistrations";
+export * from "./ev-charging";
 export * from "./posts";

--- a/apps/web/src/lib/updater/process-csv.test.ts
+++ b/apps/web/src/lib/updater/process-csv.test.ts
@@ -184,6 +184,38 @@ describe("processCSV", () => {
     expect(config.transform("  hello  ", "name")).toBe("hello");
   });
 
+  it("should pass dynamicTyping through when disabled", async () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue("mock csv content");
+    const parseMock = vi.spyOn(Papa, "parse").mockReturnValue({
+      data: [],
+      errors: [],
+      meta: { fields: [] },
+    } as never);
+
+    await processCsv(filePath, { dynamicTyping: false });
+
+    expect(parseMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ dynamicTyping: false }),
+    );
+  });
+
+  it("should pass non-string values through transform untouched", async () => {
+    vi.spyOn(fs, "readFileSync").mockReturnValue("mock csv content");
+    const parseMock = vi.spyOn(Papa, "parse").mockReturnValue({
+      data: [],
+      errors: [],
+      meta: { fields: [] },
+    } as never);
+
+    await processCsv(filePath);
+
+    const config = parseMock.mock.calls[0][1] as {
+      transform: (value: unknown, field: string) => unknown;
+    };
+    expect(config.transform(42, "age")).toBe(42);
+  });
+
   it("should return an empty array if no records are found", async () => {
     const _readFileSyncMock = vi
       .spyOn(fs, "readFileSync")

--- a/apps/web/src/lib/updater/services/process-csv.ts
+++ b/apps/web/src/lib/updater/services/process-csv.ts
@@ -4,6 +4,12 @@ import Papa, { type ParseConfig } from "papaparse";
 export interface CSVTransformOptions<_T> {
   fields?: Record<string, (value: string) => unknown>;
   columnMapping?: Record<string, string>;
+  /**
+   * PapaParse dynamic typing. Defaults to true. Disable for files where
+   * numeric-looking strings must survive intact, such as postal codes with
+   * leading zeros.
+   */
+  dynamicTyping?: boolean;
 }
 
 export async function processCsv<T>(
@@ -12,11 +18,11 @@ export async function processCsv<T>(
 ) {
   const fileContent = fs.readFileSync(filePath, "utf-8");
 
-  const { fields = {}, columnMapping = {} } = options;
+  const { fields = {}, columnMapping = {}, dynamicTyping = true } = options;
 
   const parseConfig: ParseConfig<T> = {
     header: true,
-    dynamicTyping: true,
+    dynamicTyping,
     skipEmptyLines: true,
     transformHeader: (header) => columnMapping[header] || header,
     transform: (value, field) => {

--- a/apps/web/src/workflows/ev-charging/ev-charging.test.ts
+++ b/apps/web/src/workflows/ev-charging/ev-charging.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@motormetrics/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@motormetrics/utils")>()),
+  redis: {
+    set: vi.fn(),
+  },
+}));
+
+vi.mock("@web/workflows/ev-charging/steps/process-data", () => ({
+  updateEvChargingPoints: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn(),
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}));
+
+vi.mock("workflow", () => ({
+  getWritable: vi.fn(() => ({
+    getWriter: () => ({
+      write: vi.fn().mockResolvedValue(undefined),
+      releaseLock: vi.fn(),
+    }),
+  })),
+  FatalError: class FatalError extends Error {},
+  RetryableError: class RetryableError extends Error {},
+}));
+
+import { redis } from "@motormetrics/utils";
+import {
+  evChargingWorkflow,
+  LAST_UPDATED_EV_CHARGING_KEY,
+} from "@web/workflows/ev-charging";
+import { updateEvChargingPoints } from "@web/workflows/ev-charging/steps/process-data";
+import { revalidateTag } from "next/cache";
+
+describe("evChargingWorkflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return early without revalidating when no records are processed", async () => {
+    vi.mocked(updateEvChargingPoints).mockResolvedValueOnce({
+      recordsProcessed: 0,
+      table: "ev_charging_points",
+      message: "",
+      timestamp: "",
+    });
+
+    const result = await evChargingWorkflow();
+
+    expect(result.message).toBe("No EV charging point records processed.");
+    expect(redis.set).not.toHaveBeenCalled();
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it("should update redis timestamp and revalidate cache when records are processed", async () => {
+    vi.mocked(updateEvChargingPoints).mockResolvedValueOnce({
+      recordsProcessed: 42,
+      table: "ev_charging_points",
+      message: "",
+      timestamp: "",
+    });
+
+    const result = await evChargingWorkflow();
+
+    expect(redis.set).toHaveBeenCalledWith(
+      LAST_UPDATED_EV_CHARGING_KEY,
+      expect.any(Number),
+    );
+    expect(revalidateTag).toHaveBeenCalledWith("ev-charging", "max");
+    expect(result.message).toBe(
+      "[EV CHARGING] Data processed and cache revalidated successfully",
+    );
+  });
+});

--- a/apps/web/src/workflows/ev-charging/index.ts
+++ b/apps/web/src/workflows/ev-charging/index.ts
@@ -1,0 +1,56 @@
+import { redis } from "@motormetrics/utils";
+import type { UpdaterResult } from "@web/lib/updater";
+import { updateEvChargingPoints } from "@web/workflows/ev-charging/steps/process-data";
+import { emitEvent } from "@web/workflows/shared";
+import { revalidateTag } from "next/cache";
+
+export const EV_CHARGING_CACHE_TAG = "ev-charging";
+export const LAST_UPDATED_EV_CHARGING_KEY = "last_updated:ev-charging";
+
+/**
+ * EV charging points workflow using Vercel WDK.
+ *
+ * Ingests LTA DataMall's quarterly public charging point registry. The source
+ * is quarterly, so most runs are no-ops short-circuited by the updater's
+ * checksum cache.
+ */
+export async function evChargingWorkflow(): Promise<{ message: string }> {
+  "use workflow";
+
+  await emitEvent({ type: "step:start", step: "processEvChargingData" });
+  const result = await processEvChargingData();
+  await emitEvent({
+    type: "data:processed",
+    step: "processEvChargingData",
+    data: { recordsProcessed: result.recordsProcessed },
+  });
+
+  if (result.recordsProcessed === 0) {
+    return { message: "No EV charging point records processed." };
+  }
+
+  await emitEvent({ type: "step:start", step: "revalidateEvChargingCache" });
+  await revalidateEvChargingCache();
+  await emitEvent({
+    type: "cache:revalidated",
+    step: "revalidateEvChargingCache",
+  });
+
+  return {
+    message: "[EV CHARGING] Data processed and cache revalidated successfully",
+  };
+}
+
+async function processEvChargingData(): Promise<UpdaterResult> {
+  "use step";
+  const result = await updateEvChargingPoints();
+  if (result.recordsProcessed > 0) {
+    await redis.set(LAST_UPDATED_EV_CHARGING_KEY, Date.now());
+  }
+  return result;
+}
+
+async function revalidateEvChargingCache(): Promise<void> {
+  "use step";
+  revalidateTag(EV_CHARGING_CACHE_TAG, "max");
+}

--- a/apps/web/src/workflows/ev-charging/index.ts
+++ b/apps/web/src/workflows/ev-charging/index.ts
@@ -1,10 +1,10 @@
 import { redis } from "@motormetrics/utils";
+import { EV_CHARGING_CACHE_TAG } from "@web/lib/cache-tags";
 import type { UpdaterResult } from "@web/lib/updater";
 import { updateEvChargingPoints } from "@web/workflows/ev-charging/steps/process-data";
 import { emitEvent } from "@web/workflows/shared";
 import { revalidateTag } from "next/cache";
 
-export const EV_CHARGING_CACHE_TAG = "ev-charging";
 export const LAST_UPDATED_EV_CHARGING_KEY = "last_updated:ev-charging";
 
 /**

--- a/apps/web/src/workflows/ev-charging/steps/process-data.test.ts
+++ b/apps/web/src/workflows/ev-charging/steps/process-data.test.ts
@@ -1,0 +1,123 @@
+vi.mock("@motormetrics/database", () => ({
+  evChargingPoints: { name: "ev_charging_points" },
+}));
+
+vi.mock("@web/lib/updater", () => ({
+  update: vi.fn(),
+}));
+
+import { type UpdaterResult, update } from "@web/lib/updater";
+import {
+  toIsoDate,
+  toNumberOrNull,
+  toOutlets,
+  toPubliclyAccessible,
+  toTextOrNull,
+  updateEvChargingPoints,
+} from "./process-data";
+
+const mockResult = (overrides?: Partial<UpdaterResult>): UpdaterResult => ({
+  table: "ev_charging_points",
+  recordsProcessed: 0,
+  message: "",
+  timestamp: new Date().toISOString(),
+  ...overrides,
+});
+
+describe("updateEvChargingPoints", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should download the quarterly charging points archive", async () => {
+    vi.mocked(update).mockResolvedValueOnce(mockResult());
+
+    await updateEvChargingPoints();
+
+    expect(vi.mocked(update).mock.calls[0][0]).toMatchObject({
+      url: "https://datamall.lta.gov.sg/content/dam/datamall/datasets/Facts_Figures/Electric-Vehicle-Charging-Network/EVChargingPoints.zip",
+    });
+  });
+
+  it("should return the result from update", async () => {
+    const expected = mockResult({
+      recordsProcessed: 11353,
+      message: "11353 record(s) inserted",
+    });
+    vi.mocked(update).mockResolvedValueOnce(expected);
+
+    const result = await updateEvChargingPoints();
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(expected);
+  });
+
+  it("should keep postal codes intact by disabling dynamic typing", async () => {
+    vi.mocked(update).mockResolvedValueOnce(mockResult());
+
+    await updateEvChargingPoints();
+
+    const config = vi.mocked(update).mock.calls[0][0] as {
+      csvTransformOptions?: { dynamicTyping?: boolean };
+    };
+    expect(config.csvTransformOptions?.dynamicTyping).toBe(false);
+  });
+
+  it("should map the DataMall headers onto schema columns", async () => {
+    vi.mocked(update).mockResolvedValueOnce(mockResult());
+
+    await updateEvChargingPoints();
+
+    const config = vi.mocked(update).mock.calls[0][0] as {
+      csvTransformOptions?: { columnMapping?: Record<string, string> };
+    };
+    expect(config.csvTransformOptions?.columnMapping).toMatchObject({
+      "EV Charger Registration Code": "registrationCode",
+      "No. of Charging Outlets": "outlets",
+      "charging Speed": "chargingSpeedKw",
+      PostalCode: "postalCode",
+      "Is the charger publicly accessible?": "publiclyAccessible",
+      "Registration Date": "registrationDate",
+    });
+  });
+});
+
+describe("field transforms", () => {
+  it("should parse d/M/yyyy registration dates into ISO dates", () => {
+    expect(toIsoDate("10/6/2025")).toBe("2025-06-10");
+    expect(toIsoDate("14/02/2024")).toBe("2024-02-14");
+  });
+
+  it("should return null for blank or malformed registration dates", () => {
+    expect(toIsoDate("")).toBeNull();
+    expect(toIsoDate("   ")).toBeNull();
+    expect(toIsoDate("not a date")).toBeNull();
+    expect(toIsoDate("31/13/2025")).toBeNull();
+  });
+
+  it("should convert numeric strings and null out blanks", () => {
+    expect(toNumberOrNull("22")).toBe(22);
+    expect(toNumberOrNull("7.4")).toBe(7.4);
+    expect(toNumberOrNull("103.8525029")).toBe(103.8525029);
+    expect(toNumberOrNull("")).toBeNull();
+    expect(toNumberOrNull("n/a")).toBeNull();
+  });
+
+  it("should default outlets to 1 when missing", () => {
+    expect(toOutlets("2")).toBe(2);
+    expect(toOutlets("")).toBe(1);
+  });
+
+  it("should null out blank optional text such as parking lot type", () => {
+    expect(toTextOrNull("")).toBeNull();
+    expect(toTextOrNull("  ")).toBeNull();
+    expect(toTextOrNull(" B3 ")).toBe("B3");
+  });
+
+  it("should read the public accessibility flag", () => {
+    expect(toPubliclyAccessible("Yes")).toBe(true);
+    expect(toPubliclyAccessible("yes ")).toBe(true);
+    expect(toPubliclyAccessible("No")).toBe(false);
+    expect(toPubliclyAccessible("")).toBe(false);
+  });
+});

--- a/apps/web/src/workflows/ev-charging/steps/process-data.ts
+++ b/apps/web/src/workflows/ev-charging/steps/process-data.ts
@@ -1,0 +1,74 @@
+import { evChargingPoints } from "@motormetrics/database";
+import type { EvChargingPoint } from "@motormetrics/types";
+import { update } from "@web/lib/updater";
+import { format, isValid, parse } from "date-fns";
+
+const EV_CHARGING_POINTS_URL =
+  "https://datamall.lta.gov.sg/content/dam/datamall/datasets/Facts_Figures/Electric-Vehicle-Charging-Network/EVChargingPoints.zip";
+
+/** Registration dates arrive as `d/M/yyyy`; a handful of rows are malformed. */
+export const toIsoDate = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = parse(trimmed, "d/M/yyyy", new Date());
+  return isValid(parsed) ? format(parsed, "yyyy-MM-dd") : null;
+};
+
+export const toNumberOrNull = (value: string): number | null => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export const toTextOrNull = (value: string): string | null =>
+  value.trim() || null;
+
+export const toOutlets = (value: string): number => toNumberOrNull(value) ?? 1;
+
+export const toPubliclyAccessible = (value: string): boolean =>
+  value.trim().toLowerCase() === "yes";
+
+export const updateEvChargingPoints = () =>
+  update<EvChargingPoint>({
+    table: evChargingPoints,
+    url: EV_CHARGING_POINTS_URL,
+    csvTransformOptions: {
+      // Postal codes carry leading zeros, so keep every value a string and
+      // convert the numeric columns explicitly below.
+      dynamicTyping: false,
+      columnMapping: {
+        "EV Charger Registration Code": "registrationCode",
+        "No. of Charging Outlets": "outlets",
+        "charging Speed": "chargingSpeedKw",
+        PostalCode: "postalCode",
+        "Block/House No": "blockHouseNo",
+        "Street Name": "streetName",
+        "Building Name": "buildingName",
+        "Floor No": "floorNo",
+        "Lot No": "lotNo",
+        "Is the charger publicly accessible?": "publiclyAccessible",
+        "Registration Date": "registrationDate",
+        "Type of Parking Lot": "parkingLotType",
+      },
+      fields: {
+        outlets: toOutlets,
+        chargingSpeedKw: toNumberOrNull,
+        postalCode: toTextOrNull,
+        blockHouseNo: toTextOrNull,
+        streetName: toTextOrNull,
+        buildingName: toTextOrNull,
+        floorNo: toTextOrNull,
+        lotNo: toTextOrNull,
+        publiclyAccessible: toPubliclyAccessible,
+        longitude: toNumberOrNull,
+        latitude: toNumberOrNull,
+        registrationDate: toIsoDate,
+        parkingLotType: toTextOrNull,
+      },
+    },
+  });

--- a/apps/web/vercel.ts
+++ b/apps/web/vercel.ts
@@ -33,6 +33,10 @@ export const config: VercelConfig = {
       path: "/api/workflows/electric-vehicles",
       schedule: "30 10 * * *",
     },
+    {
+      path: "/api/workflows/ev-charging",
+      schedule: "0 10 * * *",
+    },
   ],
   regions: ["sin1"],
 };


### PR DESCRIPTION
- Add a WDK workflow, cron route and daily schedule that load the quarterly \`EVChargingPoints.zip\` through the existing updater, alongside the other DataMall workflows
- Map the file's awkward headers onto schema columns and parse \`d/M/yyyy\` registration dates, blanks and the public-access flag explicitly; unit tests cover each transform
- Let updater configs turn off PapaParse dynamic typing, since it strips the leading zero from six-digit postal codes
- Keep the cache tag in \`lib/cache-tags\` so page queries never import the workflow module
- Loads are insert-only via the updater's existing \`onConflictDoNothing\`, matching every other dataset; connectors that LTA later delists stay in the table until that is revisited