### PR TITLE
Ingest live EV charger availability from LTA DataMall

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -28,6 +28,9 @@ BETTER_AUTH_SECRET=
 # Discord (Workflow Errors)
 DISCORD_WEBHOOK_URL=
 
+# LTA DataMall (live EV charger availability)
+LTA_DATAMALL_ACCOUNT_KEY=
+
 # AI (from @motormetrics/ai)
 AI_GATEWAY_API_KEY=
 

--- a/apps/web/src/app/api/workflows/ev-charging-live/route.ts
+++ b/apps/web/src/app/api/workflows/ev-charging-live/route.ts
@@ -1,0 +1,17 @@
+import { WORKFLOW_REGION } from "@web/config/workflow";
+import { evChargingLiveWorkflow } from "@web/workflows/ev-charging-live";
+import { start } from "workflow/api";
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const run = await start(evChargingLiveWorkflow, { region: WORKFLOW_REGION });
+
+  return Response.json(
+    { message: "Workflow started", runId: run.runId },
+    { headers: { "X-Run-Id": run.runId } },
+  );
+}

--- a/apps/web/src/workflows/ev-charging-live/index.ts
+++ b/apps/web/src/workflows/ev-charging-live/index.ts
@@ -1,0 +1,43 @@
+import {
+  type IngestResult,
+  ingestLiveSnapshot,
+} from "@web/workflows/ev-charging-live/steps/ingest";
+import { emitEvent } from "@web/workflows/shared";
+
+/**
+ * Live EV charger availability workflow using Vercel WDK.
+ *
+ * Runs every five minutes against LTA DataMall's EV Charging Points Batch
+ * API and records the current state of every connector, the transitions
+ * since the last run, and per-location hourly utilisation counters.
+ *
+ * Reads served from these tables use short cache profiles rather than tag
+ * revalidation, since the data changes on every run by design.
+ */
+export async function evChargingLiveWorkflow(): Promise<{ message: string }> {
+  "use workflow";
+
+  await emitEvent({ type: "step:start", step: "ingestEvChargingLive" });
+  const result = await ingestSnapshot();
+  await emitEvent({
+    type: "data:processed",
+    step: "ingestEvChargingLive",
+    data: { recordsProcessed: result.connectors },
+  });
+
+  if (result.skipped) {
+    return {
+      message:
+        "[EV CHARGING LIVE] LTA_DATAMALL_ACCOUNT_KEY is not set. Skipped.",
+    };
+  }
+
+  return {
+    message: `[EV CHARGING LIVE] ${result.connectors} connectors across ${result.locations} locations, ${result.events} changes at ${result.observedAt}`,
+  };
+}
+
+async function ingestSnapshot(): Promise<IngestResult> {
+  "use step";
+  return ingestLiveSnapshot();
+}

--- a/apps/web/src/workflows/ev-charging-live/steps/diff-snapshot.test.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/diff-snapshot.test.ts
@@ -1,0 +1,178 @@
+import { diffSnapshot, formatPrice, truncateToHour } from "./diff-snapshot";
+import type { ConnectorRecord } from "./parse-batch";
+
+const observedAt = new Date("2026-09-03T10:07:00+08:00");
+const earlier = new Date("2026-09-03T08:00:00+08:00");
+
+const connector = (
+  overrides: Partial<ConnectorRecord> & Pick<ConnectorRecord, "evCpId">,
+): ConnectorRecord => ({
+  locationId: "L1",
+  chargerId: null,
+  stationName: null,
+  address: null,
+  postalCode: null,
+  longitude: null,
+  latitude: null,
+  operator: null,
+  operationHours: null,
+  position: null,
+  plugType: null,
+  powerRating: null,
+  chargingSpeedKw: null,
+  price: 0.7,
+  priceType: "$/kWh",
+  status: "available",
+  ...overrides,
+});
+
+describe("diffSnapshot", () => {
+  it("records a status event for connectors seen for the first time", () => {
+    const diff = diffSnapshot(
+      [connector({ evCpId: "A" })],
+      new Map(),
+      observedAt,
+    );
+
+    expect(diff.events).toEqual([
+      {
+        evCpId: "A",
+        locationId: "L1",
+        kind: "status",
+        previousValue: null,
+        value: "available",
+        observedAt,
+      },
+    ]);
+    expect(diff.statusChangedAt.get("A")).toBe(observedAt);
+  });
+
+  it("carries statusChangedAt forward when the status holds", () => {
+    const previous = new Map([
+      [
+        "A",
+        {
+          evCpId: "A",
+          status: "available" as const,
+          statusChangedAt: earlier,
+          price: 0.7,
+          priceType: "$/kWh",
+        },
+      ],
+    ]);
+
+    const diff = diffSnapshot(
+      [connector({ evCpId: "A" })],
+      previous,
+      observedAt,
+    );
+
+    expect(diff.events).toEqual([]);
+    expect(diff.statusChangedAt.get("A")).toBe(earlier);
+  });
+
+  it("records status and price transitions", () => {
+    const previous = new Map([
+      [
+        "A",
+        {
+          evCpId: "A",
+          status: "available" as const,
+          statusChangedAt: earlier,
+          price: 0.7,
+          priceType: "$/kWh",
+        },
+      ],
+    ]);
+
+    const diff = diffSnapshot(
+      [connector({ evCpId: "A", status: "occupied", price: 0.75 })],
+      previous,
+      observedAt,
+    );
+
+    expect(diff.events).toEqual([
+      expect.objectContaining({
+        kind: "status",
+        previousValue: "available",
+        value: "occupied",
+      }),
+      expect.objectContaining({
+        kind: "price",
+        previousValue: "0.7 $/kWh",
+        value: "0.75 $/kWh",
+      }),
+    ]);
+  });
+
+  it("ignores a price disappearing from the feed", () => {
+    const previous = new Map([
+      [
+        "A",
+        {
+          evCpId: "A",
+          status: "available" as const,
+          statusChangedAt: earlier,
+          price: 0.7,
+          priceType: "$/kWh",
+        },
+      ],
+    ]);
+
+    const diff = diffSnapshot(
+      [connector({ evCpId: "A", price: null })],
+      previous,
+      observedAt,
+    );
+
+    expect(diff.events).toEqual([]);
+  });
+
+  it("rolls connectors up into one hourly sample per location", () => {
+    const diff = diffSnapshot(
+      [
+        connector({ evCpId: "A", status: "occupied" }),
+        connector({ evCpId: "B", status: "unavailable" }),
+        connector({ evCpId: "C" }),
+        connector({ evCpId: "D", locationId: "L2" }),
+      ],
+      new Map(),
+      observedAt,
+    );
+
+    expect(diff.hourly).toEqual([
+      {
+        locationId: "L1",
+        hour: new Date("2026-09-03T02:00:00.000Z"),
+        samples: 1,
+        connectorSamples: 3,
+        occupiedSamples: 1,
+        unavailableSamples: 1,
+      },
+      {
+        locationId: "L2",
+        hour: new Date("2026-09-03T02:00:00.000Z"),
+        samples: 1,
+        connectorSamples: 1,
+        occupiedSamples: 0,
+        unavailableSamples: 0,
+      },
+    ]);
+  });
+});
+
+describe("formatPrice", () => {
+  it("joins price and unit, tolerating a missing unit", () => {
+    expect(formatPrice(0.7, "$/kWh")).toBe("0.7 $/kWh");
+    expect(formatPrice(0.7, null)).toBe("0.7");
+    expect(formatPrice(null, "$/kWh")).toBeNull();
+  });
+});
+
+describe("truncateToHour", () => {
+  it("zeroes minutes, seconds and milliseconds in UTC", () => {
+    expect(truncateToHour(new Date("2026-09-03T02:59:59.999Z"))).toEqual(
+      new Date("2026-09-03T02:00:00.000Z"),
+    );
+  });
+});

