### PR TITLE
Add PostHog engagement events and funnels

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/components/category/category-filters.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/category/category-filters.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@heroui/react";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { useTransition } from "react";
 
 /**
@@ -59,7 +60,13 @@ export function PeriodTabs() {
                 : "bg-surface font-semibold text-muted hover:text-foreground",
             )}
             key={option}
-            onClick={() => setPeriod(option)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "period",
+                value: option,
+              });
+              setPeriod(option);
+            }}
             type="button"
           >
             {PERIOD_LABELS[option]}
@@ -100,7 +107,13 @@ export function MeasureTabs() {
                 : "font-semibold text-muted hover:text-foreground",
             )}
             key={option}
-            onClick={() => setMeasure(option)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "measure",
+                value: option,
+              });
+              setMeasure(option);
+            }}
             type="button"
           >
             {MEASURE_LABELS[option]}

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/category/type-filters.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/category/type-filters.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@heroui/react";
 import { parseAsString, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { useTransition } from "react";
 
 /**
@@ -52,7 +53,13 @@ export function PeriodTabs({
                 : "bg-surface font-semibold text-muted hover:text-foreground",
             )}
             key={key}
-            onClick={() => setPeriod(key)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "period",
+                value: key,
+              });
+              setPeriod(key);
+            }}
             type="button"
           >
             {label}

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.test.tsx
@@ -9,6 +9,9 @@ import { describe, expect, it, vi } from "vitest";
 import { DimensionTable } from "./dimension-table";
 
 const onUrlUpdate = vi.fn<OnUrlUpdateFunction>();
+const capture = vi.hoisted(() => vi.fn());
+
+vi.mock("posthog-js", () => ({ default: { capture } }));
 
 const wrapper = withNuqsTestingAdapter({
   searchParams: { dimension: "make" },
@@ -133,6 +136,10 @@ describe("DimensionTable", () => {
     expect(
       onUrlUpdate.mock.calls.at(-1)?.[0].searchParams.get("dimension"),
     ).toBe("fuelType");
+    expect(capture).toHaveBeenCalledWith("dashboard_filter_changed", {
+      filter: "dimension",
+      value: "fuelType",
+    });
   });
 
   it("should collapse a long list to the first ten rows", () => {

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/dimension-table.tsx
@@ -12,6 +12,7 @@ import type { CarDimension, DimensionStat } from "@web/queries/cars";
 import { ArrowRight, Car, Search } from "lucide-react";
 import Link from "next/link";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { useMemo, useState, useTransition } from "react";
 
 type SortKey = "name" | "count";
@@ -161,6 +162,10 @@ export function DimensionTable({
           <Segment
             aria-label="Dimension"
             onSelectionChange={(key) => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "dimension",
+                value: key,
+              });
               setQuery("");
               setSortDescriptor({ column: "count", direction: "descending" });
               setDimension(key as CarDimension);

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/adoption-columns.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/adoption-columns.test.tsx
@@ -7,6 +7,9 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const onUrlUpdate = vi.fn<OnUrlUpdateFunction>();
+const capture = vi.hoisted(() => vi.fn());
+
+vi.mock("posthog-js", () => ({ default: { capture } }));
 
 const wrapper = withNuqsTestingAdapter({
   searchParams: { month: "2025-10" },
@@ -63,6 +66,10 @@ describe("AdoptionColumns", () => {
     expect(onUrlUpdate.mock.calls[0]?.[0].searchParams.get("month")).toBe(
       "2025-08",
     );
+    expect(capture).toHaveBeenCalledWith("dashboard_filter_changed", {
+      filter: "month",
+      value: "2025-08",
+    });
   });
 
   it("should scale every column against the tallest share", () => {

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/adoption-columns.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/adoption-columns.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@heroui/react";
 import { formatDateToMonthYear } from "@motormetrics/utils";
 import { parseAsString, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 
 export interface AdoptionColumn {
   month: string;
@@ -44,7 +45,13 @@ export function AdoptionColumns({
             aria-pressed={isSelected}
             className="grid h-[150px] flex-1 cursor-pointer grid-rows-[auto_1fr_auto] gap-2"
             key={column.month}
-            onClick={() => setMonth(column.month)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "month",
+                value: column.month,
+              });
+              setMonth(column.month);
+            }}
             type="button"
           >
             <span

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/query-tabs.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/components/query-tabs.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@heroui/react";
 import { parseAsString, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 
 interface QueryTabsProps<Value extends string> {
   /** Accessible name for the group, since the tabs carry no visible label. */
