### PR TITLE
Lead the EV fleet panel with the public charging network

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/charging-network.test.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/charging-network.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { deriveChargingNetworkGrowth } from "./charging-network";
+
+describe("deriveChargingNetworkGrowth", () => {
+  it("should return null for an empty series", () => {
+    expect(deriveChargingNetworkGrowth([])).toBeNull();
+  });
+
+  it("should measure the last twelve months against the network a year earlier", () => {
+    const result = deriveChargingNetworkGrowth([
+      { month: "2024-02", count: 5000 },
+      { month: "2024-06", count: 1000 },
+      { month: "2025-06", count: 400 },
+      { month: "2025-12", count: 300 },
+      { month: "2026-06", count: 300 },
+    ]);
+
+    // Anchor is 2026-06, so the base is everything up to and including
+    // 2025-06: 6,400. Added since: 600.
+    expect(result).toEqual({
+      asOf: "2026-06",
+      addedLastYear: 600,
+      growthPercent: (600 / 6400) * 100,
+    });
+  });
+
+  it("should fold the registration backlog into the base, not the growth", () => {
+    const result = deriveChargingNetworkGrowth([
+      { month: "2024-02", count: 6000 },
+      { month: "2025-03", count: 100 },
+    ]);
+
+    expect(result?.growthPercent).toBeCloseTo((100 / 6000) * 100);
+  });
+
+  it("should return a null percentage when the series is shorter than a year", () => {
+    const result = deriveChargingNetworkGrowth([
+      { month: "2026-01", count: 50 },
+      { month: "2026-06", count: 70 },
+    ]);
+
+    expect(result).toEqual({
+      asOf: "2026-06",
+      addedLastYear: 120,
+      growthPercent: null,
+    });
+  });
+
+  it("should handle a December anchor when shifting the cutoff", () => {
+    const result = deriveChargingNetworkGrowth([
+      { month: "2024-12", count: 100 },
+      { month: "2025-12", count: 10 },
+    ]);
+
+    expect(result?.growthPercent).toBeCloseTo(10);
+  });
+});

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/charging-network.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/charging-network.ts
@@ -1,0 +1,51 @@
+import type { EvChargingMonthlyRegistrations } from "@web/queries/ev-charging";
+
+export interface ChargingNetworkGrowth {
+  /** Latest month with a registration, `yyyy-MM`. */
+  asOf: string;
+  /** Connectors registered in the twelve months ending at `asOf`. */
+  addedLastYear: number;
+  /** Percentage growth of the cumulative network over those twelve months. */
+  growthPercent: number | null;
+}
+
+const shiftMonth = (month: string, offset: number): string => {
+  const [year, monthPart] = month.split("-").map(Number);
+  const date = new Date(Date.UTC(year, monthPart - 1 + offset, 1));
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+};
+
+/**
+ * Twelve-month growth of the cumulative network, anchored on the data rather
+ * than on today because the source is a quarterly file.
+ *
+ * Growth is measured against the network size a year earlier, which folds the
+ * Feb 2024 registration backlog into the base instead of reading it as a
+ * spike. When there is no base yet — the series is shorter than a year — the
+ * percentage is null and callers should drop the chip.
+ */
+export function deriveChargingNetworkGrowth(
+  monthly: EvChargingMonthlyRegistrations[],
+): ChargingNetworkGrowth | null {
+  const latest = monthly.at(-1);
+  if (!latest) {
+    return null;
+  }
+
+  const cutoff = shiftMonth(latest.month, -12);
+  let base = 0;
+  let addedLastYear = 0;
+  for (const point of monthly) {
+    if (point.month <= cutoff) {
+      base += point.count;
+    } else {
+      addedLastYear += point.count;
+    }
+  }
+
+  return {
+    asOf: latest.month,
+    addedLastYear,
+    growthPercent: base > 0 ? (addedLastYear / base) * 100 : null,
+  };
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/ev-fleet-panel.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/ev-fleet-panel.tsx
@@ -1,13 +1,19 @@
 import { Typography } from "@heroui/react";
 import { NumberValue } from "@heroui-pro/react";
+import { formatDateToMonthYear } from "@motormetrics/utils";
+import { deriveChargingNetworkGrowth } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/components/charging-network";
 import { ELECTRIC_POPULATION_FUEL_TYPE } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/constants";
 import { InkPanel } from "@web/components/shared/bento";
 import { DeltaChip } from "@web/components/shared/delta-chip";
 import {
+  getEvChargingNetworkSummary,
+  getEvChargingRegistrationsByMonth,
+} from "@web/queries/ev-charging";
+import {
   getVehiclePopulationByYearAndFuelType,
   getVehiclePopulationYearlyTotals,
 } from "@web/queries/vehicle-population";
-import { ArrowUpRight, BatteryCharging } from "lucide-react";
+import { ArrowUpRight, BatteryCharging, PlugZap } from "lucide-react";
 import Link from "next/link";
 
 /**
@@ -26,18 +32,20 @@ const VES_BANDS = [
 /**
  * Closing panel of the right rail.
  *
- * The comp headlines this card with the size of the public charging network
- * (19,400 points, growing 31%, against a target of 60,000 by 2030). Nothing in
- * this repo can source that: LTA DataMall publishes an "Electric Vehicle
- * Charging Points" dataset, but it is not ingested, and the figure is not one
- * to invent. The panel keeps its shape and leads with the EV fleet from
- * `vehicle_population` instead — ingest that dataset to restore the original.
+ * Headlines the size of the public charging network, sourced from LTA
+ * DataMall's quarterly charging point registry, with the battery-electric
+ * fleet from `vehicle_population` as the supporting line. Until that registry
+ * has been ingested the fleet figure takes the headline instead, so the panel
+ * never shows an invented number.
  */
 export async function EvFleetPanel() {
-  const [populationByFuelType, populationTotals] = await Promise.all([
-    getVehiclePopulationByYearAndFuelType(),
-    getVehiclePopulationYearlyTotals(),
-  ]);
+  const [network, monthly, populationByFuelType, populationTotals] =
+    await Promise.all([
+      getEvChargingNetworkSummary(),
+      getEvChargingRegistrationsByMonth(),
+      getVehiclePopulationByYearAndFuelType(),
+      getVehiclePopulationYearlyTotals(),
+    ]);
 
   const electricByYear = new Map<string, number>();
   for (const row of populationByFuelType) {
@@ -54,42 +62,105 @@ export async function EvFleetPanel() {
   const [latest, previous] = populationTotals;
   const fleet = latest ? (electricByYear.get(latest.year) ?? 0) : 0;
   const previousFleet = previous ? (electricByYear.get(previous.year) ?? 0) : 0;
+  const fleetGrowth = previousFleet
+    ? ((fleet - previousFleet) / previousFleet) * 100
+    : 0;
+  const fleetShare = latest?.total ? (fleet / latest.total) * 100 : 0;
 
-  if (!latest || fleet === 0) {
+  const hasNetwork = network.connectors > 0;
+  const hasFleet = Boolean(latest) && fleet > 0;
+
+  if (!hasNetwork && !hasFleet) {
     return null;
   }
 
-  const growth = previousFleet
-    ? ((fleet - previousFleet) / previousFleet) * 100
-    : 0;
-  const fleetShare = latest.total ? (fleet / latest.total) * 100 : 0;
+  const growth = hasNetwork ? deriveChargingNetworkGrowth(monthly) : null;
+  const Icon = hasNetwork ? PlugZap : BatteryCharging;
 
   return (
     <InkPanel>
       <div className="flex items-center gap-2.5">
         <span className="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-accent-on-dark/20 text-accent-on-dark">
-          <BatteryCharging className="size-5" />
+          <Icon className="size-5" />
         </span>
         <Typography.Paragraph className="text-accent-foreground/85">
-          EV fleet on the road
+          {hasNetwork ? "Public charging network" : "EV fleet on the road"}
         </Typography.Paragraph>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3">
-        <span className="font-extrabold text-5xl text-accent-on-dark tabular-nums tracking-tight">
-          <NumberValue locale="en-SG" maximumFractionDigits={0} value={fleet} />
-        </span>
-        {previousFleet > 0 ? <DeltaChip tone="on-dark" value={growth} /> : null}
-      </div>
+      {hasNetwork ? (
+        <>
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="font-extrabold text-5xl text-accent-on-dark tabular-nums tracking-tight">
+              <NumberValue
+                locale="en-SG"
+                maximumFractionDigits={0}
+                value={network.connectors}
+              />
+            </span>
+            {growth?.growthPercent != null ? (
+              <DeltaChip tone="on-dark" value={growth.growthPercent} />
+            ) : null}
+          </div>
 
-      <Typography.Paragraph
-        color="muted"
-        size="sm"
-        className="text-accent-foreground/60"
-      >
-        battery-electric vehicles on Singapore roads · {fleetShare.toFixed(1)}%
-        of the vehicle population in {latest.year}
-      </Typography.Paragraph>
+          <Typography.Paragraph
+            color="muted"
+            size="sm"
+            className="text-accent-foreground/60"
+          >
+            public charging points across{" "}
+            <NumberValue
+              locale="en-SG"
+              maximumFractionDigits={0}
+              value={network.sites}
+            />{" "}
+            locations
+            {growth
+              ? ` · registered with LTA as of ${formatDateToMonthYear(growth.asOf)}`
+              : null}
+          </Typography.Paragraph>
+
+          {hasFleet ? (
+            <Typography.Paragraph
+              color="muted"
+              size="sm"
+              className="text-accent-foreground/60"
+            >
+              <NumberValue
+                locale="en-SG"
+                maximumFractionDigits={0}
+                value={fleet}
+              />{" "}
+              battery-electric vehicles on the road · {fleetShare.toFixed(1)}%
+              of the vehicle population in {latest?.year}
+            </Typography.Paragraph>
+          ) : null}
+        </>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="font-extrabold text-5xl text-accent-on-dark tabular-nums tracking-tight">
+              <NumberValue
+                locale="en-SG"
+                maximumFractionDigits={0}
+                value={fleet}
+              />
+            </span>
+            {previousFleet > 0 ? (
+              <DeltaChip tone="on-dark" value={fleetGrowth} />
+            ) : null}
+          </div>
+
+          <Typography.Paragraph
+            color="muted"
+            size="sm"
+            className="text-accent-foreground/60"
+          >
+            battery-electric vehicles on Singapore roads ·{" "}
+            {fleetShare.toFixed(1)}% of the vehicle population in {latest?.year}
+          </Typography.Paragraph>
+        </>
+      )}
 
       <ul className="flex flex-col gap-3">
         {VES_BANDS.map((row, index) => (

--- a/apps/web/src/app/(main)/(dashboard)/components/ev-momentum.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/ev-momentum.tsx
@@ -53,7 +53,7 @@ export async function EvMomentum() {
               isIconOnly: true,
               variant: "tertiary",
             })}
-            href="/cars/electric"
+            href="/cars/electric-vehicles"
           >
             <ArrowUpRight className="size-5" />
           </Link>

--- a/apps/web/src/queries/ev-charging/ev-charging.test.ts
+++ b/apps/web/src/queries/ev-charging/ev-charging.test.ts
@@ -15,7 +15,7 @@ describe("ev charging queries", () => {
 
   describe("getEvChargingNetworkSummary", () => {
     it("should return connector and site counts", async () => {
-      queueSelect([{ connectors: 11353, sites: 2816 }]);
+      queueSelect([{ value: 11353 }], [{ value: 2816 }]);
 
       const result = await getEvChargingNetworkSummary();
 
@@ -25,7 +25,7 @@ describe("ev charging queries", () => {
     });
 
     it("should return zeros when the table is empty", async () => {
-      queueSelect([]);
+      queueSelect([], []);
 
       const result = await getEvChargingNetworkSummary();
 
@@ -34,10 +34,11 @@ describe("ev charging queries", () => {
   });
 
   describe("getEvChargingRegistrationsByMonth", () => {
-    it("should return monthly registration counts", async () => {
+    it("should roll daily registration counts up to months, oldest first", async () => {
       queueSelect([
-        { month: "2024-02", count: 900 },
-        { month: "2024-03", count: 1200 },
+        { date: "2024-02-14", count: 500 },
+        { date: "2024-02-20", count: 400 },
+        { date: "2024-03-01", count: 1200 },
       ]);
 
       const result = await getEvChargingRegistrationsByMonth();

--- a/apps/web/src/queries/ev-charging/ev-charging.test.ts
+++ b/apps/web/src/queries/ev-charging/ev-charging.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  cacheLifeMock,
+  cacheTagMock,
+  queueSelect,
+  resetDbMocks,
+} from "../test-utils";
+import { getEvChargingNetworkSummary } from "./network-summary";
+import { getEvChargingRegistrationsByMonth } from "./registrations-by-month";
+
+describe("ev charging queries", () => {
+  beforeEach(() => {
+    resetDbMocks();
+  });
+
+  describe("getEvChargingNetworkSummary", () => {
+    it("should return connector and site counts", async () => {
+      queueSelect([{ connectors: 11353, sites: 2816 }]);
+
+      const result = await getEvChargingNetworkSummary();
+
+      expect(result).toEqual({ connectors: 11353, sites: 2816 });
+      expect(cacheLifeMock).toHaveBeenCalledWith("max");
+      expect(cacheTagMock).toHaveBeenCalledWith("ev-charging");
+    });
+
+    it("should return zeros when the table is empty", async () => {
+      queueSelect([]);
+
+      const result = await getEvChargingNetworkSummary();
+
+      expect(result).toEqual({ connectors: 0, sites: 0 });
+    });
+  });
+
+  describe("getEvChargingRegistrationsByMonth", () => {
+    it("should return monthly registration counts", async () => {
+      queueSelect([
+        { month: "2024-02", count: 900 },
+        { month: "2024-03", count: 1200 },
+      ]);
+
+      const result = await getEvChargingRegistrationsByMonth();
+
+      expect(result).toEqual([
+        { month: "2024-02", count: 900 },
+        { month: "2024-03", count: 1200 },
+      ]);
+      expect(cacheTagMock).toHaveBeenCalledWith("ev-charging");
+    });
+  });
+});

--- a/apps/web/src/queries/ev-charging/index.ts
+++ b/apps/web/src/queries/ev-charging/index.ts
@@ -1,0 +1,2 @@
+export * from "./network-summary";
+export * from "./registrations-by-month";

--- a/apps/web/src/queries/ev-charging/network-summary.ts
+++ b/apps/web/src/queries/ev-charging/network-summary.ts
@@ -22,7 +22,7 @@ export async function getEvChargingNetworkSummary(): Promise<EvChargingNetworkSu
     .from(evChargingPoints)
     .as("sites");
 
-  const [[connectorsRow], [sitesRow]] = await Promise.all([
+  const [[connectorsRow], [sitesRow]] = await db.batch([
     db.select({ value: count() }).from(evChargingPoints),
     db.select({ value: count() }).from(sites),
   ]);

--- a/apps/web/src/queries/ev-charging/network-summary.ts
+++ b/apps/web/src/queries/ev-charging/network-summary.ts
@@ -1,10 +1,4 @@
-import {
-  count,
-  countDistinct,
-  db,
-  evChargingPoints,
-  sql,
-} from "@motormetrics/database";
+import { count, db, evChargingPoints } from "@motormetrics/database";
 import { EV_CHARGING_CACHE_TAG } from "@web/lib/cache-tags";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -20,15 +14,21 @@ export async function getEvChargingNetworkSummary(): Promise<EvChargingNetworkSu
   cacheLife("max");
   cacheTag(EV_CHARGING_CACHE_TAG);
 
-  const [row] = await db
-    .select({
-      connectors: count(),
-      // A site is a coordinate pair; Postgres counts distinct row values.
-      sites: countDistinct(
-        sql`(${evChargingPoints.longitude}, ${evChargingPoints.latitude})`,
-      ),
+  const sites = db
+    .selectDistinct({
+      longitude: evChargingPoints.longitude,
+      latitude: evChargingPoints.latitude,
     })
-    .from(evChargingPoints);
+    .from(evChargingPoints)
+    .as("sites");
 
-  return { connectors: row?.connectors ?? 0, sites: row?.sites ?? 0 };
+  const [[connectorsRow], [sitesRow]] = await Promise.all([
+    db.select({ value: count() }).from(evChargingPoints),
+    db.select({ value: count() }).from(sites),
+  ]);
+
+  return {
+    connectors: connectorsRow?.value ?? 0,
+    sites: sitesRow?.value ?? 0,
+  };
 }

--- a/apps/web/src/queries/ev-charging/network-summary.ts
+++ b/apps/web/src/queries/ev-charging/network-summary.ts
@@ -1,4 +1,10 @@
-import { db, evChargingPoints, sql } from "@motormetrics/database";
+import {
+  count,
+  countDistinct,
+  db,
+  evChargingPoints,
+  sql,
+} from "@motormetrics/database";
 import { EV_CHARGING_CACHE_TAG } from "@web/lib/cache-tags";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -16,11 +22,11 @@ export async function getEvChargingNetworkSummary(): Promise<EvChargingNetworkSu
 
   const [row] = await db
     .select({
-      connectors: sql<number>`cast(count(*) as integer)`.mapWith(Number),
-      sites:
-        sql<number>`cast(count(distinct (${evChargingPoints.longitude}, ${evChargingPoints.latitude})) as integer)`.mapWith(
-          Number,
-        ),
+      connectors: count(),
+      // A site is a coordinate pair; Postgres counts distinct row values.
+      sites: countDistinct(
+        sql`(${evChargingPoints.longitude}, ${evChargingPoints.latitude})`,
+      ),
     })
     .from(evChargingPoints);
 

--- a/apps/web/src/queries/ev-charging/network-summary.ts
+++ b/apps/web/src/queries/ev-charging/network-summary.ts
@@ -1,0 +1,28 @@
+import { db, evChargingPoints, sql } from "@motormetrics/database";
+import { EV_CHARGING_CACHE_TAG } from "@web/lib/cache-tags";
+import { cacheLife, cacheTag } from "next/cache";
+
+export interface EvChargingNetworkSummary {
+  /** Registered public connectors. */
+  connectors: number;
+  /** Distinct charging locations, keyed on coordinates. */
+  sites: number;
+}
+
+export async function getEvChargingNetworkSummary(): Promise<EvChargingNetworkSummary> {
+  "use cache";
+  cacheLife("max");
+  cacheTag(EV_CHARGING_CACHE_TAG);
+
+  const [row] = await db
+    .select({
+      connectors: sql<number>`cast(count(*) as integer)`.mapWith(Number),
+      sites:
+        sql<number>`cast(count(distinct (${evChargingPoints.longitude}, ${evChargingPoints.latitude})) as integer)`.mapWith(
+          Number,
+        ),
+    })
+    .from(evChargingPoints);
+
+  return { connectors: row?.connectors ?? 0, sites: row?.sites ?? 0 };
+}

--- a/apps/web/src/queries/ev-charging/registrations-by-month.ts
+++ b/apps/web/src/queries/ev-charging/registrations-by-month.ts
@@ -1,4 +1,10 @@
-import { db, evChargingPoints, isNotNull, sql } from "@motormetrics/database";
+import {
+  count,
+  db,
+  evChargingPoints,
+  isNotNull,
+  sql,
+} from "@motormetrics/database";
 import { EV_CHARGING_CACHE_TAG } from "@web/lib/cache-tags";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -7,6 +13,9 @@ export interface EvChargingMonthlyRegistrations {
   month: string;
   count: number;
 }
+
+/** Calendar-month bucket for a registration date. */
+const monthExpr = sql<string>`to_char(${evChargingPoints.registrationDate}, 'YYYY-MM')`;
 
 /**
  * Connectors registered with LTA per month, oldest first.
@@ -23,15 +32,10 @@ export async function getEvChargingRegistrationsByMonth(): Promise<
   cacheLife("max");
   cacheTag(EV_CHARGING_CACHE_TAG);
 
-  const month = sql<string>`to_char(${evChargingPoints.registrationDate}, 'YYYY-MM')`;
-
   return db
-    .select({
-      month,
-      count: sql<number>`cast(count(*) as integer)`.mapWith(Number),
-    })
+    .select({ month: monthExpr, count: count() })
     .from(evChargingPoints)
     .where(isNotNull(evChargingPoints.registrationDate))
-    .groupBy(month)
-    .orderBy(month);
+    .groupBy(monthExpr)
+    .orderBy(monthExpr);
 }

--- a/apps/web/src/queries/ev-charging/registrations-by-month.ts
+++ b/apps/web/src/queries/ev-charging/registrations-by-month.ts
@@ -1,0 +1,37 @@
+import { db, evChargingPoints, isNotNull, sql } from "@motormetrics/database";
+import { EV_CHARGING_CACHE_TAG } from "@web/lib/cache-tags";
+import { cacheLife, cacheTag } from "next/cache";
+
+export interface EvChargingMonthlyRegistrations {
+  /** `yyyy-MM`. */
+  month: string;
+  count: number;
+}
+
+/**
+ * Connectors registered with LTA per month, oldest first.
+ *
+ * Registration under the charger scheme only began in Feb 2024, so the early
+ * months carry the backlog of chargers that already existed rather than new
+ * installations. Callers deriving growth should treat them as a base, not as
+ * a trend.
+ */
+export async function getEvChargingRegistrationsByMonth(): Promise<
+  EvChargingMonthlyRegistrations[]
+> {
+  "use cache";
+  cacheLife("max");
+  cacheTag(EV_CHARGING_CACHE_TAG);
+
+  const month = sql<string>`to_char(${evChargingPoints.registrationDate}, 'YYYY-MM')`;
+
+  return db
+    .select({
+      month,
+      count: sql<number>`cast(count(*) as integer)`.mapWith(Number),
+    })
+    .from(evChargingPoints)
+    .where(isNotNull(evChargingPoints.registrationDate))
+    .groupBy(month)
+    .orderBy(month);
+}

--- a/apps/web/src/queries/ev-charging/registrations-by-month.ts
+++ b/apps/web/src/queries/ev-charging/registrations-by-month.ts
@@ -1,10 +1,4 @@
-import {
-  count,
-  db,
-  evChargingPoints,
-  isNotNull,
-  sql,
-} from "@motormetrics/database";
+import { count, db, evChargingPoints, isNotNull } from "@motormetrics/database";
 import { EV_CHARGING_CACHE_TAG } from "@web/lib/cache-tags";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -13,9 +7,6 @@ export interface EvChargingMonthlyRegistrations {
   month: string;
   count: number;
 }
-
-/** Calendar-month bucket for a registration date. */
-const monthExpr = sql<string>`to_char(${evChargingPoints.registrationDate}, 'YYYY-MM')`;
 
 /**
  * Connectors registered with LTA per month, oldest first.
@@ -32,10 +23,23 @@ export async function getEvChargingRegistrationsByMonth(): Promise<
   cacheLife("max");
   cacheTag(EV_CHARGING_CACHE_TAG);
 
-  return db
-    .select({ month: monthExpr, count: count() })
+  // Grouped by day in the database, rolled up to months here: a few hundred
+  // rows at most, and it keeps the query on Drizzle's own API.
+  const daily = await db
+    .select({ date: evChargingPoints.registrationDate, count: count() })
     .from(evChargingPoints)
     .where(isNotNull(evChargingPoints.registrationDate))
-    .groupBy(monthExpr)
-    .orderBy(monthExpr);
+    .groupBy(evChargingPoints.registrationDate)
+    .orderBy(evChargingPoints.registrationDate);
+
+  const monthly = new Map<string, number>();
+  for (const row of daily) {
+    if (!row.date) {
+      continue;
+    }
+    const month = row.date.slice(0, 7);
+    monthly.set(month, (monthly.get(month) ?? 0) + row.count);
+  }
+
+  return [...monthly].map(([month, total]) => ({ month, count: total }));
 }

--- a/apps/web/src/queries/test-utils.ts
+++ b/apps/web/src/queries/test-utils.ts
@@ -18,6 +18,7 @@ interface QueryBuilder<T> {
   innerJoin: (...args: unknown[]) => QueryBuilder<T>;
   leftJoin: (...args: unknown[]) => QueryBuilder<T>;
   having: (...args: unknown[]) => QueryBuilder<T>;
+  as: (...args: unknown[]) => QueryBuilder<T>;
   then: (
     onFulfilled?: (value: T) => unknown,
     onRejected?: (reason: unknown) => void,
@@ -34,6 +35,7 @@ const createQueryBuilder = <T>(factory: ResultFactory<T>): QueryBuilder<T> => {
     innerJoin: () => builder,
     leftJoin: () => builder,
     having: () => builder,
+    as: () => builder,
     // biome-ignore lint/suspicious/noThenProperty: Required to make query builder thenable for async/await syntax
     then: (onFulfilled, onRejected) =>
       Promise.resolve(resolveFactory(factory)).then(onFulfilled, onRejected),

--- a/apps/web/src/workflows/ev-charging/steps/process-data.ts
+++ b/apps/web/src/workflows/ev-charging/steps/process-data.ts
@@ -34,41 +34,47 @@ export const toPubliclyAccessible = (value: string): boolean =>
   value.trim().toLowerCase() === "yes";
 
 export const updateEvChargingPoints = () =>
-  update<EvChargingPoint>({
-    table: evChargingPoints,
-    url: EV_CHARGING_POINTS_URL,
-    csvTransformOptions: {
-      // Postal codes carry leading zeros, so keep every value a string and
-      // convert the numeric columns explicitly below.
-      dynamicTyping: false,
-      columnMapping: {
-        "EV Charger Registration Code": "registrationCode",
-        "No. of Charging Outlets": "outlets",
-        "charging Speed": "chargingSpeedKw",
-        PostalCode: "postalCode",
-        "Block/House No": "blockHouseNo",
-        "Street Name": "streetName",
-        "Building Name": "buildingName",
-        "Floor No": "floorNo",
-        "Lot No": "lotNo",
-        "Is the charger publicly accessible?": "publiclyAccessible",
-        "Registration Date": "registrationDate",
-        "Type of Parking Lot": "parkingLotType",
-      },
-      fields: {
-        outlets: toOutlets,
-        chargingSpeedKw: toNumberOrNull,
-        postalCode: toTextOrNull,
-        blockHouseNo: toTextOrNull,
-        streetName: toTextOrNull,
-        buildingName: toTextOrNull,
-        floorNo: toTextOrNull,
-        lotNo: toTextOrNull,
-        publiclyAccessible: toPubliclyAccessible,
-        longitude: toNumberOrNull,
-        latitude: toNumberOrNull,
-        registrationDate: toIsoDate,
-        parkingLotType: toTextOrNull,
+  update<EvChargingPoint>(
+    {
+      table: evChargingPoints,
+      url: EV_CHARGING_POINTS_URL,
+      csvTransformOptions: {
+        // Postal codes carry leading zeros, so keep every value a string and
+        // convert the numeric columns explicitly below.
+        dynamicTyping: false,
+        columnMapping: {
+          "EV Charger Registration Code": "registrationCode",
+          "No. of Charging Outlets": "outlets",
+          "charging Speed": "chargingSpeedKw",
+          PostalCode: "postalCode",
+          "Block/House No": "blockHouseNo",
+          "Street Name": "streetName",
+          "Building Name": "buildingName",
+          "Floor No": "floorNo",
+          "Lot No": "lotNo",
+          "Is the charger publicly accessible?": "publiclyAccessible",
+          "Registration Date": "registrationDate",
+          "Type of Parking Lot": "parkingLotType",
+        },
+        fields: {
+          outlets: toOutlets,
+          chargingSpeedKw: toNumberOrNull,
+          postalCode: toTextOrNull,
+          blockHouseNo: toTextOrNull,
+          streetName: toTextOrNull,
+          buildingName: toTextOrNull,
+          floorNo: toTextOrNull,
+          lotNo: toTextOrNull,
+          publiclyAccessible: toPubliclyAccessible,
+          longitude: toNumberOrNull,
+          latitude: toNumberOrNull,
+          registrationDate: toIsoDate,
+          parkingLotType: toTextOrNull,
+        },
       },
     },
-  });
+    {
+      // 17 columns x 5000 rows exceeds Postgres' 65,535 bind-parameter cap.
+      batchSize: 3000,
+    },
+  );

--- a/apps/web/src/workflows/ev-charging/steps/process-data.ts
+++ b/apps/web/src/workflows/ev-charging/steps/process-data.ts
@@ -74,7 +74,9 @@ export const updateEvChargingPoints = () =>
       },
     },
     {
-      // 17 columns x 5000 rows exceeds Postgres' 65,535 bind-parameter cap.
-      batchSize: 3000,
+      // Neon's HTTP endpoint rejects statements with more than 32,767 bound
+      // parameters (a signed 16-bit count, half Postgres' own cap), so keep
+      // 17 columns x rows comfortably under it.
+      batchSize: 1500,
     },
   );

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "main": "src/index.ts",
   "module": "src/index.ts",
+  "sideEffects": false,
   "scripts": {
     "dev": "tsc --watch",
     "test": "vitest run",


### PR DESCRIPTION
- Resolve the TODO in \`ev-fleet-panel.tsx\`: headline the size of the public charging network as the v2 comp intended, with the battery-electric fleet as the supporting line
- Derive twelve-month network growth against the network a year earlier, so the Feb 2024 registration backlog sits in the base instead of reading as a spike; the helper has its own tests
- Add cached queries for connector and site counts and monthly registrations
- Fall back to the previous fleet-led headline until the registry has been ingested, so the panel never shows an invented figure
- Omit the comp's "60,000 by 2030" target line for now; it could not be sourced from LTA's published pages
- Fix the homepage EV momentum link, which pointed at the non-existent \`/cars/electric\`