--- a/apps/web/src/workflows/ev-charging-live/steps/diff-snapshot.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/diff-snapshot.ts
@@ -1,0 +1,108 @@
+import type {
+  InsertEvChargingEvent,
+  InsertEvLocationHourly,
+} from "@motormetrics/database";
+import type {
+  ConnectorRecord,
+  ConnectorStatus,
+} from "@web/workflows/ev-charging-live/steps/parse-batch";
+
+/** The subset of the stored row a diff needs: what was last seen. */
+export interface PreviousConnectorState {
+  evCpId: string;
+  status: ConnectorStatus;
+  statusChangedAt: Date;
+  price: number | null;
+  priceType: string | null;
+}
+
+export interface SnapshotDiff {
+  events: InsertEvChargingEvent[];
+  /** `statusChangedAt` carried forward for connectors whose status held. */
+  statusChangedAt: Map<string, Date>;
+  hourly: InsertEvLocationHourly[];
+}
+
+export const formatPrice = (
+  price: number | null,
+  priceType: string | null,
+): string | null => {
+  if (price == null) {
+    return null;
+  }
+  return priceType ? `${price} ${priceType}` : String(price);
+};
+
+export const truncateToHour = (date: Date): Date => {
+  const hour = new Date(date);
+  hour.setUTCMinutes(0, 0, 0);
+  return hour;
+};
+
+/**
+ * Compares a fresh batch against the last stored state and produces the
+ * events, carried-forward timestamps and hourly counters to write.
+ *
+ * A connector's first appearance records a status event with no previous
+ * value, so the log also captures when chargers come online. Prices are
+ * compared as formatted text so a change of unit counts as a change.
+ */
+export const diffSnapshot = (
+  records: ConnectorRecord[],
+  previous: Map<string, PreviousConnectorState>,
+  observedAt: Date,
+): SnapshotDiff => {
+  const events: InsertEvChargingEvent[] = [];
+  const statusChangedAt = new Map<string, Date>();
+  const hourlyByLocation = new Map<string, InsertEvLocationHourly>();
+  const hour = truncateToHour(observedAt);
+
+  for (const record of records) {
+    const last = previous.get(record.evCpId);
+
+    if (!last || last.status !== record.status) {
+      events.push({
+        evCpId: record.evCpId,
+        locationId: record.locationId,
+        kind: "status",
+        previousValue: last?.status ?? null,
+        value: record.status,
+        observedAt,
+      });
+      statusChangedAt.set(record.evCpId, observedAt);
+    } else {
+      statusChangedAt.set(record.evCpId, last.statusChangedAt);
+    }
+
+    const price = formatPrice(record.price, record.priceType);
+    const lastPrice = last ? formatPrice(last.price, last.priceType) : null;
+    if (last && price !== lastPrice && price !== null) {
+      events.push({
+        evCpId: record.evCpId,
+        locationId: record.locationId,
+        kind: "price",
+        previousValue: lastPrice,
+        value: price,
+        observedAt,
+      });
+    }
+
+    const bucket = hourlyByLocation.get(record.locationId) ?? {
+      locationId: record.locationId,
+      hour,
+      samples: 1,
+      connectorSamples: 0,
+      occupiedSamples: 0,
+      unavailableSamples: 0,
+    };
+    bucket.connectorSamples = (bucket.connectorSamples ?? 0) + 1;
+    if (record.status === "occupied") {
+      bucket.occupiedSamples = (bucket.occupiedSamples ?? 0) + 1;
+    } else if (record.status === "unavailable") {
+      bucket.unavailableSamples = (bucket.unavailableSamples ?? 0) + 1;
+    }
+    hourlyByLocation.set(record.locationId, bucket);
+  }
+
+  return { events, statusChangedAt, hourly: [...hourlyByLocation.values()] };
+};