@@ -68,7 +69,13 @@ export function QueryTabs<Value extends string>({
               isActive && "font-extrabold",
             )}
             key={option.key}
-            onClick={() => setValue(option.key)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: param,
+                value: option.key,
+              });
+              setValue(option.key);
+            }}
             type="button"
           >
             {option.label}

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/[make]/components/filters.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/[make]/components/filters.tsx
@@ -6,6 +6,7 @@ import {
   RANGES,
 } from "@web/app/(main)/(dashboard)/cars/makes/[make]/search-params";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { useTransition } from "react";
 
 /*
@@ -44,7 +45,13 @@ export function PeriodTabs() {
                 : "bg-surface font-semibold text-muted hover:text-foreground",
             )}
             key={option}
-            onClick={() => setRange(option)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "range",
+                value: option,
+              });
+              setRange(option);
+            }}
             type="button"
           >
             {RANGE_LABELS[option]}
@@ -92,7 +99,13 @@ export function FuelTypeTabs({ fuelTypes }: { fuelTypes: string[] }) {
                 : "font-semibold text-muted hover:text-foreground",
             )}
             key={label}
-            onClick={() => setSelected(key)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "fuel_type",
+                value: key,
+              });
+              setSelected(key);
+            }}
             type="button"
           >
             {label}

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-header-meta.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-header-meta.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@heroui/react";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { useTransition } from "react";
 import { RANGE_LABELS, RANGES } from "../search-params";
 
@@ -36,7 +37,13 @@ export function MakesHeaderMeta() {
                 : "font-semibold text-muted hover:text-foreground",
             )}
             key={option}
-            onClick={() => setRange(option)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "range",
+                value: option,
+              });
+              setRange(option);
+            }}
             type="button"
           >
             {RANGE_LABELS[option]}

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-table.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-table.test.tsx
@@ -138,18 +138,19 @@ describe("MakesTable", () => {
     expect(makeNames()).toEqual(["byd", "toyota", "mazda"]);
   });
 
-  it("captures car_make_searched when a row is opened", async () => {
+  it("captures car_make_selected when a row is opened", async () => {
     const user = userEvent.setup();
     renderTable();
 
     await user.click(screen.getAllByRole("link")[1]);
 
-    expect(capture).toHaveBeenCalledExactlyOnceWith("car_make_searched", {
+    expect(capture).toHaveBeenCalledExactlyOnceWith("car_make_selected", {
       make: "BYD",
+      source: "makes_table",
     });
   });
 
-  it("does not capture car_make_searched while the query is being typed", async () => {
+  it("does not capture car_make_selected while the query is being typed", async () => {
     const user = userEvent.setup();
     renderTable();
 

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-table.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-table.tsx
@@ -121,7 +121,7 @@ function ChangeText({
 }
 
 function trackMakeSelected(make: string) {
-  posthog.capture("car_make_searched", { make });
+  posthog.capture("car_make_selected", { make, source: "makes_table" });
 }
 
 function compareRows(a: MakesTableRow, b: MakesTableRow, key: SortKey): number {

--- a/apps/web/src/app/(main)/(dashboard)/cars/parf/components/parf-calculator.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/parf/components/parf-calculator.tsx
@@ -13,6 +13,7 @@ import {
   ReportHeadline,
   ReportStat,
 } from "@web/components/shared/report";
+import posthog from "posthog-js";
 import { useMemo, useState } from "react";
 
 /**
@@ -54,6 +55,12 @@ export function PARFCalculator() {
           <Input
             aria-label="ARF paid"
             inputMode="numeric"
+            onBlur={() =>
+              posthog.capture("parf_calculator_used", {
+                bracket: bracket.label,
+                field: "arf",
+              })
+            }
             onChange={(event) => setArfInput(event.target.value)}
             placeholder="e.g. 40,000"
             type="text"
@@ -62,7 +69,14 @@ export function PARFCalculator() {
         </div>
         <div className="flex min-w-64 flex-col gap-2">
           <Select
-            onChange={(key) => key && setBracketKey(String(key))}
+            onChange={(key) => {
+              if (!key) return;
+              posthog.capture("parf_calculator_used", {
+                bracket: AGE_BRACKETS[Number(key)]?.label,
+                field: "bracket",
+              });
+              setBracketKey(String(key));
+            }}
             value={bracketKey}
           >
             <Label>

--- a/apps/web/src/app/(main)/(dashboard)/cars/registrations/components/category-info.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/registrations/components/category-info.tsx
@@ -4,6 +4,7 @@ import { cn, Typography } from "@heroui/react";
 
 import type { COECategory } from "@web/types";
 import type { LucideIcon } from "lucide-react";
+import posthog from "posthog-js";
 
 interface CategoryInfoProps {
   icon: LucideIcon;
@@ -24,6 +25,10 @@ export function CategoryInfo({
 }: CategoryInfoProps) {
   const handleFilterCategories = () => {
     if (canFilter) {
+      posthog.capture("dashboard_filter_changed", {
+        filter: "category",
+        value: category,
+      });
       onToggle(category);
     }
   };

--- a/apps/web/src/app/(main)/(dashboard)/cars/registrations/components/filters.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/registrations/components/filters.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@heroui/react";
 import { RANGES } from "@web/app/(main)/(dashboard)/cars/registrations/search-params";
 import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { useTransition } from "react";
 
 /*
@@ -47,7 +48,13 @@ export function FuelTypeTabs({ fuelTypes }: { fuelTypes: string[] }) {
                 : "bg-surface font-semibold text-muted hover:text-foreground",
             )}
             key={label}
-            onClick={() => setSelected(key)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "fuel_type",
+                value: key,
+              });
+              setSelected(key);
+            }}
             type="button"
           >
             {label}
@@ -88,7 +95,13 @@ export function RangeTabs() {
                 : "font-semibold text-muted hover:text-foreground",
             )}
             key={option}
-            onClick={() => setRange(option)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "range",
+                value: option,
+              });
+              setRange(option);
+            }}
             type="button"
           >
             {option}

--- a/apps/web/src/app/(main)/(dashboard)/cars/registrations/trends-compare-button.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/registrations/trends-compare-button.tsx
@@ -6,6 +6,7 @@ import { TrendsComparison } from "@web/components/trends-comparison";
 import type { ComparisonData } from "@web/queries/cars/compare";
 import type { Month } from "@web/types";
 import { TrendingUp } from "lucide-react";
+import posthog from "posthog-js";
 import { useState } from "react";
 
 interface TrendsCompareButtonProps {
@@ -21,10 +22,15 @@ export function TrendsCompareButton({
 }: TrendsCompareButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
 
+  const openComparison = () => {
+    posthog.capture("trends_compare_opened");
+    setIsOpen(true);
+  };
+
   return (
     <>
       <div className="flex justify-end">
-        <Button variant="primary" onPress={() => setIsOpen(true)}>
+        <Button variant="primary" onPress={openComparison}>
           <TrendingUp className="size-4" />
           Compare Trends
         </Button>

--- a/apps/web/src/app/(main)/(dashboard)/coe/components/coe-controls.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/components/coe-controls.tsx
@@ -3,6 +3,7 @@
 import { cn, ScrollShadow } from "@heroui/react";
 import { Segment } from "@heroui-pro/react";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { type ReactNode, useTransition } from "react";
 import {
   CATEGORY_KEYS,
@@ -50,7 +51,13 @@ export function CategoryTabs({ selected }: { selected: CategoryKey }) {
                 : "bg-accent-foreground/20 text-accent-foreground hover:bg-accent-foreground/30",
             )}
             key={key}
-            onClick={() => setCategory(key)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "category",
+                value: key,
+              });
+              setCategory(key);
+            }}
             type="button"
           >
             {key}
@@ -85,7 +92,13 @@ export function CategorySelect({
       aria-label={label}
       aria-pressed={isActive}
       className={cn("w-full cursor-pointer text-left", className)}
-      onClick={() => setCategory(category)}
+      onClick={() => {
+        posthog.capture("dashboard_filter_changed", {
+          filter: "category",
+          value: category,
+        });
+        setCategory(category);
+      }}
       type="button"
     >
       {children}
@@ -120,7 +133,13 @@ export function RangeTabs() {
       <Segment
         aria-label="Exercise range"
         className={cn(isPending && "opacity-70")}
-        onSelectionChange={(key) => setRange(key as ExerciseRange)}
+        onSelectionChange={(key) => {
+          posthog.capture("dashboard_filter_changed", {
+            filter: "range",
+            value: key,
+          });
+          setRange(key as ExerciseRange);
+        }}
         selectedKey={range}
       >
         {EXERCISE_RANGES.map((option) => (

--- a/apps/web/src/app/(main)/(dashboard)/coe/pqp/components/pqp-filters.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/pqp/components/pqp-filters.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@heroui/react";
 import type { PQPCategoryKey } from "@web/app/(main)/(dashboard)/coe/pqp/search-params";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { useTransition } from "react";
 
 /**
@@ -64,7 +65,13 @@ export function CategoryTabs({
                 : "bg-surface font-semibold text-muted hover:text-foreground",
             )}
             key={option}
-            onClick={() => setCategory(option)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "category",
+                value: option,
+              });
+              setCategory(option);
+            }}
             type="button"
           >
             Cat {option}
@@ -110,7 +117,13 @@ export function TermTabs() {
                 : "font-semibold text-muted hover:text-foreground",
             )}
             key={option}
-            onClick={() => setTerm(option)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "term",
+                value: option,
+              });
+              setTerm(option);
+            }}
             type="button"
           >
             {TERM_LABELS[option]}

--- a/apps/web/src/app/(main)/(dashboard)/coe/premiums/components/filters.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/premiums/components/filters.tsx
@@ -10,6 +10,7 @@ import {
   premiumsSearchParams,
 } from "@web/app/(main)/(dashboard)/coe/premiums/search-params";
 import { useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { useTransition } from "react";
 
 /**
@@ -61,7 +62,13 @@ export function CategoryTabs() {
                 : "bg-surface font-semibold text-muted hover:text-foreground",
             )}
             key={key}
-            onClick={() => setCategory(key)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "category",
+                value: key,
+              });
+              setCategory(key);
+            }}
             type="button"
           >
             {key} · {CATEGORY_SHORT_NAMES[key]}
@@ -100,7 +107,13 @@ export function RangeTabs() {
                 : "font-semibold text-muted hover:text-foreground",
             )}
             key={option}
-            onClick={() => setRange(option)}
+            onClick={() => {
+              posthog.capture("dashboard_filter_changed", {
+                filter: "range",
+                value: option,
+              });
+              setRange(option);
+            }}
             type="button"
           >
             {option}

--- a/apps/web/src/app/(main)/(dashboard)/coe/results/components/series-filter.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/results/components/series-filter.tsx
@@ -5,6 +5,7 @@ import { COE_CATEGORIES } from "@web/app/(main)/(dashboard)/coe/components/coe-e
 import { coeSearchParams } from "@web/app/(main)/(dashboard)/coe/search-params";
 import type { COECategory } from "@web/types";
 import { useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { useTransition } from "react";
 
 /**
@@ -31,12 +32,17 @@ export function SeriesFilter() {
     coeSearchParams.categories.withOptions({ shallow: false, startTransition }),
   );
 
-  const toggle = (category: COECategory) =>
+  const toggle = (category: COECategory) => {
+    posthog.capture("dashboard_filter_changed", {
+      filter: "series",
+      value: category,
+    });
     setSelected(
       selected.includes(category)
         ? selected.filter((entry) => entry !== category)
         : [...selected, category],
     );
+  };
 
   return (
     <fieldset

--- a/apps/web/src/app/(main)/(dashboard)/components/coe-premiums-card.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/coe-premiums-card.tsx
@@ -5,6 +5,7 @@ import { buttonVariants } from "@heroui/styles";
 import { NumberValue } from "@heroui-pro/react";
 import { ArrowUpRight, Calculator } from "lucide-react";
 import Link from "next/link";
+import posthog from "posthog-js";
 import { useState } from "react";
 import { CostTrendChip } from "./cost-trend-chip";
 
@@ -98,7 +99,13 @@ export function CoePremiumsCard({ series }: { series: CoeCategorySeries[] }) {
                     : "bg-default text-muted hover:bg-accent/15"
                 }`}
                 key={item.category}
-                onClick={() => setSelected(item.category)}
+                onClick={() => {
+                  posthog.capture("dashboard_filter_changed", {
+                    filter: "category",
+                    value: item.category,
+                  });
+                  setSelected(item.category);
+                }}
                 type="button"
               >
                 {item.label}

--- a/apps/web/src/app/(main)/(site)/blog/components/share-buttons.tsx
+++ b/apps/web/src/app/(main)/(site)/blog/components/share-buttons.tsx
@@ -6,6 +6,7 @@ import { SiTelegram, SiWhatsapp, SiX } from "@icons-pack/react-simple-icons";
 import { SITE_URL } from "@web/config";
 import { Check, Copy, Linkedin, Share2 } from "lucide-react";
 import Link from "next/link";
+import posthog from "posthog-js";
 import { useState } from "react";
 
 interface ShareButtonsProps {
@@ -19,13 +20,19 @@ export function ShareButtons({ url, title }: ShareButtonsProps) {
   const encodedUrl = encodeURIComponent(fullUrl);
   const encodedTitle = encodeURIComponent(title);
 
+  function trackShare(channel: string) {
+    posthog.capture("page_shared", { channel, content_type: "blog" });
+  }
+
   async function copyLink() {
+    trackShare("copy");
     await navigator.clipboard.writeText(fullUrl);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }
 
   async function nativeShare() {
+    trackShare("native");
     await navigator.share({ title, url: fullUrl });
   }
 
@@ -81,6 +88,7 @@ export function ShareButtons({ url, title }: ShareButtonsProps) {
               variant: "tertiary",
             })}
             href={linkedinUrl}
+            onClick={() => trackShare("linkedin")}
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -97,6 +105,7 @@ export function ShareButtons({ url, title }: ShareButtonsProps) {
               variant: "tertiary",
             })}
             href={telegramUrl}
+            onClick={() => trackShare("telegram")}
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -113,6 +122,7 @@ export function ShareButtons({ url, title }: ShareButtonsProps) {
               variant: "tertiary",
             })}
             href={whatsappUrl}
+            onClick={() => trackShare("whatsapp")}
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -129,6 +139,7 @@ export function ShareButtons({ url, title }: ShareButtonsProps) {
               variant: "tertiary",
             })}
             href={xUrl}
+            onClick={() => trackShare("x")}
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/apps/web/src/app/(main)/(site)/learn/[slug]/components/guide-head.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/[slug]/components/guide-head.tsx
@@ -41,7 +41,7 @@ export function GuideHead({ guide }: { guide: Guide }) {
             year: "numeric",
           })}
         </span>
-        <SharePill title={guide.title} />
+        <SharePill contentType="guide" title={guide.title} />
       </div>
     </div>
   );

--- a/apps/web/src/components/notification-prompt.test.tsx
+++ b/apps/web/src/components/notification-prompt.test.tsx
@@ -3,6 +3,10 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NotificationPrompt } from "./notification-prompt";
 
+const capture = vi.hoisted(() => vi.fn());
+
+vi.mock("posthog-js", () => ({ default: { capture } }));
+
 vi.mock("@heroui/react", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   const toastMock = Object.assign(
@@ -138,6 +142,9 @@ describe("NotificationPrompt Component", () => {
     });
 
     expect(globalThis.Notification.requestPermission).toHaveBeenCalledOnce();
+    expect(capture).toHaveBeenCalledWith("notification_prompt_answered", {
+      answer: "enabled",
+    });
     expect(toast.close).toHaveBeenCalledWith("notification-toast-id");
     expect(toast.success).toHaveBeenCalledWith("Notifications enabled", {
       description: "You will receive an alert when new data is published.",
@@ -151,6 +158,9 @@ describe("NotificationPrompt Component", () => {
     fireEvent.click(screen.getAllByTestId("button")[1]);
 
     expect(globalThis.Notification.requestPermission).not.toHaveBeenCalled();
+    expect(capture).toHaveBeenCalledWith("notification_prompt_answered", {
+      answer: "dismissed",
+    });
     expect(toast.close).toHaveBeenCalledWith("notification-toast-id");
     expect(localStorageMock.setItem).toHaveBeenCalledWith(
       "motormetrics:notification-prompt-dismissed",

--- a/apps/web/src/components/notification-prompt.tsx
+++ b/apps/web/src/components/notification-prompt.tsx
@@ -2,6 +2,7 @@
 
 import { Button, toast } from "@heroui/react";
 
+import posthog from "posthog-js";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 const NOTIFICATION_PROMPT_DISMISSED_KEY =
@@ -40,7 +41,13 @@ export function NotificationPrompt() {
     rememberDismissal();
   }, [rememberDismissal]);
 
+  const handleDismiss = useCallback(() => {
+    posthog.capture("notification_prompt_answered", { answer: "dismissed" });
+    closePrompt();
+  }, [closePrompt]);
+
   const handleEnable = useCallback(async () => {
+    posthog.capture("notification_prompt_answered", { answer: "enabled" });
     closePrompt();
     const nextPermission = await Notification.requestPermission();
 
@@ -80,7 +87,7 @@ export function NotificationPrompt() {
               <Button onPress={handleEnable} size="sm" variant="primary">
                 {NOTIFICATION_PROMPT.allowLabel}
               </Button>
-              <Button onPress={closePrompt} size="sm" variant="tertiary">
+              <Button onPress={handleDismiss} size="sm" variant="tertiary">
                 {NOTIFICATION_PROMPT.dismissLabel}
               </Button>
             </div>
@@ -93,7 +100,7 @@ export function NotificationPrompt() {
     }, NOTIFICATION_PROMPT_DELAY_MS);
 
     return () => window.clearTimeout(timer);
-  }, [closePrompt, handleClose, handleEnable, isPromptDismissed]);
+  }, [handleDismiss, handleClose, handleEnable, isPromptDismissed]);
 
   return null;
 }

--- a/apps/web/src/components/shared/month-selector.tsx
+++ b/apps/web/src/components/shared/month-selector.tsx
@@ -15,6 +15,7 @@ import type { Month } from "@web/types";
 import { groupByYear } from "@web/utils/group-by-year";
 import { Calendar } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { useEffect, useMemo, useRef } from "react";
 
 interface MonthSelectorProps {
@@ -51,7 +52,13 @@ export function MonthSelector({
   return (
     <ComboBox
       selectedKey={month}
-      onSelectionChange={(key) => setMonth(key as string)}
+      onSelectionChange={(key) => {
+        posthog.capture("dashboard_filter_changed", {
+          filter: "month",
+          value: key,
+        });
+        setMonth(key as string);
+      }}
     >
       <Label className="sr-only">Month</Label>
       <ComboBox.InputGroup className="relative">

--- a/apps/web/src/components/shared/share-pill.tsx
+++ b/apps/web/src/components/shared/share-pill.tsx
@@ -7,6 +7,7 @@ import { SiTelegram, SiWhatsapp, SiX } from "@icons-pack/react-simple-icons";
 import { SITE_URL } from "@web/config";
 import { Check, Link2, Linkedin, Share2 } from "lucide-react";
 import { usePathname } from "next/navigation";
+import posthog from "posthog-js";
 import { useState } from "react";
 
 const COPY_KEY = "copy";
@@ -49,13 +50,27 @@ const TARGETS = [
  * buttons, which suits an article footer but not the page head, where the comp
  * budgets one control's width beside the month picker.
  */
