### PR TITLE
Add live EV charging page with prices and busy hours

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/busy-hours.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/busy-hours.tsx
@@ -1,0 +1,67 @@
+import { Typography } from "@heroui/react";
+import { SurfaceCard } from "@web/components/shared/bento";
+import { getEvChargingUtilisationByHour } from "@web/queries/ev-charging";
+
+const formatHour = (hour: number) => {
+  const suffix = hour < 12 ? "am" : "pm";
+  const twelve = hour % 12 === 0 ? 12 : hour % 12;
+  return `${twelve} ${suffix}`;
+};
+
+/** Occupancy by hour of day over the past week, as a 24-bar strip. */
+export async function BusyHours() {
+  const hours = await getEvChargingUtilisationByHour();
+  const peak = hours.reduce((best, item) =>
+    item.utilisationPercent > best.utilisationPercent ? item : best,
+  );
+  const max = Math.max(peak.utilisationPercent, 1);
+
+  if (peak.utilisationPercent === 0) {
+    return null;
+  }
+
+  return (
+    <SurfaceCard className="gap-4 p-7">
+      <div className="flex flex-col gap-1">
+        <Typography.Paragraph className="text-muted">
+          Busy hours
+        </Typography.Paragraph>
+        <Typography.Heading level={3}>
+          Busiest at {formatHour(peak.hour)} ·{" "}
+          {peak.utilisationPercent.toFixed(0)}% in use
+        </Typography.Heading>
+      </div>
+
+      <div
+        aria-label="Share of connectors in use by hour of day"
+        className="flex h-32 items-end gap-1"
+        role="img"
+      >
+        {hours.map((item) => (
+          <div
+            className="flex-1 rounded-t-md"
+            key={item.hour}
+            style={{
+              background:
+                item.hour === peak.hour ? "var(--accent)" : "var(--chart-1)",
+              height: `${(item.utilisationPercent / max) * 100}%`,
+              opacity: item.hour === peak.hour ? 1 : 0.55,
+            }}
+            title={`${formatHour(item.hour)} · ${item.utilisationPercent.toFixed(0)}% in use`}
+          />
+        ))}
+      </div>
+      <div className="flex justify-between text-muted text-xs">
+        <span>12 am</span>
+        <span>6 am</span>
+        <span>12 pm</span>
+        <span>6 pm</span>
+        <span>11 pm</span>
+      </div>
+
+      <Typography.Paragraph color="muted" size="xs">
+        Share of connectors in use, Singapore time · past 7 days
+      </Typography.Paragraph>
+    </SurfaceCard>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/district-select.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/district-select.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import {
+  ComboBox,
+  Header,
+  Input,
+  Label,
+  ListBox,
+  Separator,
+} from "@heroui/react";
+import {
+  POSTAL_DISTRICTS,
+  type PostalRegion,
+} from "@web/config/postal-districts";
+import { MapPin } from "lucide-react";
+import { parseAsString, useQueryState } from "nuqs";
+import posthog from "posthog-js";
+
+const ALL_SINGAPORE = "all";
+const REGION_ORDER: PostalRegion[] = [
+  "Central",
+  "East",
+  "North-East",
+  "North",
+  "West",
+];
+
+/** District filter shared by every list on the charging page. */
+export function DistrictSelect({ district }: { district: string }) {
+  const [, setDistrict] = useQueryState(
+    "district",
+    parseAsString.withDefault("").withOptions({ shallow: false }),
+  );
+
+  return (
+    <ComboBox
+      selectedKey={district || ALL_SINGAPORE}
+      onSelectionChange={(key) => {
+        const value = key === ALL_SINGAPORE || key == null ? "" : String(key);
+        posthog.capture("dashboard_filter_changed", {
+          filter: "district",
+          value: value || ALL_SINGAPORE,
+        });
+        setDistrict(value);
+      }}
+    >
+      <Label className="sr-only">District</Label>
+      <ComboBox.InputGroup className="relative">
+        <MapPin
+          aria-hidden
+          className="pointer-events-none absolute top-1/2 left-3.5 z-10 size-4 -translate-y-1/2 text-muted"
+        />
+        <Input className="pl-10" placeholder="All Singapore" />
+        <ComboBox.Trigger />
+      </ComboBox.InputGroup>
+      <ComboBox.Popover>
+        <ListBox>
+          <ListBox.Item id={ALL_SINGAPORE} textValue="All Singapore">
+            All Singapore
+            <ListBox.ItemIndicator />
+          </ListBox.Item>
+          {REGION_ORDER.map((region) => (
+            <ListBox.Section key={region}>
+              <Separator />
+              <Header>{region}</Header>
+              {POSTAL_DISTRICTS.filter((item) => item.region === region).map(
+                (item) => (
+                  <ListBox.Item
+                    id={item.slug}
+                    key={item.slug}
+                    textValue={item.name}
+                  >
+                    {item.name}
+                    <ListBox.ItemIndicator />
+                  </ListBox.Item>
+                ),
+              )}
+            </ListBox.Section>
+          ))}
+        </ListBox>
+      </ComboBox.Popover>
+    </ComboBox>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/live-status.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/live-status.tsx
@@ -1,0 +1,76 @@
+import { Typography } from "@heroui/react";
+import { NumberValue } from "@heroui-pro/react";
+import { HeroCard } from "@web/components/shared/bento";
+import { getEvChargingLiveSummary } from "@web/queries/ev-charging";
+
+const formatObservedAt = (iso: string) =>
+  new Date(iso).toLocaleString("en-SG", {
+    timeZone: "Asia/Singapore",
+    day: "numeric",
+    month: "short",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+/** Island-wide connector state at the last five-minute batch. */
+export async function LiveStatus() {
+  const summary = await getEvChargingLiveSummary();
+  if (summary.connectors === 0 || !summary.observedAt) {
+    return null;
+  }
+
+  const usable = summary.connectors - summary.unavailable;
+  const inUsePercent = usable > 0 ? (summary.occupied / usable) * 100 : 0;
+
+  return (
+    <HeroCard>
+      <span className="w-fit rounded-full bg-accent-foreground/20 px-4 py-2 font-bold text-sm">
+        Live · {formatObservedAt(summary.observedAt)} SGT
+      </span>
+
+      <div className="flex flex-wrap items-center gap-4">
+        <span className="font-extrabold text-6xl tabular-nums tracking-tight">
+          {inUsePercent.toFixed(0)}%
+        </span>
+        <span className="rounded-full bg-accent-foreground/20 px-4 py-2 font-bold text-sm tabular-nums">
+          <NumberValue
+            locale="en-SG"
+            maximumFractionDigits={0}
+            value={summary.available}
+          />{" "}
+          free
+        </span>
+      </div>
+
+      <Typography.Paragraph className="text-accent-foreground/85">
+        of public connectors in use right now
+      </Typography.Paragraph>
+
+      <Typography.Paragraph size="sm" className="text-accent-foreground/70">
+        <NumberValue
+          locale="en-SG"
+          maximumFractionDigits={0}
+          value={summary.connectors}
+        />{" "}
+        connectors across{" "}
+        <NumberValue
+          locale="en-SG"
+          maximumFractionDigits={0}
+          value={summary.locations}
+        />{" "}
+        locations
+        {summary.unavailable > 0 ? (
+          <>
+            {" · "}
+            <NumberValue
+              locale="en-SG"
+              maximumFractionDigits={0}
+              value={summary.unavailable}
+            />{" "}
+            out of service
+          </>
+        ) : null}
+      </Typography.Paragraph>
+    </HeroCard>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/location-row.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/location-row.tsx
@@ -1,0 +1,50 @@
+import { Typography } from "@heroui/react";
+import { districtForPostalCode } from "@web/config/postal-districts";
+import type { EvChargingLocation } from "@web/queries/ev-charging";
+import type { ReactNode } from "react";
+
+/** "2× DC 120 kW" style summary of what a location offers. */
+export const describeConnectors = (location: EvChargingLocation): string => {
+  const rating = location.dcConnectors > 0 ? "DC" : "AC";
+  const speed = location.maxSpeedKw != null ? ` ${location.maxSpeedKw} kW` : "";
+  return `${location.connectors}× ${rating}${speed}`;
+};
+
+/** A location line item shared by the ranked lists on the charging page. */
+export function LocationRow({
+  index,
+  location,
+  trailing,
+}: {
+  index: number;
+  location: EvChargingLocation;
+  /** Right-aligned figure: a price, a percentage, or a date. */
+  trailing: ReactNode;
+}) {
+  const district = districtForPostalCode(location.postalCode);
+  const title = location.stationName ?? location.address ?? location.locationId;
+
+  return (
+    <li className="flex items-center gap-3">
+      <span className="flex size-[26px] shrink-0 items-center justify-center rounded-full bg-accent/15 font-extrabold text-accent-strong text-xs tabular-nums">
+        {index + 1}
+      </span>
+      <div className="flex min-w-0 flex-col">
+        <Typography.Paragraph
+          size="sm"
+          className="truncate font-semibold text-foreground/85"
+        >
+          {title}
+        </Typography.Paragraph>
+        <Typography.Paragraph color="muted" size="xs" className="truncate">
+          {[district?.name, describeConnectors(location)]
+            .filter(Boolean)
+            .join(" · ")}
+        </Typography.Paragraph>
+      </div>
+      <span className="ml-auto shrink-0 font-extrabold text-sm tabular-nums">
+        {trailing}
+      </span>
+    </li>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/price-list.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/price-list.tsx
@@ -1,0 +1,77 @@
+import { Typography } from "@heroui/react";
+import { QueryTabs } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/components/query-tabs";
+import { SurfaceCard } from "@web/components/shared/bento";
+import { getPostalDistrict } from "@web/config/postal-districts";
+import {
+  getEvChargingPriceRankings,
+  type PowerRating,
+  type PriceOrder,
+} from "@web/queries/ev-charging";
+import { LocationRow } from "./location-row";
+
+const POWER_OPTIONS = [
+  { key: "AC" as const, label: "AC" },
+  { key: "DC" as const, label: "DC" },
+];
+
+/** Cheapest or priciest advertised per-kWh rates for one power rating. */
+export async function PriceList({
+  district,
+  order,
+  power,
+}: {
+  district: string;
+  order: PriceOrder;
+  power: PowerRating;
+}) {
+  const locations = await getEvChargingPriceRankings({
+    powerRating: power,
+    order,
+    district: district || undefined,
+  });
+  const scope = getPostalDistrict(district)?.name ?? "Singapore";
+
+  return (
+    <SurfaceCard className="gap-4 p-7">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <Typography.Paragraph className="text-muted">
+            {order === "cheapest" ? "Lowest" : "Highest"} advertised price
+          </Typography.Paragraph>
+          <Typography.Heading level={3}>
+            {order === "cheapest" ? "Cheapest" : "Most expensive"} {power}{" "}
+            charging
+          </Typography.Heading>
+        </div>
+        <QueryTabs
+          ariaLabel="Power rating"
+          options={POWER_OPTIONS}
+          param="power"
+          value={power}
+          variant="segmented"
+        />
+      </div>
+
+      {locations.length === 0 ? (
+        <Typography.Paragraph color="muted" size="sm">
+          No {power} chargers with a per-kWh price in {scope} yet.
+        </Typography.Paragraph>
+      ) : (
+        <ul className="flex flex-col gap-3.5">
+          {locations.map((location, index) => (
+            <LocationRow
+              index={index}
+              key={location.locationId}
+              location={location}
+              trailing={`$${location.pricePerKwh.toFixed(2)}/kWh`}
+            />
+          ))}
+        </ul>
+      )}
+
+      <Typography.Paragraph color="muted" size="xs">
+        Per-kWh rates from LTA DataMall · {scope}
+      </Typography.Paragraph>
+    </SurfaceCard>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/recent-changes.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/recent-changes.tsx
@@ -1,0 +1,96 @@
+import { Typography } from "@heroui/react";
+import { InkPanel } from "@web/components/shared/bento";
+import { districtForPostalCode } from "@web/config/postal-districts";
+import { getEvChargingRecentChanges } from "@web/queries/ev-charging";
+import { Sparkles } from "lucide-react";
+import { describeConnectors } from "./location-row";
+
+const LIMIT = 5;
+
+const formatDay = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-SG", {
+    timeZone: "Asia/Singapore",
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  });
+
+/** New locations and price moves spotted in the past week. */
+export async function RecentChanges() {
+  const { newLocations, priceChanges } = await getEvChargingRecentChanges();
+
+  return (
+    <InkPanel>
+      <div className="flex items-center gap-2.5">
+        <span className="flex size-10 shrink-0 items-center justify-center rounded-2xl bg-accent-on-dark/20 text-accent-on-dark">
+          <Sparkles className="size-5" />
+        </span>
+        <Typography.Paragraph className="text-accent-foreground/85">
+          This week
+        </Typography.Paragraph>
+      </div>
+
+      <Typography.Paragraph
+        size="sm"
+        className="font-bold text-accent-foreground"
+      >
+        New chargers
+      </Typography.Paragraph>
+      {newLocations.length === 0 ? (
+        <Typography.Paragraph size="sm" className="text-accent-foreground/60">
+          No new chargers spotted this week.
+        </Typography.Paragraph>
+      ) : (
+        <ul className="flex flex-col gap-2.5">
+          {newLocations.slice(0, LIMIT).map((location) => (
+            <li className="flex flex-col" key={location.locationId}>
+              <span className="truncate font-bold text-accent-foreground text-sm">
+                {location.stationName ??
+                  location.address ??
+                  location.locationId}
+              </span>
+              <span className="text-accent-foreground/60 text-xs">
+                {[
+                  describeConnectors(location),
+                  districtForPostalCode(location.postalCode)?.name,
+                  `Spotted ${formatDay(location.spottedAt)}`,
+                ]
+                  .filter(Boolean)
+                  .join(" · ")}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Typography.Paragraph
+        size="sm"
+        className="mt-2 font-bold text-accent-foreground"
+      >
+        Price changes
+      </Typography.Paragraph>
+      {priceChanges.length === 0 ? (
+        <Typography.Paragraph size="sm" className="text-accent-foreground/60">
+          No price changes spotted this week.
+        </Typography.Paragraph>
+      ) : (
+        <ul className="flex flex-col gap-2.5">
+          {priceChanges.slice(0, LIMIT).map((change) => (
+            <li
+              className="flex flex-col"
+              key={`${change.locationId}-${change.previousValue}-${change.value}`}
+            >
+              <span className="truncate font-bold text-accent-foreground text-sm">
+                {change.stationName ?? change.address ?? change.locationId}
+              </span>
+              <span className="text-accent-foreground/60 text-xs tabular-nums">
+                {change.previousValue ?? "—"} → {change.value} ·{" "}
+                {formatDay(change.observedAt)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </InkPanel>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/utilisation-list.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/utilisation-list.tsx
@@ -1,0 +1,58 @@
+import { Typography } from "@heroui/react";
+import { SurfaceCard } from "@web/components/shared/bento";
+import { getPostalDistrict } from "@web/config/postal-districts";
+import {
+  getEvChargingLocationUtilisation,
+  type UtilisationOrder,
+} from "@web/queries/ev-charging";
+import { LocationRow } from "./location-row";
+
+/** Locations with the highest or lowest average occupancy this week. */
+export async function UtilisationList({
+  district,
+  order,
+}: {
+  district: string;
+  order: UtilisationOrder;
+}) {
+  const locations = await getEvChargingLocationUtilisation({
+    order,
+    district: district || undefined,
+  });
+  const scope = getPostalDistrict(district)?.name ?? "Singapore";
+
+  return (
+    <SurfaceCard className="gap-4 p-7">
+      <div className="flex flex-col gap-1">
+        <Typography.Paragraph className="text-muted">
+          {order === "busiest" ? "Highest" : "Lowest"} average use
+        </Typography.Paragraph>
+        <Typography.Heading level={3}>
+          {order === "busiest" ? "Busiest" : "Quietest"} locations
+        </Typography.Heading>
+      </div>
+
+      {locations.length === 0 ? (
+        <Typography.Paragraph color="muted" size="sm">
+          Not enough usage history for {scope} yet. Check back after a day of
+          readings.
+        </Typography.Paragraph>
+      ) : (
+        <ul className="flex flex-col gap-3.5">
+          {locations.map((location, index) => (
+            <LocationRow
+              index={index}
+              key={location.locationId}
+              location={location}
+              trailing={`${location.utilisationPercent.toFixed(0)}%`}
+            />
+          ))}
+        </ul>
+      )}
+
+      <Typography.Paragraph color="muted" size="xs">
+        Share of connectors in use · past 7 days · {scope}
+      </Typography.Paragraph>
+    </SurfaceCard>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/page.tsx
@@ -1,0 +1,197 @@
+import { Skeleton } from "@heroui/react";
+import { BusyHours } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/busy-hours";
+import { DistrictSelect } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/district-select";
+import { LiveStatus } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/live-status";
+import { PriceList } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/price-list";
+import { RecentChanges } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/recent-changes";
+import { UtilisationList } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/utilisation-list";
+import { loadSearchParams } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/search-params";
+import { AnimatedGrid } from "@web/app/(main)/(dashboard)/components/animated-grid";
+import { AnimatedSection } from "@web/app/(main)/(dashboard)/components/animated-section";
+import { SectionErrorBoundary } from "@web/components/error-boundary";
+import { Bento } from "@web/components/shared/bento";
+import { EmptyState } from "@web/components/shared/empty-state";
+import { PageHead } from "@web/components/shared/page-head";
+import { StructuredData } from "@web/components/structured-data";
+import { SITE_TITLE, SITE_URL } from "@web/config";
+import { generateBreadcrumbSchema } from "@web/lib/metadata";
+import { getEvChargingLiveSummary } from "@web/queries/ev-charging";
+import { PlugZap } from "lucide-react";
+import type { Metadata } from "next";
+import type { SearchParams } from "nuqs/server";
+import { Suspense } from "react";
+import type { WebPage, WithContext } from "schema-dts";
+
+export const metadata: Metadata = {
+  title: "EV Charging in Singapore",
+  description:
+    "Live public EV charger availability across Singapore, with the cheapest and most expensive charging rates, busiest hours and locations, and new chargers this week.",
+  openGraph: {
+    title: "EV Charging - Live Singapore Charger Stats",
+    description:
+      "Live availability, prices and busy hours for Singapore's public EV chargers.",
+    type: "website",
+  },
+  alternates: {
+    canonical: "/cars/electric-vehicles/charging",
+  },
+};
+
+const structuredData: WithContext<WebPage> = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: "EV Charging",
+  description:
+    "Live public EV charger availability, prices and busy hours across Singapore",
+  url: `${SITE_URL}/cars/electric-vehicles/charging`,
+  publisher: {
+    "@type": "Organization",
+    name: SITE_TITLE,
+    url: SITE_URL,
+  },
+};
+
+interface PageProps {
+  searchParams: Promise<SearchParams>;
+}
+
+function CardSkeleton({ className = "" }: { className?: string }) {
+  return (
+    <div className={`rounded-4xl bg-surface p-7 shadow-surface ${className}`}>
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-4 w-32 rounded-lg" />
+        <Skeleton className="h-12 w-40 rounded-lg" />
+        <Skeleton className="h-6 w-44 rounded-full" />
+      </div>
+    </div>
+  );
+}
+
+export default function ChargingPage({ searchParams }: PageProps) {
+  return (
+    <>
+      <StructuredData data={structuredData} />
+      <StructuredData
+        data={{
+          "@context": "https://schema.org",
+          ...generateBreadcrumbSchema([
+            { name: "Home", path: "/" },
+            { name: "Cars", path: "/cars" },
+            { name: "Electric Vehicles", path: "/cars/electric-vehicles" },
+            { name: "Charging", path: "/cars/electric-vehicles/charging" },
+          ]),
+        }}
+      />
+
+      <PageHead
+        controls={
+          <Suspense fallback={<Skeleton className="h-12 w-56 rounded-full" />}>
+            <DistrictControl searchParams={searchParams} />
+          </Suspense>
+        }
+        title="EV charging"
+      />
+
+      <Suspense
+        fallback={
+          <Bento>
+            <CardSkeleton className="h-[520px]" />
+            <CardSkeleton className="h-[520px]" />
+            <CardSkeleton className="h-[520px]" />
+          </Bento>
+        }
+      >
+        <ChargingBento searchParams={searchParams} />
+      </Suspense>
+    </>
+  );
+}
+
+async function DistrictControl({ searchParams }: PageProps) {
+  const { district } = await loadSearchParams(searchParams);
+  return <DistrictSelect district={district} />;
+}
+
+async function ChargingBento({ searchParams }: PageProps) {
+  const [{ district, power }, summary] = await Promise.all([
+    loadSearchParams(searchParams),
+    getEvChargingLiveSummary(),
+  ]);
+
+  if (summary.connectors === 0) {
+    return (
+      <EmptyState
+        description="Live charger availability has not been collected yet. Please check back later."
+        icon={
+          <div className="flex size-16 items-center justify-center rounded-2xl bg-default">
+            <PlugZap className="size-8 text-muted" />
+          </div>
+        }
+        showDefaultActions={false}
+        title="No Live Data Yet"
+      />
+    );
+  }
+
+  return (
+    <Bento>
+      <AnimatedGrid className="flex flex-col gap-6">
+        <AnimatedSection>
+          <SectionErrorBoundary title="Live status unavailable">
+            <Suspense fallback={<CardSkeleton className="h-80" />}>
+              <LiveStatus />
+            </Suspense>
+          </SectionErrorBoundary>
+        </AnimatedSection>
+        <AnimatedSection>
+          <SectionErrorBoundary title="Busy hours unavailable">
+            <Suspense fallback={<CardSkeleton className="h-72" />}>
+              <BusyHours />
+            </Suspense>
+          </SectionErrorBoundary>
+        </AnimatedSection>
+        <AnimatedSection>
+          <SectionErrorBoundary title="Recent changes unavailable">
+            <Suspense fallback={<CardSkeleton className="h-72" />}>
+              <RecentChanges />
+            </Suspense>
+          </SectionErrorBoundary>
+        </AnimatedSection>
+      </AnimatedGrid>
+
+      <AnimatedGrid className="flex flex-col gap-6">
+        <AnimatedSection>
+          <SectionErrorBoundary title="Cheapest chargers unavailable">
+            <Suspense fallback={<CardSkeleton className="h-[520px]" />}>
+              <PriceList district={district} order="cheapest" power={power} />
+            </Suspense>
+          </SectionErrorBoundary>
+        </AnimatedSection>
+        <AnimatedSection>
+          <SectionErrorBoundary title="Most expensive chargers unavailable">
+            <Suspense fallback={<CardSkeleton className="h-[520px]" />}>
+              <PriceList district={district} order="priciest" power={power} />
+            </Suspense>
+          </SectionErrorBoundary>
+        </AnimatedSection>
+      </AnimatedGrid>
+
+      <AnimatedGrid className="flex flex-col gap-6">
+        <AnimatedSection>
+          <SectionErrorBoundary title="Busiest locations unavailable">
+            <Suspense fallback={<CardSkeleton className="h-[520px]" />}>
+              <UtilisationList district={district} order="busiest" />
+            </Suspense>
+          </SectionErrorBoundary>
+        </AnimatedSection>
+        <AnimatedSection>
+          <SectionErrorBoundary title="Quietest locations unavailable">
+            <Suspense fallback={<CardSkeleton className="h-[520px]" />}>
+              <UtilisationList district={district} order="quietest" />
+            </Suspense>
+          </SectionErrorBoundary>
+        </AnimatedSection>
+      </AnimatedGrid>
+    </Bento>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/search-params.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/search-params.ts
@@ -1,0 +1,12 @@
+import { createLoader, parseAsString, parseAsStringLiteral } from "nuqs/server";
+
+/** Which power rating the price rankings list. */
+export const POWER_RATINGS = ["AC", "DC"] as const;
+
+export const chargingSearchParams = {
+  /** Postal district slug from `config/postal-districts`; empty means all. */
+  district: parseAsString.withDefault(""),
+  power: parseAsStringLiteral(POWER_RATINGS).withDefault("DC"),
+};
+
+export const loadSearchParams = createLoader(chargingSearchParams);

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -65,6 +65,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly" as const,
     },
     {
+      url: `${SITE_URL}/cars/electric-vehicles/charging`,
+      lastModified: new Date(),
+      changeFrequency: "hourly" as const,
+    },
+    {
       url: `${SITE_URL}/cars/deregistrations`,
       lastModified: new Date(),
       changeFrequency: "monthly" as const,

--- a/apps/web/src/config/navigation.ts
+++ b/apps/web/src/config/navigation.ts
@@ -19,6 +19,7 @@ import {
   Fuel,
   LayoutDashboard,
   type LucideIcon,
+  PlugZap,
   TrendingUp,
   Zap,
 } from "lucide-react";
@@ -122,6 +123,13 @@ export const navLinks: NavLinks = {
       url: "/cars/electric-vehicles",
       icon: Zap,
       description: "BEV, PHEV and hybrid adoption trends and market share",
+      badge: "new",
+    },
+    {
+      title: "EV Charging",
+      url: "/cars/electric-vehicles/charging",
+      icon: PlugZap,
+      description: "Live charger availability, prices and busy hours",
       badge: "new",
     },
     {


### PR DESCRIPTION
- New page at `/cars/electric-vehicles/charging`: live in-use share, busiest hours strip, this week's new chargers and price changes, cheapest and most expensive AC/DC lists, busiest and quietest locations
- District filter and AC/DC toggle write to the URL so the page stays a server component
- Shows an empty state until the first ingest has run
- Adds the page to the Cars nav and sitemap