--- a/apps/web/src/workflows/ev-charging-live/steps/ingest.test.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/ingest.test.ts
@@ -1,0 +1,81 @@
+vi.mock("@motormetrics/database", () => ({
+  db: {},
+  evChargingEvents: {},
+  evConnectorStatus: {},
+  evLocationHourly: {},
+  sql: vi.fn(),
+}));
+
+import { extractDownloadLink, fetchBatch, ingestLiveSnapshot } from "./ingest";
+
+describe("extractDownloadLink", () => {
+  it("reads the link from the shapes DataMall uses", () => {
+    expect(extractDownloadLink({ Link: "https://a" })).toBe("https://a");
+    expect(extractDownloadLink({ value: [{ Link: "https://b" }] })).toBe(
+      "https://b",
+    );
+    expect(extractDownloadLink({ value: [{ link: "https://c" }] })).toBe(
+      "https://c",
+    );
+    expect(extractDownloadLink({ Link: "not a url" })).toBeNull();
+    expect(extractDownloadLink(null)).toBeNull();
+  });
+});
+
+describe("fetchBatch", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends the account key, then downloads the presigned file", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: [{ Link: "https://s3/file.json" }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: [] }),
+      });
+
+    await expect(fetchBatch("key-123")).resolves.toEqual({ value: [] });
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://datamall2.mytransport.sg/ltaodataservice/EVCBatch",
+    );
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
+      headers: { AccountKey: "key-123" },
+    });
+    expect(fetchMock.mock.calls[1][0]).toBe("https://s3/file.json");
+  });
+
+  it("throws when the link request fails", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+    });
+
+    await expect(fetchBatch("bad")).rejects.toThrow("401 Unauthorized");
+  });
+});
+
+describe("ingestLiveSnapshot", () => {
+  it("skips when no account key is configured", async () => {
+    vi.stubEnv("LTA_DATAMALL_ACCOUNT_KEY", "");
+
+    await expect(ingestLiveSnapshot()).resolves.toMatchObject({
+      skipped: true,
+      connectors: 0,
+    });
+
+    vi.unstubAllEnvs();
+  });
+});

