### PR TITLE
Use the nuqs testing adapter and stop component tests relying on jsdom quirks

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/components/category/cars-category-charts.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/category/cars-category-charts.test.tsx
@@ -17,13 +17,13 @@ describe("Cars Category Charts", () => {
     };
 
     it("should render chart title and description", () => {
-      render(<TopMakesChart {...defaultProps} />);
+      const { container } = render(<TopMakesChart {...defaultProps} />);
 
       expect(screen.getByText("Top Makes - Petrol")).toBeInTheDocument();
       expect(
         screen.getByText("Most popular brands in this category"),
       ).toBeInTheDocument();
-      expect(document.body.firstChild).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     it("should render custom description when provided", () => {
@@ -37,9 +37,10 @@ describe("Cars Category Charts", () => {
     it("should render top 3 ranking chips", () => {
       render(<TopMakesChart {...defaultProps} />);
 
-      expect(screen.getByText("Toyota")).toBeInTheDocument();
-      expect(screen.getByText("Honda")).toBeInTheDocument();
-      expect(screen.getByText("BMW")).toBeInTheDocument();
+      // Recharts also renders a hidden measurement span with the label text.
+      expect(screen.getAllByText("Toyota")[0]).toBeInTheDocument();
+      expect(screen.getAllByText("Honda")[0]).toBeInTheDocument();
+      expect(screen.getAllByText("BMW")[0]).toBeInTheDocument();
     });
 
     it("should render empty state when makes array is empty", () => {

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.test.tsx
@@ -1,20 +1,19 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { DimensionStat } from "@web/queries/cars";
-import { NuqsTestingAdapter, type UrlUpdateEvent } from "nuqs/adapters/testing";
+import {
+  type OnUrlUpdateFunction,
+  withNuqsTestingAdapter,
+} from "nuqs/adapters/testing";
 import { describe, expect, it, vi } from "vitest";
 import { DimensionTable } from "./dimension-table";
 
-const onUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>();
+const onUrlUpdate = vi.fn<OnUrlUpdateFunction>();
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <NuqsTestingAdapter
-    searchParams={{ dimension: "make" }}
-    onUrlUpdate={onUrlUpdate}
-  >
-    {children}
-  </NuqsTestingAdapter>
-);
+const wrapper = withNuqsTestingAdapter({
+  searchParams: { dimension: "make" },
+  onUrlUpdate,
+});
 
 const rows: DimensionStat[] = [
   { name: "TOYOTA", count: 600, share: 60, trend: [], yoyChange: 12.5 },

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.test.tsx
@@ -1,17 +1,20 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { DimensionStat } from "@web/queries/cars";
+import { NuqsTestingAdapter, type UrlUpdateEvent } from "nuqs/adapters/testing";
 import { describe, expect, it, vi } from "vitest";
 import { DimensionTable } from "./dimension-table";
 
-const setDimension = vi.fn();
+const onUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>();
 
-vi.mock("nuqs", () => ({
-  parseAsStringLiteral: () => ({
-    withDefault: () => ({ withOptions: () => ({}) }),
-  }),
-  useQueryState: () => ["make", setDimension],
-}));
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <NuqsTestingAdapter
+    searchParams={{ dimension: "make" }}
+    onUrlUpdate={onUrlUpdate}
+  >
+    {children}
+  </NuqsTestingAdapter>
+);
 
 const rows: DimensionStat[] = [
   { name: "TOYOTA", count: 600, share: 60, trend: [], yoyChange: 12.5 },
@@ -35,6 +38,7 @@ const renderTable = (rowsToRender: DimensionStat[] = rows) =>
       monthLabel="October 2025"
       rows={rowsToRender}
     />,
+    { wrapper },
   );
 
 /**
@@ -127,7 +131,9 @@ describe("DimensionTable", () => {
 
     await user.click(tab);
 
-    expect(setDimension).toHaveBeenCalledWith("fuelType");
+    expect(
+      onUrlUpdate.mock.calls.at(-1)?.[0].searchParams.get("dimension"),
+    ).toBe("fuelType");
   });
 
   it("should collapse a long list to the first ten rows", () => {

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-card.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-card.test.tsx
@@ -7,8 +7,10 @@ describe("MakeCard", () => {
   const mockLogoUrl = "https://blob.vercel-storage.com/logos/bmw.png";
 
   it("should render the make name", () => {
-    render(<MakeCard make={mockMake} logoUrl={mockLogoUrl} />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(
+      <MakeCard make={mockMake} logoUrl={mockLogoUrl} />,
+    );
+    expect(container).toMatchSnapshot();
     expect(screen.getByText(mockMake)).toBeVisible();
   });
 

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-grid.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-grid.test.tsx
@@ -1,22 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import { MakeGrid } from "./make-grid";
 
-vi.mock("nuqs", () => ({
-  useQueryState: () => [null, vi.fn()],
-}));
-
-vi.mock("nuqs/server", () => ({
-  parseAsString: {},
-  createSerializer: () => (path: string) => path,
-  createLoader: () => vi.fn(),
-}));
-
 describe("MakeGrid", () => {
   const germanMakes = ["AUDI", "BMW", "MERCEDES BENZ", "VOLKSWAGEN"];
 
   it("should render all makes in grid layout", () => {
-    render(<MakeGrid makes={germanMakes} />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(<MakeGrid makes={germanMakes} />);
+    expect(container).toMatchSnapshot();
     germanMakes.forEach((make) => {
       expect(screen.getByText(make)).toBeVisible();
     });

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/makes.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/makes.test.tsx
@@ -14,7 +14,7 @@ describe("Makes", () => {
   const lettersGerman = ["ALL", "A", "B", "M", "P"];
 
   it("should render the section with title and count", () => {
-    render(
+    const { container } = render(
       <AllMakes
         title="Test Makes"
         sortedMakes={germanMakes}
@@ -22,7 +22,7 @@ describe("Makes", () => {
         letters={lettersGerman}
       />,
     );
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByText("Test Makes")).toBeVisible();
     expect(screen.getByText(germanMakes.length.toString())).toBeVisible();
   });

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/adoption-columns.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/adoption-columns.test.tsx
@@ -1,18 +1,17 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { AdoptionColumns } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/components/adoption-columns";
-import { NuqsTestingAdapter, type UrlUpdateEvent } from "nuqs/adapters/testing";
+import {
+  type OnUrlUpdateFunction,
+  withNuqsTestingAdapter,
+} from "nuqs/adapters/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const onUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>();
+const onUrlUpdate = vi.fn<OnUrlUpdateFunction>();
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <NuqsTestingAdapter
-    searchParams={{ month: "2025-10" }}
-    onUrlUpdate={onUrlUpdate}
-  >
-    {children}
-  </NuqsTestingAdapter>
-);
+const wrapper = withNuqsTestingAdapter({
+  searchParams: { month: "2025-10" },
+  onUrlUpdate,
+});
 
 const columns = [
   { month: "2025-08", share: 24.1 },

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/adoption-columns.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/adoption-columns.test.tsx
@@ -1,17 +1,18 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { AdoptionColumns } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/components/adoption-columns";
+import { NuqsTestingAdapter, type UrlUpdateEvent } from "nuqs/adapters/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const setMonth = vi.fn();
+const onUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>();
 
-vi.mock("nuqs", () => ({
-  parseAsString: {
-    withDefault: vi.fn(() => ({
-      withOptions: vi.fn(() => ({})),
-    })),
-  },
-  useQueryState: vi.fn(() => ["2025-10", setMonth]),
-}));
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <NuqsTestingAdapter
+    searchParams={{ month: "2025-10" }}
+    onUrlUpdate={onUrlUpdate}
+  >
+    {children}
+  </NuqsTestingAdapter>
+);
 
 const columns = [
   { month: "2025-08", share: 24.1 },
@@ -21,11 +22,13 @@ const columns = [
 
 describe("AdoptionColumns", () => {
   beforeEach(() => {
-    setMonth.mockClear();
+    onUrlUpdate.mockClear();
   });
 
   it("should render one labelled column per month", () => {
-    render(<AdoptionColumns columns={columns} selectedMonth="2025-10" />);
+    render(<AdoptionColumns columns={columns} selectedMonth="2025-10" />, {
+      wrapper,
+    });
 
     expect(screen.getByRole("button", { name: "Show Aug 2025" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Show Sep 2025" })).toBeTruthy();
@@ -33,7 +36,9 @@ describe("AdoptionColumns", () => {
   });
 
   it("should mark only the selected month as pressed", () => {
-    render(<AdoptionColumns columns={columns} selectedMonth="2025-09" />);
+    render(<AdoptionColumns columns={columns} selectedMonth="2025-09" />, {
+      wrapper,
+    });
 
     expect(
       screen
@@ -47,23 +52,34 @@ describe("AdoptionColumns", () => {
     ).toBe("false");
   });
 
-  it("should move the page to the month behind the column that was clicked", () => {
-    render(<AdoptionColumns columns={columns} selectedMonth="2025-10" />);
+  it("should move the page to the month behind the column that was clicked", async () => {
+    render(<AdoptionColumns columns={columns} selectedMonth="2025-10" />, {
+      wrapper,
+    });
 
     fireEvent.click(screen.getByRole("button", { name: "Show Aug 2025" }));
 
-    expect(setMonth).toHaveBeenCalledWith("2025-08");
+    // nuqs flushes URL updates asynchronously.
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalledOnce());
+    expect(onUrlUpdate.mock.calls[0]?.[0].searchParams.get("month")).toBe(
+      "2025-08",
+    );
   });
 
   it("should scale every column against the tallest share", () => {
     const { container } = render(
       <AdoptionColumns columns={columns} selectedMonth="2025-10" />,
+      { wrapper },
     );
     const bars = container.querySelectorAll<HTMLElement>("[data-column-bar]");
 
     expect(bars).toHaveLength(3);
     expect(bars[2]?.style.height).toBe("100%");
-    expect(bars[0]?.style.height).toBe(`${(24.1 / 30.4) * 100}%`);
+    // Browsers round the serialised percentage, so compare numerically.
+    expect(Number.parseFloat(bars[0]?.style.height ?? "")).toBeCloseTo(
+      (24.1 / 30.4) * 100,
+      3,
+    );
   });
 
   it("should not divide by zero when no month has any share", () => {
@@ -72,6 +88,7 @@ describe("AdoptionColumns", () => {
         columns={[{ month: "2025-10", share: 0 }]}
         selectedMonth="2025-10"
       />,
+      { wrapper },
     );
     const bar = container.querySelector<HTMLElement>("[data-column-bar]");
 

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-table.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-table.test.tsx
@@ -142,6 +142,10 @@ describe("MakesTable", () => {
     const user = userEvent.setup();
     renderTable();
 
+    // Stop the real anchor navigating the browser test page away.
+    document.addEventListener("click", (event) => event.preventDefault(), {
+      once: true,
+    });
     await user.click(screen.getAllByRole("link")[1]);
 
     expect(capture).toHaveBeenCalledExactlyOnceWith("car_make_searched", {

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-table.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-table.test.tsx
@@ -142,10 +142,6 @@ describe("MakesTable", () => {
     const user = userEvent.setup();
     renderTable();
 
-    // Stop the real anchor navigating the browser test page away.
-    document.addEventListener("click", (event) => event.preventDefault(), {
-      once: true,
-    });
     await user.click(screen.getAllByRole("link")[1]);
 
     expect(capture).toHaveBeenCalledExactlyOnceWith("car_make_searched", {

--- a/apps/web/src/components/announcement.test.tsx
+++ b/apps/web/src/components/announcement.test.tsx
@@ -4,31 +4,35 @@ import type { Announcement as AnnouncementType } from "@web/types";
 import { createElement } from "react";
 import { vi } from "vitest";
 
-const announcementsFixture: AnnouncementType[] = [];
-let mockPathname = "/";
+// Hoisted so the mock factories below can reach it once they are lifted
+// above the imports (the browser mocker evaluates them eagerly).
+const state = vi.hoisted(() => ({
+  announcements: [] as AnnouncementType[],
+  pathname: "/",
+}));
 
 vi.mock("@web/config", () => ({
   get announcements() {
-    return announcementsFixture;
+    return state.announcements;
   },
 }));
 
 vi.mock("next/navigation", () => ({
-  usePathname: () => mockPathname,
+  usePathname: () => state.pathname,
 }));
 
 describe("Announcement", () => {
   beforeEach(() => {
-    announcementsFixture.length = 0;
-    mockPathname = "/";
+    state.announcements.length = 0;
+    state.pathname = "/";
   });
 
   it("should prioritise path-specific announcements", () => {
-    announcementsFixture.push(
+    state.announcements.push(
       { content: "Cars update", paths: ["/cars"] },
       { content: "Global update" },
     );
-    mockPathname = "/cars/makes";
+    state.pathname = "/cars/makes";
 
     const { container } = render(createElement(Announcement));
 
@@ -37,8 +41,8 @@ describe("Announcement", () => {
   });
 
   it("should fall back to global announcements", () => {
-    announcementsFixture.push({ content: "Global notice" });
-    mockPathname = "/unknown";
+    state.announcements.push({ content: "Global notice" });
+    state.pathname = "/unknown";
 
     render(createElement(Announcement));
 
@@ -51,8 +55,8 @@ describe("Announcement", () => {
   });
 
   it("should render nothing when no path matches and no global fallback exists", () => {
-    announcementsFixture.push({ content: "Cars update", paths: ["/cars"] });
-    mockPathname = "/coe";
+    state.announcements.push({ content: "Cars update", paths: ["/cars"] });
+    state.pathname = "/coe";
 
     const { container } = render(createElement(Announcement));
 

--- a/apps/web/src/components/banner.test.tsx
+++ b/apps/web/src/components/banner.test.tsx
@@ -22,9 +22,9 @@ describe("Banner", () => {
       <span data-testid="banner-content">Hello COE</span>
     );
 
-    render(<Banner />);
+    const { container } = render(<Banner />);
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByTestId("banner-content")).toHaveTextContent("Hello COE");
   });
 

--- a/apps/web/src/components/category-info.test.tsx
+++ b/apps/web/src/components/category-info.test.tsx
@@ -11,7 +11,7 @@ describe("CategoryInfo", () => {
   });
 
   it("should render with required props", () => {
-    render(
+    const { container } = render(
       <CategoryInfo
         icon={Car}
         category="Category A"
@@ -21,7 +21,7 @@ describe("CategoryInfo", () => {
       />,
     );
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByText("Category A")).toBeInTheDocument();
     expect(screen.getByText("Cars up to 1600cc and 97kW")).toBeInTheDocument();
   });

--- a/apps/web/src/components/coming-soon.test.tsx
+++ b/apps/web/src/components/coming-soon.test.tsx
@@ -3,13 +3,13 @@ import { ComingSoon } from "@web/components/coming-soon";
 
 describe("ComingSoon", () => {
   it("should render ComingSoon label", () => {
-    render(
+    const { container } = render(
       <ComingSoon>
         <span>Trends</span>
       </ComingSoon>,
     );
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByText("Coming Soon")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/latest-coe.test.tsx
+++ b/apps/web/src/components/latest-coe.test.tsx
@@ -4,7 +4,8 @@ import type { COECategory, COEResult } from "@web/types";
 import type React from "react";
 import { LatestCoePremium } from "./coe/latest-coe-premium";
 
-vi.mock("@heroui-pro/react", () => {
+vi.mock("@heroui-pro/react", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
   const KPI = ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   );
@@ -22,7 +23,7 @@ vi.mock("@heroui-pro/react", () => {
     <div data-testid="sparkline" data-colour={color} />
   );
 
-  return { KPI };
+  return { ...actual, KPI };
 });
 
 describe("LatestCoe", () => {
@@ -48,9 +49,9 @@ describe("LatestCoe", () => {
   ];
 
   it("should render all COE results", () => {
-    render(<LatestCoePremium results={mockResults} />);
+    const { container } = render(<LatestCoePremium results={mockResults} />);
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByText("Category A")).toBeInTheDocument();
     expect(screen.getByText("Category B")).toBeInTheDocument();
     expect(screen.getByText("95000")).toBeInTheDocument();

--- a/apps/web/src/components/link-with-params.test.tsx
+++ b/apps/web/src/components/link-with-params.test.tsx
@@ -26,13 +26,13 @@ describe("LinkWithParams", () => {
       toString: () => "",
     } as any);
 
-    render(
+    const { container } = render(
       <LinkWithParams href="/test">
         <span>Test Link</span>
       </LinkWithParams>,
     );
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByRole("link")).toBeInTheDocument();
     expect(screen.getByText("Test Link")).toBeInTheDocument();
   });

--- a/apps/web/src/components/loading-indicator.test.tsx
+++ b/apps/web/src/components/loading-indicator.test.tsx
@@ -11,8 +11,8 @@ describe("LoadingIndicator", () => {
   it("should render progress bar when pending", async () => {
     const { default: LoadingIndicator } = await import("./loading-indicator");
 
-    render(<LoadingIndicator />);
+    const { container } = render(<LoadingIndicator />);
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/apps/web/src/components/maintenance-notice.test.tsx
+++ b/apps/web/src/components/maintenance-notice.test.tsx
@@ -14,8 +14,8 @@ describe("MaintenanceNotice", () => {
   });
 
   it("should render the maintenance copy and run the hook", () => {
-    render(<MaintenanceNotice />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(<MaintenanceNotice />);
+    expect(container).toMatchSnapshot();
     expect(screen.getByText(/Pit Stop in Progress/i)).toBeInTheDocument();
     expect(mockUseMaintenance).toHaveBeenCalled();
   });

--- a/apps/web/src/components/metrics-comparison.test.tsx
+++ b/apps/web/src/components/metrics-comparison.test.tsx
@@ -3,8 +3,10 @@ import { MetricsComparison } from "@web/components/metrics-comparison";
 
 describe("MetricsComparison", () => {
   it("should indicate positive growth", () => {
-    render(<MetricsComparison current={110} previousMonth={100} />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(
+      <MetricsComparison current={110} previousMonth={100} />,
+    );
+    expect(container).toMatchSnapshot();
     expect(screen.getByText("vs last month")).toBeInTheDocument();
     expect(screen.getByText("10%")).toBeInTheDocument();
   });

--- a/apps/web/src/components/notification-prompt.test.tsx
+++ b/apps/web/src/components/notification-prompt.test.tsx
@@ -60,7 +60,7 @@ async function renderDelayedPrompt() {
 }
 
 describe("NotificationPrompt Component", () => {
-  let originalNotification: typeof global.Notification;
+  let originalNotification: typeof globalThis.Notification;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -70,15 +70,15 @@ describe("NotificationPrompt Component", () => {
       configurable: true,
       value: localStorageMock,
     });
-    originalNotification = global.Notification;
-    global.Notification = {
+    originalNotification = globalThis.Notification;
+    globalThis.Notification = {
       requestPermission: vi.fn().mockResolvedValue("default"),
       permission: "default",
-    } as unknown as typeof global.Notification;
+    } as unknown as typeof globalThis.Notification;
   });
 
   afterEach(() => {
-    global.Notification = originalNotification;
+    globalThis.Notification = originalNotification;
     vi.useRealTimers();
   });
 
@@ -111,10 +111,10 @@ describe("NotificationPrompt Component", () => {
     "granted",
     "denied",
   ] as const)("does not prompt when permission is %s", async (permission) => {
-    global.Notification = {
+    globalThis.Notification = {
       requestPermission: vi.fn(),
       permission,
-    } as unknown as typeof global.Notification;
+    } as unknown as typeof globalThis.Notification;
 
     await renderDelayedPrompt();
     expect(toast).not.toHaveBeenCalled();
@@ -127,7 +127,7 @@ describe("NotificationPrompt Component", () => {
   });
 
   it("requests permission only when Enable is pressed", async () => {
-    vi.mocked(global.Notification.requestPermission).mockResolvedValue(
+    vi.mocked(globalThis.Notification.requestPermission).mockResolvedValue(
       "granted",
     );
     await renderDelayedPrompt();
@@ -137,7 +137,7 @@ describe("NotificationPrompt Component", () => {
       fireEvent.click(screen.getAllByTestId("button")[0]);
     });
 
-    expect(global.Notification.requestPermission).toHaveBeenCalledOnce();
+    expect(globalThis.Notification.requestPermission).toHaveBeenCalledOnce();
     expect(toast.close).toHaveBeenCalledWith("notification-toast-id");
     expect(toast.success).toHaveBeenCalledWith("Notifications enabled", {
       description: "You will receive an alert when new data is published.",
@@ -150,7 +150,7 @@ describe("NotificationPrompt Component", () => {
 
     fireEvent.click(screen.getAllByTestId("button")[1]);
 
-    expect(global.Notification.requestPermission).not.toHaveBeenCalled();
+    expect(globalThis.Notification.requestPermission).not.toHaveBeenCalled();
     expect(toast.close).toHaveBeenCalledWith("notification-toast-id");
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
       "motormetrics:notification-prompt-dismissed",
@@ -159,7 +159,7 @@ describe("NotificationPrompt Component", () => {
   });
 
   it("shows guidance when the browser declines permission", async () => {
-    vi.mocked(global.Notification.requestPermission).mockResolvedValue(
+    vi.mocked(globalThis.Notification.requestPermission).mockResolvedValue(
       "denied",
     );
     await renderDelayedPrompt();
@@ -186,7 +186,7 @@ describe("NotificationPrompt Component", () => {
   });
 
   it("does not prompt when the Notification API is unavailable", async () => {
-    delete (global as Partial<typeof globalThis>).Notification;
+    delete (globalThis as Partial<typeof globalThis>).Notification;
     await renderDelayedPrompt();
     expect(toast).not.toHaveBeenCalled();
   });

--- a/apps/web/src/components/page-not-found.test.tsx
+++ b/apps/web/src/components/page-not-found.test.tsx
@@ -24,7 +24,9 @@ describe("PageNotFound", () => {
   });
 
   it("should go back when Go Back button is clicked", () => {
-    const historyBackSpy = vi.spyOn(history, "back");
+    const historyBackSpy = vi
+      .spyOn(history, "back")
+      .mockImplementation(() => {});
     render(<PageNotFound />);
 
     fireEvent.click(screen.getByRole("button", { name: "Go Back" }));

--- a/apps/web/src/components/recent-posts.test.tsx
+++ b/apps/web/src/components/recent-posts.test.tsx
@@ -114,9 +114,9 @@ describe("RecentPosts", () => {
   ];
 
   it("should render title and view all link", () => {
-    render(<RecentPosts posts={mockPosts} />);
+    const { container } = render(<RecentPosts posts={mockPosts} />);
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByText("Recent Posts")).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "View all blog posts" }),

--- a/apps/web/src/components/shared/empty-state.test.tsx
+++ b/apps/web/src/components/shared/empty-state.test.tsx
@@ -17,9 +17,9 @@ describe("EmptyState", () => {
   });
 
   it("should render default title and description", () => {
-    render(<EmptyState />);
+    const { container } = render(<EmptyState />);
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByText("No Data Available")).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -89,7 +89,9 @@ describe("EmptyState", () => {
   });
 
   it("should call history.back when Go Back button is clicked", () => {
-    const historyBackSpy = vi.spyOn(history, "back");
+    const historyBackSpy = vi
+      .spyOn(history, "back")
+      .mockImplementation(() => {});
     render(<EmptyState />);
 
     fireEvent.click(screen.getByRole("button", { name: /go back/i }));

--- a/apps/web/src/components/shared/metric-card.test.tsx
+++ b/apps/web/src/components/shared/metric-card.test.tsx
@@ -3,7 +3,7 @@ import { MetricCard } from "@web/components/shared/metric-card";
 
 describe("MetricCard", () => {
   it("should combine metric value and comparison", () => {
-    render(
+    const { container } = render(
       <MetricCard
         title="COE Premiums"
         value={50000}
@@ -12,13 +12,13 @@ describe("MetricCard", () => {
       />,
     );
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByText("COE Premiums")).toBeInTheDocument();
     expect(screen.getByText("vs last month")).toBeInTheDocument();
   });
 
   it("should render with hero variant", () => {
-    render(
+    const { container } = render(
       <MetricCard
         title="Total Registrations"
         value={10000}
@@ -28,7 +28,7 @@ describe("MetricCard", () => {
       />,
     );
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByText("Total Registrations")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/shared/month-selector.test.tsx
+++ b/apps/web/src/components/shared/month-selector.test.tsx
@@ -1,12 +1,10 @@
 import { render, screen } from "@testing-library/react";
-import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
 import { MonthSelector } from "./month-selector";
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <NuqsTestingAdapter searchParams={{ month: "2024-01" }}>
-    {children}
-  </NuqsTestingAdapter>
-);
+const wrapper = withNuqsTestingAdapter({
+  searchParams: { month: "2024-01" },
+});
 
 vi.mock("@heroui/react", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();

--- a/apps/web/src/components/shared/month-selector.test.tsx
+++ b/apps/web/src/components/shared/month-selector.test.tsx
@@ -1,14 +1,12 @@
 import { render, screen } from "@testing-library/react";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
 import { MonthSelector } from "./month-selector";
 
-vi.mock("nuqs", () => ({
-  parseAsString: {
-    withDefault: vi.fn(() => ({
-      withOptions: vi.fn(() => ({})),
-    })),
-  },
-  useQueryState: vi.fn(() => ["2024-01", vi.fn()]),
-}));
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <NuqsTestingAdapter searchParams={{ month: "2024-01" }}>
+    {children}
+  </NuqsTestingAdapter>
+);
 
 vi.mock("@heroui/react", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
@@ -53,13 +51,16 @@ vi.mock("@web/utils/group-by-year", () => ({
 describe("MonthSelector", () => {
   it("should render with months array", () => {
     const mockMonths = ["2024-01"];
-    render(<MonthSelector months={mockMonths} latestMonth="2024-01" />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(
+      <MonthSelector months={mockMonths} latestMonth="2024-01" />,
+      { wrapper },
+    );
+    expect(container).toMatchSnapshot();
     expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 
   it("should render with empty months array", () => {
-    render(<MonthSelector months={[]} latestMonth="" />);
+    render(<MonthSelector months={[]} latestMonth="" />, { wrapper });
     expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 
@@ -71,6 +72,7 @@ describe("MonthSelector", () => {
         latestMonth="2024-01"
         wasAdjusted={true}
       />,
+      { wrapper },
     );
     expect(screen.getByRole("combobox")).toBeInTheDocument();
   });

--- a/apps/web/src/components/shared/report-table.test.tsx
+++ b/apps/web/src/components/shared/report-table.test.tsx
@@ -45,9 +45,9 @@ describe("ReportTable", () => {
 
     // The width is applied through a custom property and a `sm:` utility, so
     // jsdom — which loads no Tailwind — only ever sees the variable.
-    expect(getByRole("columnheader")).toHaveStyle({
-      "--report-col-width": "30%",
-    });
+    expect(
+      getByRole("columnheader").style.getPropertyValue("--report-col-width"),
+    ).toBe("30%");
   });
 });
 

--- a/apps/web/src/components/shared/skeleton.test.tsx
+++ b/apps/web/src/components/shared/skeleton.test.tsx
@@ -15,70 +15,70 @@ import {
 
 describe("Skeleton components", () => {
   it("should render SkeletonText", () => {
-    render(<SkeletonText />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(<SkeletonText />);
+    expect(container).toMatchSnapshot();
   });
 
   it("should render SkeletonHeading", () => {
-    render(<SkeletonHeading />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(<SkeletonHeading />);
+    expect(container).toMatchSnapshot();
   });
 
   it("should render SkeletonCard", () => {
-    render(<SkeletonCard />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(<SkeletonCard />);
+    expect(container).toMatchSnapshot();
   });
 
   it("should render SkeletonChart", () => {
-    render(<SkeletonChart />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(<SkeletonChart />);
+    expect(container).toMatchSnapshot();
   });
 
   it("should render SkeletonMetricCard", () => {
-    render(<SkeletonMetricCard />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(<SkeletonMetricCard />);
+    expect(container).toMatchSnapshot();
   });
 
   it("should render SkeletonChartWidget", () => {
-    render(<SkeletonChartWidget />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(<SkeletonChartWidget />);
+    expect(container).toMatchSnapshot();
   });
 
   it("should render SkeletonPageHeader", () => {
-    render(<SkeletonPageHeader />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(<SkeletonPageHeader />);
+    expect(container).toMatchSnapshot();
   });
 
   it("should render SkeletonBentoCard", () => {
-    render(<SkeletonBentoCard />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(<SkeletonBentoCard />);
+    expect(container).toMatchSnapshot();
   });
 
   it("should render SectionSkeleton with title", () => {
-    render(
+    const { container } = render(
       <SectionSkeleton>
         <SkeletonCard />
       </SectionSkeleton>,
     );
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it("should render SectionSkeleton without title", () => {
-    render(
+    const { container } = render(
       <SectionSkeleton title={false}>
         <SkeletonCard />
       </SectionSkeleton>,
     );
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it("should render GridSkeleton", () => {
-    render(<GridSkeleton count={4} />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(<GridSkeleton count={4} />);
+    expect(container).toMatchSnapshot();
   });
 
   it("should render ListSkeleton", () => {
-    render(<ListSkeleton count={3} />);
-    expect(document.body.firstChild).toMatchSnapshot();
+    const { container } = render(<ListSkeleton count={3} />);
+    expect(container).toMatchSnapshot();
   });
 });

--- a/apps/web/src/components/shared/stat-card.test.tsx
+++ b/apps/web/src/components/shared/stat-card.test.tsx
@@ -37,9 +37,9 @@ describe("StatCard", () => {
   };
 
   it("should render with required props", () => {
-    render(<StatCard {...defaultProps} />);
+    const { container } = render(<StatCard {...defaultProps} />);
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByText("Test Title")).toBeInTheDocument();
     expect(screen.getByText("Test Description")).toBeInTheDocument();
     expect(screen.getByTestId("bar-chart")).toBeInTheDocument();
@@ -51,9 +51,9 @@ describe("StatCard", () => {
   });
 
   it("should render with hero variant", () => {
-    render(<StatCard {...defaultProps} variant="hero" />);
+    const { container } = render(<StatCard {...defaultProps} variant="hero" />);
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByText("Test Title")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/shared/year-selector.test.tsx
+++ b/apps/web/src/components/shared/year-selector.test.tsx
@@ -1,15 +1,17 @@
 import { toast } from "@heroui/react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { NuqsTestingAdapter, type UrlUpdateEvent } from "nuqs/adapters/testing";
+import {
+  type OnUrlUpdateFunction,
+  withNuqsTestingAdapter,
+} from "nuqs/adapters/testing";
 import { YearSelector } from "./year-selector";
 
-const onUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>();
+const onUrlUpdate = vi.fn<OnUrlUpdateFunction>();
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <NuqsTestingAdapter searchParams={{ year: "2024" }} onUrlUpdate={onUrlUpdate}>
-    {children}
-  </NuqsTestingAdapter>
-);
+const wrapper = withNuqsTestingAdapter({
+  searchParams: { year: "2024" },
+  onUrlUpdate,
+});
 
 const lastUrlUpdate = () => onUrlUpdate.mock.calls.at(-1)?.[0];
 

--- a/apps/web/src/components/shared/year-selector.test.tsx
+++ b/apps/web/src/components/shared/year-selector.test.tsx
@@ -1,18 +1,17 @@
 import { toast } from "@heroui/react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { NuqsTestingAdapter, type UrlUpdateEvent } from "nuqs/adapters/testing";
 import { YearSelector } from "./year-selector";
 
-const mockSetYear = vi.fn();
-const mockUseQueryState = vi.fn(() => [2024, mockSetYear]);
+const onUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>();
 
-vi.mock("nuqs", () => ({
-  parseAsInteger: {
-    withDefault: vi.fn(() => ({
-      withOptions: vi.fn(() => ({})),
-    })),
-  },
-  useQueryState: () => mockUseQueryState(),
-}));
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <NuqsTestingAdapter searchParams={{ year: "2024" }} onUrlUpdate={onUrlUpdate}>
+    {children}
+  </NuqsTestingAdapter>
+);
+
+const lastUrlUpdate = () => onUrlUpdate.mock.calls.at(-1)?.[0];
 
 vi.mock("@heroui/react", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
@@ -67,6 +66,7 @@ describe("YearSelector", () => {
   it("should render years sorted from newest to oldest", () => {
     const { container } = render(
       <YearSelector years={[2022, 2024, 2023]} latestYear={2024} />,
+      { wrapper },
     );
 
     expect(container).toMatchSnapshot();
@@ -78,18 +78,25 @@ describe("YearSelector", () => {
     expect(options).toEqual(["2024", "2023", "2022"]);
   });
 
-  it("should update query state when selection changes", () => {
-    render(<YearSelector years={[2022, 2024]} latestYear={2024} />);
+  it("should update query state when selection changes", async () => {
+    render(<YearSelector years={[2022, 2024]} latestYear={2024} />, {
+      wrapper,
+    });
 
     fireEvent.change(screen.getByTestId("year-selector"), {
       target: { value: "2022" },
     });
-    expect(mockSetYear).toHaveBeenCalledWith(2022);
+    // nuqs flushes URL updates asynchronously.
+    await waitFor(() =>
+      expect(lastUrlUpdate()?.searchParams.get("year")).toBe("2022"),
+    );
 
     fireEvent.change(screen.getByTestId("year-selector"), {
       target: { value: "" },
     });
-    expect(mockSetYear).toHaveBeenCalledWith(null);
+    await waitFor(() =>
+      expect(lastUrlUpdate()?.searchParams.get("year")).toBeNull(),
+    );
   });
 
   it("should show adjustment toast only once", () => {
@@ -99,6 +106,7 @@ describe("YearSelector", () => {
         latestYear={2024}
         wasAdjusted={true}
       />,
+      { wrapper },
     );
 
     expect(toast.info).toHaveBeenCalledTimes(1);
@@ -121,6 +129,7 @@ describe("YearSelector", () => {
         latestYear={2024}
         wasAdjusted={false}
       />,
+      { wrapper },
     );
 
     expect(toast.info).not.toHaveBeenCalled();

--- a/apps/web/src/components/trends-comparison.test.tsx
+++ b/apps/web/src/components/trends-comparison.test.tsx
@@ -23,7 +23,7 @@ const mockComparisonData = {
 describe("TrendsComparison", () => {
   it("should render TrendsComparison content when open", () => {
     const handleChange = vi.fn();
-    render(
+    const { container } = render(
       <NuqsTestingAdapter>
         <TrendsComparison
           isOpen
@@ -35,7 +35,7 @@ describe("TrendsComparison", () => {
       </NuqsTestingAdapter>,
     );
 
-    expect(document.body.firstChild).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
     expect(screen.getByText("Trends Comparison")).toBeInTheDocument();
   });
 

--- a/apps/web/src/hooks/use-maintenance.test.tsx
+++ b/apps/web/src/hooks/use-maintenance.test.tsx
@@ -33,8 +33,8 @@ describe("useMaintenance", () => {
       get: mockGet,
     });
 
-    intervalSpy = vi.spyOn(global, "setInterval");
-    vi.spyOn(global, "clearInterval");
+    intervalSpy = vi.spyOn(globalThis, "setInterval");
+    vi.spyOn(globalThis, "clearInterval");
   });
 
   afterEach(() => {
@@ -109,7 +109,7 @@ describe("useMaintenance", () => {
 
     unmount();
 
-    expect(global.clearInterval).toHaveBeenCalled();
+    expect(globalThis.clearInterval).toHaveBeenCalled();
   });
 
   it("should handle errors gracefully", async () => {


### PR DESCRIPTION
- Replace hand-written `nuqs` mocks with `NuqsTestingAdapter` in the year, month, dimension-table and adoption-columns suites, asserting on `onUrlUpdate` instead of a mocked setter; drop the unused `nuqs` mocks from make-grid
- Snapshot the render `container` instead of `document.body.firstChild` across 17 suites
- Mock `history.back` and prevent default on a real anchor click so those tests cannot navigate the page; use `globalThis` instead of Node's `global`
- Hoist the announcement fixtures with `vi.hoisted` and spread the real `@heroui-pro/react` module in the latest-coe mock so mocked modules keep every export the component imports
- Query Recharts labels with `getAllByText` and compare the adoption column height numerically
- Read the `--report-col-width` custom property directly, fixing the pre-existing typecheck error that blocked the pre-commit hook

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791023596&installation_model_id=21947&pr_number=965&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F965&signature=e98417ea6c4755dfd5857c13ee2d42b2bd15c59456f38c014673b62548234826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->