-export function SharePill({ title }: { title: string }) {
+export function SharePill({
+  title,
+  contentType = "dashboard",
+}: {
+  title: string;
+  contentType?: "dashboard" | "guide";
+}) {
   const pathname = usePathname();
   const [copied, setCopied] = useState(false);
 
   const url = `${SITE_URL}${pathname}`;
 
   const handleAction = async (key: Key) => {
+    const channel =
+      key === COPY_KEY
+        ? "copy"
+        : TARGETS.find(
+            (target) => target.build(url, title) === key,
+          )?.label.toLowerCase();
+    posthog.capture("page_shared", { channel, content_type: contentType });
+
     if (key === COPY_KEY) {
       await navigator.clipboard.writeText(url);
       setCopied(true);

--- a/apps/web/src/components/shared/year-selector.test.tsx
+++ b/apps/web/src/components/shared/year-selector.test.tsx
@@ -7,6 +7,9 @@ import {
 import { YearSelector } from "./year-selector";
 
 const onUrlUpdate = vi.fn<OnUrlUpdateFunction>();
+const capture = vi.hoisted(() => vi.fn());
+
+vi.mock("posthog-js", () => ({ default: { capture } }));
 
 const wrapper = withNuqsTestingAdapter({
   searchParams: { year: "2024" },
@@ -92,6 +95,10 @@ describe("YearSelector", () => {
     await waitFor(() =>
       expect(lastUrlUpdate()?.searchParams.get("year")).toBe("2022"),
     );
+    expect(capture).toHaveBeenCalledWith("dashboard_filter_changed", {
+      filter: "year",
+      value: "2022",
+    });
 
     fireEvent.change(screen.getByTestId("year-selector"), {
       target: { value: "" },

--- a/apps/web/src/components/shared/year-selector.tsx
+++ b/apps/web/src/components/shared/year-selector.tsx
@@ -4,6 +4,7 @@ import { ComboBox, Input, Label, ListBox, toast } from "@heroui/react";
 
 import { Calendar } from "lucide-react";
 import { parseAsInteger, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { useEffect, useRef } from "react";
 
 interface YearSelectorProps {
@@ -37,7 +38,13 @@ export function YearSelector({
   return (
     <ComboBox
       selectedKey={year?.toString()}
-      onSelectionChange={(key) => setYear(key ? Number(key) : null)}
+      onSelectionChange={(key) => {
+        posthog.capture("dashboard_filter_changed", {
+          filter: "year",
+          value: key,
+        });
+        setYear(key ? Number(key) : null);
+      }}
     >
       <Label className="sr-only">Year</Label>
       <ComboBox.InputGroup className="relative">

--- a/apps/web/src/components/trends-comparison.tsx
+++ b/apps/web/src/components/trends-comparison.tsx
@@ -19,6 +19,7 @@ import { groupByYear } from "@web/utils/group-by-year";
 import { format, subMonths } from "date-fns";
 import { Calendar } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
+import posthog from "posthog-js";
 import { useEffect, useMemo } from "react";
 
 interface TrendsComparisonProps {
@@ -90,12 +91,20 @@ export function TrendsComparison({
 
   const renderMonthPicker = (
     label: string,
+    filter: "compare_a" | "compare_b",
     value: string,
     onChange: (val: string) => void,
   ) => (
     <ComboBox
       selectedKey={value}
-      onSelectionChange={(key) => key && onChange(key as string)}
+      onSelectionChange={(key) => {
+        if (!key) return;
+        posthog.capture("dashboard_filter_changed", {
+          filter,
+          value: key,
+        });
+        onChange(key as string);
+      }}
     >
       <Label>{label}</Label>
       <ComboBox.InputGroup className="relative">
@@ -144,8 +153,8 @@ export function TrendsComparison({
           </Drawer.Header>
           <Drawer.Body className="flex flex-col gap-6">
             <div className="grid grid-cols-2 gap-4">
-              {renderMonthPicker("Month A", monthA, setCompareA)}
-              {renderMonthPicker("Month B", monthB, setCompareB)}
+              {renderMonthPicker("Month A", "compare_a", monthA, setCompareA)}
+              {renderMonthPicker("Month B", "compare_b", monthB, setCompareB)}
             </div>
             {!comparisonData && (
               <div className="flex justify-center py-8">


### PR DESCRIPTION
- Capture `dashboard_filter_changed` with a `filter` and `value` from the shared month and year selectors, the compare drawer and every category, range, period, measure, term, series, fuel type and dimension control on the cars and COE pages
- Capture `page_shared` with `channel` and `content_type` from the dashboard and guide share pill and the blog share buttons
- Add `trends_compare_opened`, `parf_calculator_used` and `notification_prompt_answered`
- Rename the makes table row click to `car_make_selected` with a `source` property so it no longer collides with the combobox `car_make_searched` event
- Extend the affected component tests with capture assertions
- Three funnels (Explore → Interact → Share, Content → Data, Make discovery) and two breakdown trends are already saved on the Analytics basics dashboard and will populate once this deploys

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791024502&installation_model_id=21947&pr_number=966&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F966&signature=5a9325c26d6f857420099f75650b05651bff05e55a663f16c11e430c1a10a607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->