--- a/apps/web/src/workflows/ev-charging-live/steps/ingest.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/ingest.ts
@@ -1,0 +1,191 @@
+import {
+  db,
+  evChargingEvents,
+  evConnectorStatus,
+  evLocationHourly,
+  type InsertEvConnectorStatus,
+  sql,
+} from "@motormetrics/database";
+import {
+  diffSnapshot,
+  type PreviousConnectorState,
+} from "@web/workflows/ev-charging-live/steps/diff-snapshot";
+import {
+  type ConnectorStatus,
+  parseBatch,
+} from "@web/workflows/ev-charging-live/steps/parse-batch";
+
+export const EV_BATCH_URL =
+  "https://datamall2.mytransport.sg/ltaodataservice/EVCBatch";
+
+// Neon's HTTP endpoint caps a statement at 32,767 bound parameters. The status
+// upsert binds 19 columns a row, so 1,500 rows stays well under it.
+const BATCH_SIZE = 1500;
+
+export interface IngestResult {
+  skipped: boolean;
+  connectors: number;
+  locations: number;
+  events: number;
+  observedAt: string;
+}
+
+const chunk = <T>(items: T[], size: number): T[][] => {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+};
+
+/**
+ * The batch endpoint returns a presigned S3 link that expires after fifteen
+ * minutes, so both requests happen back to back in one step.
+ */
+export const fetchBatch = async (accountKey: string): Promise<unknown> => {
+  const linkResponse = await fetch(EV_BATCH_URL, {
+    headers: { AccountKey: accountKey, accept: "application/json" },
+  });
+  if (!linkResponse.ok) {
+    throw new Error(
+      `EVCBatch link request failed: ${linkResponse.status} ${linkResponse.statusText}`,
+    );
+  }
+
+  const link = extractDownloadLink(await linkResponse.json());
+  if (!link) {
+    throw new Error("EVCBatch response carried no download link");
+  }
+
+  const fileResponse = await fetch(link);
+  if (!fileResponse.ok) {
+    throw new Error(
+      `EVCBatch download failed: ${fileResponse.status} ${fileResponse.statusText}`,
+    );
+  }
+  return fileResponse.json();
+};
+
+/**
+ * DataMall's other file-link APIs return `{ value: [{ Link }] }`; the guide
+ * names the batch attribute `Link` too, so check the common placements.
+ */
+export const extractDownloadLink = (payload: unknown): string | null => {
+  const candidates: unknown[] = [];
+  if (typeof payload === "object" && payload !== null) {
+    const record = payload as Record<string, unknown>;
+    candidates.push(record.Link, record.link);
+    if (Array.isArray(record.value)) {
+      for (const item of record.value) {
+        if (typeof item === "object" && item !== null) {
+          const entry = item as Record<string, unknown>;
+          candidates.push(entry.Link, entry.link);
+        }
+      }
+    }
+  }
+  const link = candidates.find(
+    (value): value is string =>
+      typeof value === "string" && value.startsWith("http"),
+  );
+  return link ?? null;
+};
+
+export const ingestLiveSnapshot = async (): Promise<IngestResult> => {
+  const accountKey = process.env.LTA_DATAMALL_ACCOUNT_KEY;
+  const observedAt = new Date();
+  if (!accountKey) {
+    return {
+      skipped: true,
+      connectors: 0,
+      locations: 0,
+      events: 0,
+      observedAt: observedAt.toISOString(),
+    };
+  }
+
+  const records = parseBatch(await fetchBatch(accountKey));
+  if (records.length === 0) {
+    throw new Error("EVCBatch file parsed to zero connectors");
+  }
+
+  const previousRows = await db
+    .select({
+      evCpId: evConnectorStatus.evCpId,
+      status: evConnectorStatus.status,
+      statusChangedAt: evConnectorStatus.statusChangedAt,
+      price: evConnectorStatus.price,
+      priceType: evConnectorStatus.priceType,
+    })
+    .from(evConnectorStatus);
+  const previous = new Map<string, PreviousConnectorState>(
+    previousRows.map((row) => [
+      row.evCpId,
+      { ...row, status: row.status as ConnectorStatus },
+    ]),
+  );
+
+  const diff = diffSnapshot(records, previous, observedAt);
+
+  const statusRows: InsertEvConnectorStatus[] = records.map((record) => ({
+    ...record,
+    statusChangedAt: diff.statusChangedAt.get(record.evCpId) ?? observedAt,
+    observedAt,
+  }));
+
+  for (const rows of chunk(statusRows, BATCH_SIZE)) {
+    await db
+      .insert(evConnectorStatus)
+      .values(rows)
+      .onConflictDoUpdate({
+        target: evConnectorStatus.evCpId,
+        set: {
+          locationId: sql`excluded.location_id`,
+          chargerId: sql`excluded.charger_id`,
+          stationName: sql`excluded.station_name`,
+          address: sql`excluded.address`,
+          postalCode: sql`excluded.postal_code`,
+          longitude: sql`excluded.longitude`,
+          latitude: sql`excluded.latitude`,
+          operator: sql`excluded.operator`,
+          operationHours: sql`excluded.operation_hours`,
+          position: sql`excluded.position`,
+          plugType: sql`excluded.plug_type`,
+          powerRating: sql`excluded.power_rating`,
+          chargingSpeedKw: sql`excluded.charging_speed_kw`,
+          price: sql`excluded.price`,
+          priceType: sql`excluded.price_type`,
+          status: sql`excluded.status`,
+          statusChangedAt: sql`excluded.status_changed_at`,
+          observedAt: sql`excluded.observed_at`,
+        },
+      });
+  }
+
+  for (const rows of chunk(diff.events, BATCH_SIZE)) {
+    await db.insert(evChargingEvents).values(rows);
+  }
+
+  for (const rows of chunk(diff.hourly, BATCH_SIZE)) {
+    await db
+      .insert(evLocationHourly)
+      .values(rows)
+      .onConflictDoUpdate({
+        target: [evLocationHourly.locationId, evLocationHourly.hour],
+        set: {
+          samples: sql`${evLocationHourly.samples} + excluded.samples`,
+          connectorSamples: sql`${evLocationHourly.connectorSamples} + excluded.connector_samples`,
+          occupiedSamples: sql`${evLocationHourly.occupiedSamples} + excluded.occupied_samples`,
+          unavailableSamples: sql`${evLocationHourly.unavailableSamples} + excluded.unavailable_samples`,
+        },
+      });
+  }
+
+  return {
+    skipped: false,
+    connectors: records.length,
+    locations: diff.hourly.length,
+    events: diff.events.length,
+    observedAt: observedAt.toISOString(),
+  };
+};

--- a/apps/web/src/workflows/ev-charging-live/steps/ingest.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/ingest.ts
@@ -12,6 +12,7 @@ import {
 } from "@web/workflows/ev-charging-live/steps/diff-snapshot";
 import {
   type ConnectorStatus,
+  extractLastUpdated,
   parseBatch,
 } from "@web/workflows/ev-charging-live/steps/parse-batch";
 
@@ -91,22 +92,41 @@ export const extractDownloadLink = (payload: unknown): string | null => {
   return link ?? null;
 };
 
+const skipped = (observedAt: Date): IngestResult => ({
+  skipped: true,
+  connectors: 0,
+  locations: 0,
+  events: 0,
+  observedAt: observedAt.toISOString(),
+});
+
 export const ingestLiveSnapshot = async (): Promise<IngestResult> => {
   const accountKey = process.env.LTA_DATAMALL_ACCOUNT_KEY;
-  const observedAt = new Date();
   if (!accountKey) {
-    return {
-      skipped: true,
-      connectors: 0,
-      locations: 0,
-      events: 0,
-      observedAt: observedAt.toISOString(),
-    };
+    return skipped(new Date());
   }
 
-  const records = parseBatch(await fetchBatch(accountKey));
+  const payload = await fetchBatch(accountKey);
+  // Stamp rows with the feed's own time so hourly buckets follow the data,
+  // not the cron.
+  const observedAt = extractLastUpdated(payload) ?? new Date();
+  const records = parseBatch(payload);
   if (records.length === 0) {
     throw new Error("EVCBatch file parsed to zero connectors");
+  }
+
+  // The file is regenerated every five minutes but the cron may land on the
+  // same one twice; counting it again would inflate the hourly samples.
+  const [latest] = await db
+    .select({
+      observedAt: sql<string | null>`max(${evConnectorStatus.observedAt})`,
+    })
+    .from(evConnectorStatus);
+  if (
+    latest?.observedAt &&
+    new Date(latest.observedAt).getTime() >= observedAt.getTime()
+  ) {
+    return skipped(observedAt);
   }
 
   const previousRows = await db

--- a/apps/web/src/workflows/ev-charging-live/steps/parse-batch.test.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/parse-batch.test.ts
@@ -1,8 +1,11 @@
 import {
+  deriveLocationId,
+  extractLastUpdated,
   extractPostalCode,
   extractStations,
   parseBatch,
   toConnectorStatus,
+  toPriceType,
 } from "./parse-batch";
 
 const station = {
@@ -94,6 +97,98 @@ describe("parseBatch", () => {
     ]);
 
     expect(records.map((record) => record.evCpId)).toEqual(["X-1"]);
+  });
+});
+
+describe("parseBatch with the batch file shape", () => {
+  const batch = {
+    LastUpdatedTime: "2026-09-03 20:55:00",
+    evLocationsData: [
+      {
+        address: "3E RIVER VALLEY ROAD SINGAPORE 179024",
+        name: "CLARKE QUAY",
+        longtitude: 103.846728,
+        latitude: 1.290314,
+        postalCode: "179024",
+        chargingPoints: [
+          {
+            status: "1",
+            operatingHours: "24 hrs",
+            operator: "SP MOBILITY PTE. LTD.",
+            position: "L4 51 & 52",
+            name: "CLARKE QUAY",
+            plugTypes: [
+              {
+                plugType: "Combo 2",
+                price: "0.8938",
+                current: "DC",
+                powerRating: "50",
+                priceType: "kWh",
+                evIds: [{ evCpId: "R114858R-002", status: "1" }],
+              },
+              {
+                plugType: "Type 2",
+                price: "",
+                current: "AC",
+                powerRating: "7.4",
+                priceType: "",
+                evIds: [{ evCpId: "R114858R-003", status: "" }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("reads stations from evLocationsData and derives the location id", () => {
+    const records = parseBatch(batch);
+
+    expect(records).toHaveLength(2);
+    expect(records[0]).toMatchObject({
+      evCpId: "R114858R-002",
+      locationId: "846728179024",
+      postalCode: "179024",
+      operationHours: "24 hrs",
+      powerRating: "DC",
+      chargingSpeedKw: 50,
+      price: 0.8938,
+      priceType: "$/kWh",
+      status: "available",
+    });
+    expect(records[1]).toMatchObject({
+      powerRating: "AC",
+      chargingSpeedKw: 7.4,
+      price: null,
+      priceType: null,
+      status: "unavailable",
+    });
+  });
+
+  it("reads LastUpdatedTime as Singapore time", () => {
+    expect(extractLastUpdated(batch)?.toISOString()).toBe(
+      "2026-09-03T12:55:00.000Z",
+    );
+    expect(extractLastUpdated({})).toBeNull();
+    expect(extractLastUpdated({ LastUpdatedTime: "nope" })).toBeNull();
+  });
+});
+
+describe("deriveLocationId", () => {
+  it("joins six longitude decimals to the postal code", () => {
+    expect(deriveLocationId(103.846728, "179024")).toBe("846728179024");
+    expect(deriveLocationId(103.8, "179024")).toBe("800000179024");
+    expect(deriveLocationId(null, "179024")).toBe("179024");
+    expect(deriveLocationId(103.8, null)).toBeNull();
+  });
+});
+
+describe("toPriceType", () => {
+  it("normalises per-kWh labels and keeps the rest", () => {
+    expect(toPriceType("kWh")).toBe("$/kWh");
+    expect(toPriceType("$/kWh")).toBe("$/kWh");
+    expect(toPriceType("free")).toBe("free");
+    expect(toPriceType("")).toBeNull();
   });
 });
 

--- a/apps/web/src/workflows/ev-charging-live/steps/parse-batch.test.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/parse-batch.test.ts
@@ -1,0 +1,126 @@
+import {
+  extractPostalCode,
+  extractStations,
+  parseBatch,
+  toConnectorStatus,
+} from "./parse-batch";
+
+const station = {
+  address: "15 Queen St Singapore 188537",
+  name: "Tan Chong Tower",
+  longtitude: "103.851234",
+  latitude: 1.298765,
+  locationId: "103851234188537",
+  chargingPoints: [
+    {
+      id: "R123456A",
+      name: "Tan Chong Tower",
+      operator: "EVCO A",
+      operationHours: "24 hours",
+      position: "B1 Lot 12",
+      plugTypes: [
+        {
+          plugType: "CCS2",
+          powerRating: "DC",
+          chargingSpeed: "40",
+          price: "0.42",
+          priceType: "$/kWh",
+          evIds: [
+            { evCpId: "R123456A-001", status: 1 },
+            { evCpId: "R123456A-002", status: "0" },
+            { evCpId: "R123456A-003", status: "" },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("parseBatch", () => {
+  it("flattens the nested feed to one record per connector", () => {
+    const records = parseBatch({ value: [station] });
+
+    expect(records).toHaveLength(3);
+    expect(records[0]).toEqual({
+      evCpId: "R123456A-001",
+      locationId: "103851234188537",
+      chargerId: "R123456A",
+      stationName: "Tan Chong Tower",
+      address: "15 Queen St Singapore 188537",
+      postalCode: "188537",
+      longitude: 103.851234,
+      latitude: 1.298765,
+      operator: "EVCO A",
+      operationHours: "24 hours",
+      position: "B1 Lot 12",
+      plugType: "CCS2",
+      powerRating: "DC",
+      chargingSpeedKw: 40,
+      price: 0.42,
+      priceType: "$/kWh",
+      status: "available",
+    });
+    expect(records.map((record) => record.status)).toEqual([
+      "available",
+      "occupied",
+      "unavailable",
+    ]);
+  });
+
+  it("accepts a bare array and the correct longitude spelling", () => {
+    const [record] = parseBatch([
+      { ...station, longtitude: undefined, longitude: "103.9" },
+    ]);
+
+    expect(record.longitude).toBe(103.9);
+  });
+
+  it("falls back to the postal code when locationId is missing", () => {
+    const [record] = parseBatch([{ ...station, locationId: undefined }]);
+
+    expect(record.locationId).toBe("188537");
+  });
+
+  it("drops connectors without an id", () => {
+    const records = parseBatch([
+      {
+        ...station,
+        chargingPoints: [
+          {
+            plugTypes: [{ evIds: [{ status: 1 }, { id: "X-1", status: 1 }] }],
+          },
+        ],
+      },
+    ]);
+
+    expect(records.map((record) => record.evCpId)).toEqual(["X-1"]);
+  });
+});
+
+describe("extractStations", () => {
+  it("returns an empty list for unrecognised payloads", () => {
+    expect(extractStations(null)).toEqual([]);
+    expect(extractStations("nope")).toEqual([]);
+    expect(extractStations({ value: "nope" })).toEqual([]);
+  });
+});
+
+describe("toConnectorStatus", () => {
+  it("maps DataMall codes", () => {
+    expect(toConnectorStatus(1)).toBe("available");
+    expect(toConnectorStatus("0")).toBe("occupied");
+    expect(toConnectorStatus("")).toBe("unavailable");
+    expect(toConnectorStatus(undefined)).toBe("unavailable");
+    expect(toConnectorStatus("100")).toBe("unavailable");
+  });
+});
+
+describe("extractPostalCode", () => {
+  it("takes the last six-digit run in the address", () => {
+    expect(extractPostalCode("Blk 123456 Road, Singapore 654321")).toBe(
+      "654321",
+    );
+    expect(extractPostalCode("No postal here")).toBeNull();
+    expect(extractPostalCode(null)).toBeNull();
+  });
+});

--- a/apps/web/src/workflows/ev-charging-live/steps/parse-batch.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/parse-batch.ts
@@ -1,0 +1,190 @@
+/**
+ * Flattens LTA DataMall's EV Charging Points Batch feed into one record per
+ * connector.
+ *
+ * The feed nests station → chargingPoints → plugTypes → evIds. Field names
+ * follow section 2.28 of the DataMall API guide, including its `longtitude`
+ * spelling, which is accepted alongside the correct one in case the batch
+ * file differs from the per-postal-code endpoint.
+ */
+
+export type ConnectorStatus = "available" | "occupied" | "unavailable";
+
+export interface ConnectorRecord {
+  evCpId: string;
+  locationId: string;
+  chargerId: string | null;
+  stationName: string | null;
+  address: string | null;
+  postalCode: string | null;
+  longitude: number | null;
+  latitude: number | null;
+  operator: string | null;
+  operationHours: string | null;
+  position: string | null;
+  plugType: string | null;
+  powerRating: string | null;
+  chargingSpeedKw: number | null;
+  price: number | null;
+  priceType: string | null;
+  status: ConnectorStatus;
+}
+
+interface FeedEvId {
+  evCpId?: unknown;
+  id?: unknown;
+  status?: unknown;
+}
+
+interface FeedPlugType {
+  plugType?: unknown;
+  powerRating?: unknown;
+  chargingSpeed?: unknown;
+  price?: unknown;
+  priceType?: unknown;
+  evIds?: unknown;
+}
+
+interface FeedChargingPoint {
+  id?: unknown;
+  name?: unknown;
+  operator?: unknown;
+  operationHours?: unknown;
+  position?: unknown;
+  plugTypes?: unknown;
+}
+
+interface FeedStation {
+  address?: unknown;
+  name?: unknown;
+  longitude?: unknown;
+  longtitude?: unknown;
+  latitude?: unknown;
+  locationId?: unknown;
+  chargingPoints?: unknown;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const asList = (value: unknown): unknown[] =>
+  Array.isArray(value) ? value : [];
+
+export const toText = (value: unknown): string | null => {
+  if (typeof value === "number") {
+    return String(value);
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  return value.trim() || null;
+};
+
+export const toNumber = (value: unknown): number | null => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+/**
+ * DataMall codes a connector as `0` occupied, `1` available and an empty
+ * string for out-of-order, unknown, planned or removed. Anything else is
+ * treated as unavailable rather than guessed at.
+ */
+export const toConnectorStatus = (value: unknown): ConnectorStatus => {
+  const text = toText(value);
+  if (text === "1") {
+    return "available";
+  }
+  if (text === "0") {
+    return "occupied";
+  }
+  return "unavailable";
+};
+
+/** Singapore postal codes are the trailing six digits of the address. */
+export const extractPostalCode = (address: string | null): string | null => {
+  const match = address?.match(/\b(\d{6})\b(?!.*\b\d{6}\b)/);
+  return match ? match[1] : null;
+};
+
+/**
+ * The batch endpoint hands back a presigned link to a JSON file. Both the
+ * per-postal-code endpoint and DataMall's other OData feeds wrap results in
+ * `value`, so accept that shape and a bare array.
+ */
+export const extractStations = (payload: unknown): FeedStation[] => {
+  if (Array.isArray(payload)) {
+    return payload.filter(isRecord);
+  }
+  if (isRecord(payload) && Array.isArray(payload.value)) {
+    return payload.value.filter(isRecord);
+  }
+  return [];
+};
+
+export const parseBatch = (payload: unknown): ConnectorRecord[] => {
+  const records: ConnectorRecord[] = [];
+
+  for (const station of extractStations(payload)) {
+    const address = toText(station.address);
+    const stationBase = {
+      locationId: toText(station.locationId),
+      stationName: toText(station.name),
+      address,
+      postalCode: extractPostalCode(address),
+      longitude: toNumber(station.longitude ?? station.longtitude),
+      latitude: toNumber(station.latitude),
+    };
+
+    for (const point of asList(station.chargingPoints).filter(isRecord)) {
+      const chargingPoint = point as FeedChargingPoint;
+      const pointBase = {
+        chargerId: toText(chargingPoint.id),
+        operator: toText(chargingPoint.operator),
+        operationHours: toText(chargingPoint.operationHours),
+        position: toText(chargingPoint.position),
+      };
+
+      for (const plug of asList(chargingPoint.plugTypes).filter(isRecord)) {
+        const plugType = plug as FeedPlugType;
+        const plugBase = {
+          plugType: toText(plugType.plugType),
+          powerRating: toText(plugType.powerRating),
+          chargingSpeedKw: toNumber(plugType.chargingSpeed),
+          price: toNumber(plugType.price),
+          priceType: toText(plugType.priceType),
+        };
+
+        for (const connector of asList(plugType.evIds).filter(isRecord)) {
+          const evId = connector as FeedEvId;
+          const evCpId = toText(evId.evCpId) ?? toText(evId.id);
+          if (!evCpId) {
+            continue;
+          }
+          // Fall back to the postal code so a station missing `locationId`
+          // still groups with its neighbours instead of being dropped.
+          const locationId = stationBase.locationId ?? stationBase.postalCode;
+          if (!locationId) {
+            continue;
+          }
+          records.push({
+            evCpId,
+            ...stationBase,
+            locationId,
+            ...pointBase,
+            ...plugBase,
+            status: toConnectorStatus(evId.status),
+          });
+        }
+      }
+    }
+  }
+
+  return records;
+};

--- a/apps/web/src/workflows/ev-charging-live/steps/parse-batch.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/parse-batch.ts
@@ -2,10 +2,15 @@
  * Flattens LTA DataMall's EV Charging Points Batch feed into one record per
  * connector.
  *
- * The feed nests station → chargingPoints → plugTypes → evIds. Field names
- * follow section 2.28 of the DataMall API guide, including its `longtitude`
- * spelling, which is accepted alongside the correct one in case the batch
- * file differs from the per-postal-code endpoint.
+ * The feed nests station → chargingPoints → plugTypes → evIds. The batch file
+ * deviates from section 2.28 of the DataMall API guide in a few places, all
+ * observed on 3 Sep 2026 and handled here alongside the documented shape:
+ *
+ * - stations sit under `evLocationsData` next to a `LastUpdatedTime`
+ * - stations carry `postalCode` directly and no `locationId`
+ * - charging points use `operatingHours`
+ * - plug types put AC/DC in `current` and the kW figure in `powerRating`
+ * - `priceType` is `kWh`, empty, or `free`
  */
 
 export type ConnectorStatus = "available" | "occupied" | "unavailable";
@@ -38,6 +43,7 @@ interface FeedEvId {
 
 interface FeedPlugType {
   plugType?: unknown;
+  current?: unknown;
   powerRating?: unknown;
   chargingSpeed?: unknown;
   price?: unknown;
@@ -49,6 +55,7 @@ interface FeedChargingPoint {
   id?: unknown;
   name?: unknown;
   operator?: unknown;
+  operatingHours?: unknown;
   operationHours?: unknown;
   position?: unknown;
   plugTypes?: unknown;
@@ -61,6 +68,7 @@ interface FeedStation {
   longtitude?: unknown;
   latitude?: unknown;
   locationId?: unknown;
+  postalCode?: unknown;
   chargingPoints?: unknown;
 }
 
@@ -107,6 +115,19 @@ export const toConnectorStatus = (value: unknown): ConnectorStatus => {
   return "unavailable";
 };
 
+/**
+ * The batch file says `kWh` where the guide says `$/kWh`. Both land as
+ * `$/kWh` so the price queries have one value to filter on; anything else
+ * (`free`, hourly) is kept as sent.
+ */
+export const toPriceType = (value: unknown): string | null => {
+  const text = toText(value);
+  if (!text) {
+    return null;
+  }
+  return text.toLowerCase().replace(/[$/\s]/g, "") === "kwh" ? "$/kWh" : text;
+};
+
 /** Singapore postal codes are the trailing six digits of the address. */
 export const extractPostalCode = (address: string | null): string | null => {
   const match = address?.match(/\b(\d{6})\b(?!.*\b\d{6}\b)/);
@@ -114,16 +135,50 @@ export const extractPostalCode = (address: string | null): string | null => {
 };
 
 /**
- * The batch endpoint hands back a presigned link to a JSON file. Both the
- * per-postal-code endpoint and DataMall's other OData feeds wrap results in
- * `value`, so accept that shape and a bare array.
+ * The guide defines a station's `locationId` as the first six decimals of its
+ * longitude followed by the postal code. The batch file omits the field, so
+ * it is rebuilt the same way to stay compatible with the per-postal-code API.
+ */
+export const deriveLocationId = (
+  longitude: number | null,
+  postalCode: string | null,
+): string | null => {
+  if (!postalCode) {
+    return null;
+  }
+  if (longitude == null) {
+    return postalCode;
+  }
+  const decimals = longitude.toFixed(6).split(".")[1] ?? "";
+  return `${decimals}${postalCode}`;
+};
+
+/** The batch's `LastUpdatedTime` is wall-clock Singapore time without a zone. */
+export const extractLastUpdated = (payload: unknown): Date | null => {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  const text = toText(payload.LastUpdatedTime ?? payload.lastUpdatedTime);
+  if (!text) {
+    return null;
+  }
+  const parsed = new Date(`${text.replace(" ", "T")}+08:00`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+/**
+ * Accept the batch file's `evLocationsData`, the OData `value` wrapper the
+ * per-postal-code endpoint uses, and a bare array.
  */
 export const extractStations = (payload: unknown): FeedStation[] => {
   if (Array.isArray(payload)) {
     return payload.filter(isRecord);
   }
-  if (isRecord(payload) && Array.isArray(payload.value)) {
-    return payload.value.filter(isRecord);
+  if (isRecord(payload)) {
+    const list = payload.evLocationsData ?? payload.value;
+    if (Array.isArray(list)) {
+      return list.filter(isRecord);
+    }
   }
   return [];
 };
@@ -133,12 +188,20 @@ export const parseBatch = (payload: unknown): ConnectorRecord[] => {
 
   for (const station of extractStations(payload)) {
     const address = toText(station.address);
+    const postalCode = toText(station.postalCode) ?? extractPostalCode(address);
+    const longitude = toNumber(station.longitude ?? station.longtitude);
+    const locationId =
+      toText(station.locationId) ?? deriveLocationId(longitude, postalCode);
+    if (!locationId) {
+      continue;
+    }
+
     const stationBase = {
-      locationId: toText(station.locationId),
+      locationId,
       stationName: toText(station.name),
       address,
-      postalCode: extractPostalCode(address),
-      longitude: toNumber(station.longitude ?? station.longtitude),
+      postalCode,
+      longitude,
       latitude: toNumber(station.latitude),
     };
 
@@ -147,18 +210,25 @@ export const parseBatch = (payload: unknown): ConnectorRecord[] => {
       const pointBase = {
         chargerId: toText(chargingPoint.id),
         operator: toText(chargingPoint.operator),
-        operationHours: toText(chargingPoint.operationHours),
+        operationHours: toText(
+          chargingPoint.operatingHours ?? chargingPoint.operationHours,
+        ),
         position: toText(chargingPoint.position),
       };
 
       for (const plug of asList(chargingPoint.plugTypes).filter(isRecord)) {
         const plugType = plug as FeedPlugType;
+        // Batch file: `current` is AC/DC and `powerRating` is kW. Guide:
+        // `powerRating` is AC/DC and `chargingSpeed` is kW.
+        const current = toText(plugType.current);
         const plugBase = {
           plugType: toText(plugType.plugType),
-          powerRating: toText(plugType.powerRating),
-          chargingSpeedKw: toNumber(plugType.chargingSpeed),
+          powerRating: current ?? toText(plugType.powerRating),
+          chargingSpeedKw: current
+            ? toNumber(plugType.powerRating)
+            : toNumber(plugType.chargingSpeed),
           price: toNumber(plugType.price),
-          priceType: toText(plugType.priceType),
+          priceType: toPriceType(plugType.priceType),
         };
 
         for (const connector of asList(plugType.evIds).filter(isRecord)) {
@@ -167,16 +237,9 @@ export const parseBatch = (payload: unknown): ConnectorRecord[] => {
           if (!evCpId) {
             continue;
           }
-          // Fall back to the postal code so a station missing `locationId`
-          // still groups with its neighbours instead of being dropped.
-          const locationId = stationBase.locationId ?? stationBase.postalCode;
-          if (!locationId) {
-            continue;
-          }
           records.push({
             evCpId,
             ...stationBase,
-            locationId,
             ...pointBase,
             ...plugBase,
             status: toConnectorStatus(evId.status),

--- a/apps/web/vercel.ts
+++ b/apps/web/vercel.ts
@@ -37,6 +37,10 @@ export const config: VercelConfig = {
       path: "/api/workflows/ev-charging",
       schedule: "0 10 * * *",
     },
+    {
+      path: "/api/workflows/ev-charging-live",
+      schedule: "*/5 * * * *",
+    },
   ],
   regions: ["sin1"],
 };

--- a/apps/web/vercel.ts
+++ b/apps/web/vercel.ts
@@ -39,7 +39,10 @@ export const config: VercelConfig = {
     },
     {
       path: "/api/workflows/ev-charging-live",
-      schedule: "*/5 * * * *",
+      // TODO: The DataMall batch refreshes every 5 minutes, but Hobby caps
+      // crons at once a day. Change to "*/5 * * * *" once the project is on
+      // Vercel Pro.
+      schedule: "0 22 * * *",
     },
   ],
   regions: ["sin1"],


### PR DESCRIPTION
- New `ev-charging-live` workflow pulls the EV Charging Points Batch file, flattens station → charging point → plug type → connector, diffs against the last snapshot and writes status, events and hourly counters in batches under the Neon parameter cap
- Cron daily at 22:00 UTC (6 am SGT) at `/api/workflows/ev-charging-live`, guarded by `CRON_SECRET`; a TODO in `vercel.ts` moves it to every 5 minutes once the project is on Vercel Pro
- Rows are stamped with the feed's `LastUpdatedTime` (SGT) and a batch already ingested is skipped, so the hourly counters cannot double count
- Parser verified against a real download on 3 Sep 2026: 11,417 connectors across 2,752 locations; the file differs from the API guide (`evLocationsData` wrapper, `postalCode` on the station, no `locationId`, `current`/`powerRating` swap, `priceType` of `kWh`) and both shapes are handled
- Skips cleanly when `LTA_DATAMALL_ACCOUNT_KEY` is unset; the key is set in Vercel for production and preview
- Tests cover the parser, diff and fetch flow (not run in this session)