### PR TITLE
Read live EV charger availability from LTA DataMall

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -28,6 +28,9 @@ BETTER_AUTH_SECRET=
 # Discord (Workflow Errors)
 DISCORD_WEBHOOK_URL=
 
+# LTA DataMall (live EV charger availability)
+LTA_DATAMALL_ACCOUNT_KEY=
+
 # AI (from @motormetrics/ai)
 AI_GATEWAY_API_KEY=
 

--- a/apps/web/src/config/postal-districts.test.ts
+++ b/apps/web/src/config/postal-districts.test.ts
@@ -1,0 +1,41 @@
+import {
+  districtForPostalCode,
+  getPostalDistrict,
+  POSTAL_DISTRICTS,
+} from "./postal-districts";
+
+describe("POSTAL_DISTRICTS", () => {
+  it("should cover every sector exactly once", () => {
+    const sectors = POSTAL_DISTRICTS.flatMap((district) => district.sectors);
+
+    expect(new Set(sectors).size).toBe(sectors.length);
+    expect(POSTAL_DISTRICTS).toHaveLength(28);
+  });
+
+  it("should use unique slugs", () => {
+    const slugs = POSTAL_DISTRICTS.map((district) => district.slug);
+
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});
+
+describe("districtForPostalCode", () => {
+  it("should resolve the leading sector", () => {
+    expect(districtForPostalCode("188537")?.slug).toBe("middle-road-bugis");
+    expect(districtForPostalCode("520618")?.region).toBe("East");
+  });
+
+  it("should return undefined for unassigned or missing codes", () => {
+    expect(districtForPostalCode("740000")).toBeUndefined();
+    expect(districtForPostalCode(null)).toBeUndefined();
+  });
+});
+
+describe("getPostalDistrict", () => {
+  it("should look up by slug", () => {
+    expect(getPostalDistrict("jurong-boon-lay-tuas")?.name).toBe(
+      "Jurong / Boon Lay / Tuas",
+    );
+    expect(getPostalDistrict("nowhere")).toBeUndefined();
+  });
+});

--- a/apps/web/src/config/postal-districts.ts
+++ b/apps/web/src/config/postal-districts.ts
@@ -1,0 +1,206 @@
+/**
+ * Singapore's 28 postal districts, keyed by the first two digits of a postal
+ * code, with the region each one is grouped under on the charging pages.
+ *
+ * Names follow the common usage rather than the gazetted list, so they read
+ * the way drivers talk about them.
+ */
+
+export type PostalRegion = "Central" | "East" | "North-East" | "North" | "West";
+
+export interface PostalDistrict {
+  slug: string;
+  name: string;
+  region: PostalRegion;
+  /** Leading two digits of the postal codes that fall in the district. */
+  sectors: string[];
+}
+
+export const POSTAL_DISTRICTS: PostalDistrict[] = [
+  {
+    slug: "raffles-place-marina",
+    name: "Raffles Place / Marina",
+    region: "Central",
+    sectors: ["01", "02", "03", "04", "05", "06"],
+  },
+  {
+    slug: "anson-tanjong-pagar",
+    name: "Anson / Tanjong Pagar",
+    region: "Central",
+    sectors: ["07", "08"],
+  },
+  {
+    slug: "queenstown-tiong-bahru",
+    name: "Queenstown / Tiong Bahru",
+    region: "Central",
+    sectors: ["14", "15", "16"],
+  },
+  {
+    slug: "telok-blangah-harbourfront",
+    name: "Telok Blangah / HarbourFront",
+    region: "Central",
+    sectors: ["09", "10"],
+  },
+  {
+    slug: "pasir-panjang-clementi",
+    name: "Pasir Panjang / Clementi",
+    region: "West",
+    sectors: ["11", "12", "13"],
+  },
+  {
+    slug: "high-street-city-hall",
+    name: "High Street / City Hall",
+    region: "Central",
+    sectors: ["17"],
+  },
+  {
+    slug: "middle-road-bugis",
+    name: "Middle Road / Bugis",
+    region: "Central",
+    sectors: ["18", "19"],
+  },
+  {
+    slug: "little-india-farrer-park",
+    name: "Little India / Farrer Park",
+    region: "Central",
+    sectors: ["20", "21"],
+  },
+  {
+    slug: "orchard-river-valley",
+    name: "Orchard / River Valley",
+    region: "Central",
+    sectors: ["22", "23"],
+  },
+  {
+    slug: "bukit-timah-holland",
+    name: "Bukit Timah / Holland",
+    region: "Central",
+    sectors: ["24", "25", "26", "27"],
+  },
+  {
+    slug: "novena-thomson",
+    name: "Novena / Thomson",
+    region: "Central",
+    sectors: ["28", "29", "30"],
+  },
+  {
+    slug: "balestier-toa-payoh",
+    name: "Balestier / Toa Payoh",
+    region: "Central",
+    sectors: ["31", "32", "33"],
+  },
+  {
+    slug: "macpherson-potong-pasir",
+    name: "Macpherson / Potong Pasir",
+    region: "Central",
+    sectors: ["34", "35", "36", "37"],
+  },
+  {
+    slug: "geylang-paya-lebar",
+    name: "Geylang / Paya Lebar",
+    region: "Central",
+    sectors: ["38", "39", "40", "41"],
+  },
+  {
+    slug: "katong-marine-parade",
+    name: "Katong / Marine Parade",
+    region: "East",
+    sectors: ["42", "43", "44", "45"],
+  },
+  {
+    slug: "bedok-upper-east-coast",
+    name: "Bedok / Upper East Coast",
+    region: "East",
+    sectors: ["46", "47", "48"],
+  },
+  {
+    slug: "loyang-changi",
+    name: "Loyang / Changi",
+    region: "East",
+    sectors: ["49", "50", "81"],
+  },
+  {
+    slug: "tampines-pasir-ris",
+    name: "Tampines / Pasir Ris",
+    region: "East",
+    sectors: ["51", "52"],
+  },
+  {
+    slug: "hougang-punggol-sengkang",
+    name: "Hougang / Punggol / Sengkang",
+    region: "North-East",
+    sectors: ["53", "54", "55", "82"],
+  },
+  {
+    slug: "bishan-ang-mo-kio",
+    name: "Bishan / Ang Mo Kio",
+    region: "North-East",
+    sectors: ["56", "57"],
+  },
+  {
+    slug: "upper-bukit-timah-clementi-park",
+    name: "Upper Bukit Timah / Clementi Park",
+    region: "West",
+    sectors: ["58", "59"],
+  },
+  {
+    slug: "jurong-boon-lay-tuas",
+    name: "Jurong / Boon Lay / Tuas",
+    region: "West",
+    sectors: ["60", "61", "62", "63", "64"],
+  },
+  {
+    slug: "hillview-bukit-panjang-choa-chu-kang",
+    name: "Hillview / Bukit Panjang / Choa Chu Kang",
+    region: "West",
+    sectors: ["65", "66", "67", "68"],
+  },
+  {
+    slug: "lim-chu-kang-tengah",
+    name: "Lim Chu Kang / Tengah",
+    region: "North",
+    sectors: ["69", "70", "71"],
+  },
+  {
+    slug: "woodlands-admiralty",
+    name: "Woodlands / Admiralty",
+    region: "North",
+    sectors: ["72", "73"],
+  },
+  {
+    slug: "yishun-sembawang",
+    name: "Yishun / Sembawang",
+    region: "North",
+    sectors: ["75", "76"],
+  },
+  {
+    slug: "upper-thomson-springleaf",
+    name: "Upper Thomson / Springleaf",
+    region: "North",
+    sectors: ["77", "78"],
+  },
+  {
+    slug: "seletar-yio-chu-kang",
+    name: "Seletar / Yio Chu Kang",
+    region: "North-East",
+    sectors: ["79", "80"],
+  },
+];
+
+const BY_SLUG = new Map(
+  POSTAL_DISTRICTS.map((district) => [district.slug, district]),
+);
+const BY_SECTOR = new Map(
+  POSTAL_DISTRICTS.flatMap((district) =>
+    district.sectors.map((sector) => [sector, district] as const),
+  ),
+);
+
+export const getPostalDistrict = (slug: string): PostalDistrict | undefined =>
+  BY_SLUG.get(slug);
+
+/** The district a postal code falls in, or `undefined` for unassigned sectors. */
+export const districtForPostalCode = (
+  postalCode: string | null | undefined,
+): PostalDistrict | undefined =>
+  postalCode ? BY_SECTOR.get(postalCode.slice(0, 2)) : undefined;

--- a/apps/web/src/lib/ev-charging/fetch-batch.test.ts
+++ b/apps/web/src/lib/ev-charging/fetch-batch.test.ts
@@ -1,0 +1,57 @@
+import { extractDownloadLink, fetchBatch } from "./fetch-batch";
+
+describe("extractDownloadLink", () => {
+  it("should read the link from the shapes DataMall uses", () => {
+    expect(extractDownloadLink({ Link: "https://a" })).toBe("https://a");
+    expect(extractDownloadLink({ value: [{ Link: "https://b" }] })).toBe(
+      "https://b",
+    );
+    expect(extractDownloadLink({ value: [{ link: "https://c" }] })).toBe(
+      "https://c",
+    );
+    expect(extractDownloadLink({ Link: "not a url" })).toBeNull();
+    expect(extractDownloadLink(null)).toBeNull();
+  });
+});
+
+describe("fetchBatch", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should send the account key, then download the presigned file", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: [{ Link: "https://s3/file.json" }] }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ value: [] }) });
+
+    await expect(fetchBatch("key-123")).resolves.toEqual({ value: [] });
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://datamall2.mytransport.sg/ltaodataservice/EVCBatch",
+    );
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
+      headers: { AccountKey: "key-123" },
+    });
+    expect(fetchMock.mock.calls[1][0]).toBe("https://s3/file.json");
+  });
+
+  it("should throw when the link request fails", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+    });
+
+    await expect(fetchBatch("bad")).rejects.toThrow("401 Unauthorized");
+  });
+});

--- a/apps/web/src/lib/ev-charging/fetch-batch.ts
+++ b/apps/web/src/lib/ev-charging/fetch-batch.ts
@@ -1,0 +1,55 @@
+export const EV_BATCH_URL =
+  "https://datamall2.mytransport.sg/ltaodataservice/EVCBatch";
+
+/**
+ * DataMall's file-link APIs return `{ value: [{ Link }] }`; the batch one
+ * does too, but the placements the guide hints at are all accepted.
+ */
+export const extractDownloadLink = (payload: unknown): string | null => {
+  const candidates: unknown[] = [];
+  if (typeof payload === "object" && payload !== null) {
+    const record = payload as Record<string, unknown>;
+    candidates.push(record.Link, record.link);
+    if (Array.isArray(record.value)) {
+      for (const item of record.value) {
+        if (typeof item === "object" && item !== null) {
+          const entry = item as Record<string, unknown>;
+          candidates.push(entry.Link, entry.link);
+        }
+      }
+    }
+  }
+  const link = candidates.find(
+    (value): value is string =>
+      typeof value === "string" && value.startsWith("http"),
+  );
+  return link ?? null;
+};
+
+/**
+ * The batch endpoint returns a presigned S3 link that expires after fifteen
+ * minutes, so both requests happen back to back.
+ */
+export const fetchBatch = async (accountKey: string): Promise<unknown> => {
+  const linkResponse = await fetch(EV_BATCH_URL, {
+    headers: { AccountKey: accountKey, accept: "application/json" },
+  });
+  if (!linkResponse.ok) {
+    throw new Error(
+      `EVCBatch link request failed: ${linkResponse.status} ${linkResponse.statusText}`,
+    );
+  }
+
+  const link = extractDownloadLink(await linkResponse.json());
+  if (!link) {
+    throw new Error("EVCBatch response carried no download link");
+  }
+
+  const fileResponse = await fetch(link);
+  if (!fileResponse.ok) {
+    throw new Error(
+      `EVCBatch download failed: ${fileResponse.status} ${fileResponse.statusText}`,
+    );
+  }
+  return fileResponse.json();
+};

--- a/apps/web/src/lib/ev-charging/index.ts
+++ b/apps/web/src/lib/ev-charging/index.ts
@@ -1,0 +1,2 @@
+export * from "./fetch-batch";
+export * from "./parse-batch";

--- a/apps/web/src/lib/ev-charging/parse-batch.test.ts
+++ b/apps/web/src/lib/ev-charging/parse-batch.test.ts
@@ -1,0 +1,221 @@
+import {
+  deriveLocationId,
+  extractLastUpdated,
+  extractPostalCode,
+  extractStations,
+  parseBatch,
+  toConnectorStatus,
+  toPriceType,
+} from "./parse-batch";
+
+const station = {
+  address: "15 Queen St Singapore 188537",
+  name: "Tan Chong Tower",
+  longtitude: "103.851234",
+  latitude: 1.298765,
+  locationId: "103851234188537",
+  chargingPoints: [
+    {
+      id: "R123456A",
+      name: "Tan Chong Tower",
+      operator: "EVCO A",
+      operationHours: "24 hours",
+      position: "B1 Lot 12",
+      plugTypes: [
+        {
+          plugType: "CCS2",
+          powerRating: "DC",
+          chargingSpeed: "40",
+          price: "0.42",
+          priceType: "$/kWh",
+          evIds: [
+            { evCpId: "R123456A-001", status: 1 },
+            { evCpId: "R123456A-002", status: "0" },
+            { evCpId: "R123456A-003", status: "" },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("parseBatch", () => {
+  it("should flatten the nested feed to one record per connector", () => {
+    const records = parseBatch({ value: [station] });
+
+    expect(records).toHaveLength(3);
+    expect(records[0]).toEqual({
+      evCpId: "R123456A-001",
+      locationId: "103851234188537",
+      chargerId: "R123456A",
+      stationName: "Tan Chong Tower",
+      address: "15 Queen St Singapore 188537",
+      postalCode: "188537",
+      longitude: 103.851234,
+      latitude: 1.298765,
+      operator: "EVCO A",
+      operationHours: "24 hours",
+      position: "B1 Lot 12",
+      plugType: "CCS2",
+      powerRating: "DC",
+      chargingSpeedKw: 40,
+      price: 0.42,
+      priceType: "$/kWh",
+      status: "available",
+    });
+    expect(records.map((record) => record.status)).toEqual([
+      "available",
+      "occupied",
+      "unavailable",
+    ]);
+  });
+
+  it("should accept a bare array and the correct longitude spelling", () => {
+    const [record] = parseBatch([
+      { ...station, longtitude: undefined, longitude: "103.9" },
+    ]);
+
+    expect(record.longitude).toBe(103.9);
+  });
+
+  it("should fall back to the postal code when locationId is missing", () => {
+    const [record] = parseBatch([{ ...station, locationId: undefined }]);
+
+    expect(record.locationId).toBe("188537");
+  });
+
+  it("should drop connectors without an id", () => {
+    const records = parseBatch([
+      {
+        ...station,
+        chargingPoints: [
+          {
+            plugTypes: [{ evIds: [{ status: 1 }, { id: "X-1", status: 1 }] }],
+          },
+        ],
+      },
+    ]);
+
+    expect(records.map((record) => record.evCpId)).toEqual(["X-1"]);
+  });
+});
+
+describe("parseBatch with the batch file shape", () => {
+  const batch = {
+    LastUpdatedTime: "2026-09-03 20:55:00",
+    evLocationsData: [
+      {
+        address: "3E RIVER VALLEY ROAD SINGAPORE 179024",
+        name: "CLARKE QUAY",
+        longtitude: 103.846728,
+        latitude: 1.290314,
+        postalCode: "179024",
+        chargingPoints: [
+          {
+            status: "1",
+            operatingHours: "24 hrs",
+            operator: "SP MOBILITY PTE. LTD.",
+            position: "L4 51 & 52",
+            name: "CLARKE QUAY",
+            plugTypes: [
+              {
+                plugType: "Combo 2",
+                price: "0.8938",
+                current: "DC",
+                powerRating: "50",
+                priceType: "kWh",
+                evIds: [{ evCpId: "R114858R-002", status: "1" }],
+              },
+              {
+                plugType: "Type 2",
+                price: "",
+                current: "AC",
+                powerRating: "7.4",
+                priceType: "",
+                evIds: [{ evCpId: "R114858R-003", status: "" }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("should read stations from evLocationsData and derives the location id", () => {
+    const records = parseBatch(batch);
+
+    expect(records).toHaveLength(2);
+    expect(records[0]).toMatchObject({
+      evCpId: "R114858R-002",
+      locationId: "846728179024",
+      postalCode: "179024",
+      operationHours: "24 hrs",
+      powerRating: "DC",
+      chargingSpeedKw: 50,
+      price: 0.8938,
+      priceType: "$/kWh",
+      status: "available",
+    });
+    expect(records[1]).toMatchObject({
+      powerRating: "AC",
+      chargingSpeedKw: 7.4,
+      price: null,
+      priceType: null,
+      status: "unavailable",
+    });
+  });
+
+  it("should read LastUpdatedTime as Singapore time", () => {
+    expect(extractLastUpdated(batch)?.toISOString()).toBe(
+      "2026-09-03T12:55:00.000Z",
+    );
+    expect(extractLastUpdated({})).toBeNull();
+    expect(extractLastUpdated({ LastUpdatedTime: "nope" })).toBeNull();
+  });
+});
+
+describe("deriveLocationId", () => {
+  it("should join six longitude decimals to the postal code", () => {
+    expect(deriveLocationId(103.846728, "179024")).toBe("846728179024");
+    expect(deriveLocationId(103.8, "179024")).toBe("800000179024");
+    expect(deriveLocationId(null, "179024")).toBe("179024");
+    expect(deriveLocationId(103.8, null)).toBeNull();
+  });
+});
+
+describe("toPriceType", () => {
+  it("should normalise per-kWh labels and keeps the rest", () => {
+    expect(toPriceType("kWh")).toBe("$/kWh");
+    expect(toPriceType("$/kWh")).toBe("$/kWh");
+    expect(toPriceType("free")).toBe("free");
+    expect(toPriceType("")).toBeNull();
+  });
+});
+
+describe("extractStations", () => {
+  it("should return an empty list for unrecognised payloads", () => {
+    expect(extractStations(null)).toEqual([]);
+    expect(extractStations("nope")).toEqual([]);
+    expect(extractStations({ value: "nope" })).toEqual([]);
+  });
+});
+
+describe("toConnectorStatus", () => {
+  it("should map DataMall codes", () => {
+    expect(toConnectorStatus(1)).toBe("available");
+    expect(toConnectorStatus("0")).toBe("occupied");
+    expect(toConnectorStatus("")).toBe("unavailable");
+    expect(toConnectorStatus(undefined)).toBe("unavailable");
+    expect(toConnectorStatus("100")).toBe("unavailable");
+  });
+});
+
+describe("extractPostalCode", () => {
+  it("should take the last six-digit run in the address", () => {
+    expect(extractPostalCode("Blk 123456 Road, Singapore 654321")).toBe(
+      "654321",
+    );
+    expect(extractPostalCode("No postal here")).toBeNull();
+    expect(extractPostalCode(null)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/ev-charging/parse-batch.test.ts
+++ b/apps/web/src/lib/ev-charging/parse-batch.test.ts
@@ -78,10 +78,10 @@ describe("parseBatch", () => {
     expect(record.longitude).toBe(103.9);
   });
 
-  it("should fall back to the postal code when locationId is missing", () => {
+  it("should derive the location id when locationId is missing", () => {
     const [record] = parseBatch([{ ...station, locationId: undefined }]);
 
-    expect(record.locationId).toBe("188537");
+    expect(record.locationId).toBe("851234188537");
   });
 
   it("should drop connectors without an id", () => {

--- a/apps/web/src/lib/ev-charging/parse-batch.ts
+++ b/apps/web/src/lib/ev-charging/parse-batch.ts
@@ -1,0 +1,253 @@
+/**
+ * Flattens LTA DataMall's EV Charging Points Batch feed into one record per
+ * connector.
+ *
+ * The feed nests station → chargingPoints → plugTypes → evIds. The batch file
+ * deviates from section 2.28 of the DataMall API guide in a few places, all
+ * observed on 3 Sep 2026 and handled here alongside the documented shape:
+ *
+ * - stations sit under `evLocationsData` next to a `LastUpdatedTime`
+ * - stations carry `postalCode` directly and no `locationId`
+ * - charging points use `operatingHours`
+ * - plug types put AC/DC in `current` and the kW figure in `powerRating`
+ * - `priceType` is `kWh`, empty, or `free`
+ */
+
+export type ConnectorStatus = "available" | "occupied" | "unavailable";
+
+export interface ConnectorRecord {
+  evCpId: string;
+  locationId: string;
+  chargerId: string | null;
+  stationName: string | null;
+  address: string | null;
+  postalCode: string | null;
+  longitude: number | null;
+  latitude: number | null;
+  operator: string | null;
+  operationHours: string | null;
+  position: string | null;
+  plugType: string | null;
+  powerRating: string | null;
+  chargingSpeedKw: number | null;
+  price: number | null;
+  priceType: string | null;
+  status: ConnectorStatus;
+}
+
+interface FeedEvId {
+  evCpId?: unknown;
+  id?: unknown;
+  status?: unknown;
+}
+
+interface FeedPlugType {
+  plugType?: unknown;
+  current?: unknown;
+  powerRating?: unknown;
+  chargingSpeed?: unknown;
+  price?: unknown;
+  priceType?: unknown;
+  evIds?: unknown;
+}
+
+interface FeedChargingPoint {
+  id?: unknown;
+  name?: unknown;
+  operator?: unknown;
+  operatingHours?: unknown;
+  operationHours?: unknown;
+  position?: unknown;
+  plugTypes?: unknown;
+}
+
+interface FeedStation {
+  address?: unknown;
+  name?: unknown;
+  longitude?: unknown;
+  longtitude?: unknown;
+  latitude?: unknown;
+  locationId?: unknown;
+  postalCode?: unknown;
+  chargingPoints?: unknown;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const asList = (value: unknown): unknown[] =>
+  Array.isArray(value) ? value : [];
+
+export const toText = (value: unknown): string | null => {
+  if (typeof value === "number") {
+    return String(value);
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  return value.trim() || null;
+};
+
+export const toNumber = (value: unknown): number | null => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+/**
+ * DataMall codes a connector as `0` occupied, `1` available and an empty
+ * string for out-of-order, unknown, planned or removed. Anything else is
+ * treated as unavailable rather than guessed at.
+ */
+export const toConnectorStatus = (value: unknown): ConnectorStatus => {
+  const text = toText(value);
+  if (text === "1") {
+    return "available";
+  }
+  if (text === "0") {
+    return "occupied";
+  }
+  return "unavailable";
+};
+
+/**
+ * The batch file says `kWh` where the guide says `$/kWh`. Both land as
+ * `$/kWh` so the price queries have one value to filter on; anything else
+ * (`free`, hourly) is kept as sent.
+ */
+export const toPriceType = (value: unknown): string | null => {
+  const text = toText(value);
+  if (!text) {
+    return null;
+  }
+  return text.toLowerCase().replace(/[$/\s]/g, "") === "kwh" ? "$/kWh" : text;
+};
+
+/** Singapore postal codes are the trailing six digits of the address. */
+export const extractPostalCode = (address: string | null): string | null => {
+  const match = address?.match(/\b(\d{6})\b(?!.*\b\d{6}\b)/);
+  return match ? match[1] : null;
+};
+
+/**
+ * The guide defines a station's `locationId` as the first six decimals of its
+ * longitude followed by the postal code. The batch file omits the field, so
+ * it is rebuilt the same way to stay compatible with the per-postal-code API.
+ */
+export const deriveLocationId = (
+  longitude: number | null,
+  postalCode: string | null,
+): string | null => {
+  if (!postalCode) {
+    return null;
+  }
+  if (longitude == null) {
+    return postalCode;
+  }
+  const decimals = longitude.toFixed(6).split(".")[1] ?? "";
+  return `${decimals}${postalCode}`;
+};
+
+/** The batch's `LastUpdatedTime` is wall-clock Singapore time without a zone. */
+export const extractLastUpdated = (payload: unknown): Date | null => {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  const text = toText(payload.LastUpdatedTime ?? payload.lastUpdatedTime);
+  if (!text) {
+    return null;
+  }
+  const parsed = new Date(`${text.replace(" ", "T")}+08:00`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+/**
+ * Accept the batch file's `evLocationsData`, the OData `value` wrapper the
+ * per-postal-code endpoint uses, and a bare array.
+ */
+export const extractStations = (payload: unknown): FeedStation[] => {
+  if (Array.isArray(payload)) {
+    return payload.filter(isRecord);
+  }
+  if (isRecord(payload)) {
+    const list = payload.evLocationsData ?? payload.value;
+    if (Array.isArray(list)) {
+      return list.filter(isRecord);
+    }
+  }
+  return [];
+};
+
+export const parseBatch = (payload: unknown): ConnectorRecord[] => {
+  const records: ConnectorRecord[] = [];
+
+  for (const station of extractStations(payload)) {
+    const address = toText(station.address);
+    const postalCode = toText(station.postalCode) ?? extractPostalCode(address);
+    const longitude = toNumber(station.longitude ?? station.longtitude);
+    const locationId =
+      toText(station.locationId) ?? deriveLocationId(longitude, postalCode);
+    if (!locationId) {
+      continue;
+    }
+
+    const stationBase = {
+      locationId,
+      stationName: toText(station.name),
+      address,
+      postalCode,
+      longitude,
+      latitude: toNumber(station.latitude),
+    };
+
+    for (const point of asList(station.chargingPoints).filter(isRecord)) {
+      const chargingPoint = point as FeedChargingPoint;
+      const pointBase = {
+        chargerId: toText(chargingPoint.id),
+        operator: toText(chargingPoint.operator),
+        operationHours: toText(
+          chargingPoint.operatingHours ?? chargingPoint.operationHours,
+        ),
+        position: toText(chargingPoint.position),
+      };
+
+      for (const plug of asList(chargingPoint.plugTypes).filter(isRecord)) {
+        const plugType = plug as FeedPlugType;
+        // Batch file: `current` is AC/DC and `powerRating` is kW. Guide:
+        // `powerRating` is AC/DC and `chargingSpeed` is kW.
+        const current = toText(plugType.current);
+        const plugBase = {
+          plugType: toText(plugType.plugType),
+          powerRating: current ?? toText(plugType.powerRating),
+          chargingSpeedKw: current
+            ? toNumber(plugType.powerRating)
+            : toNumber(plugType.chargingSpeed),
+          price: toNumber(plugType.price),
+          priceType: toPriceType(plugType.priceType),
+        };
+
+        for (const connector of asList(plugType.evIds).filter(isRecord)) {
+          const evId = connector as FeedEvId;
+          const evCpId = toText(evId.evCpId) ?? toText(evId.id);
+          if (!evCpId) {
+            continue;
+          }
+          records.push({
+            evCpId,
+            ...stationBase,
+            ...pointBase,
+            ...plugBase,
+            status: toConnectorStatus(evId.status),
+          });
+        }
+      }
+    }
+  }
+
+  return records;
+};

--- a/apps/web/src/queries/ev-charging/fixtures.ts
+++ b/apps/web/src/queries/ev-charging/fixtures.ts
@@ -1,0 +1,24 @@
+import type { ConnectorRecord } from "@web/lib/ev-charging";
+
+/** A connector with sensible defaults; override what the test cares about. */
+export const connector = (
+  overrides: Partial<ConnectorRecord> & Pick<ConnectorRecord, "evCpId">,
+): ConnectorRecord => ({
+  locationId: "L1",
+  chargerId: null,
+  stationName: "Station",
+  address: null,
+  postalCode: "188537",
+  longitude: null,
+  latitude: null,
+  operator: null,
+  operationHours: null,
+  position: null,
+  plugType: null,
+  powerRating: "AC",
+  chargingSpeedKw: 7.4,
+  price: 0.7,
+  priceType: "$/kWh",
+  status: "available",
+  ...overrides,
+});

--- a/apps/web/src/queries/ev-charging/index.ts
+++ b/apps/web/src/queries/ev-charging/index.ts
@@ -1,2 +1,6 @@
+export * from "./live-summary";
+export * from "./locations";
 export * from "./network-summary";
+export * from "./price-rankings";
 export * from "./registrations-by-month";
+export * from "./snapshot";

--- a/apps/web/src/queries/ev-charging/live-summary.test.ts
+++ b/apps/web/src/queries/ev-charging/live-summary.test.ts
@@ -1,0 +1,54 @@
+vi.mock("./snapshot", () => ({ getEvChargingSnapshot: vi.fn() }));
+
+import { connector } from "./fixtures";
+import { getEvChargingLiveSummary } from "./live-summary";
+import { getEvChargingSnapshot } from "./snapshot";
+
+const records = [
+  connector({ evCpId: "A" }),
+  connector({ evCpId: "B", status: "occupied" }),
+  connector({ evCpId: "C", status: "unavailable", locationId: "L2" }),
+  connector({ evCpId: "D", locationId: "L3", postalCode: "520618" }),
+];
+
+describe("getEvChargingLiveSummary", () => {
+  beforeEach(() => {
+    vi.mocked(getEvChargingSnapshot).mockResolvedValue({
+      observedAt: "2026-09-03T12:55:00.000Z",
+      records,
+    });
+  });
+
+  it("should count connectors by status and distinct locations", async () => {
+    await expect(getEvChargingLiveSummary()).resolves.toEqual({
+      connectors: 4,
+      locations: 3,
+      available: 2,
+      occupied: 1,
+      unavailable: 1,
+      observedAt: "2026-09-03T12:55:00.000Z",
+    });
+  });
+
+  it("should restrict to a district", async () => {
+    await expect(
+      getEvChargingLiveSummary("tampines-pasir-ris"),
+    ).resolves.toMatchObject({ connectors: 1, locations: 1, available: 1 });
+  });
+
+  it("should return zeros for an empty snapshot", async () => {
+    vi.mocked(getEvChargingSnapshot).mockResolvedValueOnce({
+      observedAt: null,
+      records: [],
+    });
+
+    await expect(getEvChargingLiveSummary()).resolves.toEqual({
+      connectors: 0,
+      locations: 0,
+      available: 0,
+      occupied: 0,
+      unavailable: 0,
+      observedAt: null,
+    });
+  });
+});

--- a/apps/web/src/queries/ev-charging/live-summary.ts
+++ b/apps/web/src/queries/ev-charging/live-summary.ts
@@ -1,0 +1,40 @@
+import { inDistrict } from "./locations";
+import { getEvChargingSnapshot } from "./snapshot";
+
+export interface EvChargingLiveSummary {
+  connectors: number;
+  locations: number;
+  available: number;
+  occupied: number;
+  unavailable: number;
+  /** ISO timestamp of the batch the figures come from. */
+  observedAt: string | null;
+}
+
+/** Connector state at the latest batch, island-wide or for one district. */
+export async function getEvChargingLiveSummary(
+  district?: string,
+): Promise<EvChargingLiveSummary> {
+  const { observedAt, records } = await getEvChargingSnapshot();
+  const summary: EvChargingLiveSummary = {
+    connectors: 0,
+    locations: 0,
+    available: 0,
+    occupied: 0,
+    unavailable: 0,
+    observedAt,
+  };
+  const locations = new Set<string>();
+
+  for (const record of records) {
+    if (!inDistrict(record.postalCode, district)) {
+      continue;
+    }
+    summary.connectors += 1;
+    summary[record.status] += 1;
+    locations.add(record.locationId);
+  }
+
+  summary.locations = locations.size;
+  return summary;
+}

--- a/apps/web/src/queries/ev-charging/locations.test.ts
+++ b/apps/web/src/queries/ev-charging/locations.test.ts
@@ -1,0 +1,61 @@
+import type { ConnectorRecord } from "@web/lib/ev-charging";
+import { groupLocations, inDistrict } from "./locations";
+
+const connector = (
+  overrides: Partial<ConnectorRecord> & Pick<ConnectorRecord, "evCpId">,
+): ConnectorRecord => ({
+  locationId: "L1",
+  chargerId: null,
+  stationName: "Station",
+  address: null,
+  postalCode: "188537",
+  longitude: null,
+  latitude: null,
+  operator: null,
+  operationHours: null,
+  position: null,
+  plugType: null,
+  powerRating: "AC",
+  chargingSpeedKw: 7.4,
+  price: 0.7,
+  priceType: "$/kWh",
+  status: "available",
+  ...overrides,
+});
+
+describe("groupLocations", () => {
+  it("should roll connectors up per location with counts, top speed and lowest price", () => {
+    const locations = groupLocations([
+      connector({ evCpId: "A" }),
+      connector({
+        evCpId: "B",
+        powerRating: "DC",
+        chargingSpeedKw: 120,
+        price: 0.65,
+      }),
+      connector({ evCpId: "C", price: 2, priceType: "$/h" }),
+      connector({ evCpId: "D", locationId: "L2", stationName: "Other" }),
+    ]);
+
+    expect(locations).toEqual([
+      expect.objectContaining({
+        locationId: "L1",
+        connectors: 3,
+        dcConnectors: 1,
+        maxSpeedKw: 120,
+        minPricePerKwh: 0.65,
+      }),
+      expect.objectContaining({ locationId: "L2", connectors: 1 }),
+    ]);
+  });
+});
+
+describe("inDistrict", () => {
+  it("should match the postal sector and treat unknown slugs as all Singapore", () => {
+    expect(inDistrict("188537", "middle-road-bugis")).toBe(true);
+    expect(inDistrict("520618", "middle-road-bugis")).toBe(false);
+    expect(inDistrict(null, "middle-road-bugis")).toBe(false);
+    expect(inDistrict("520618", undefined)).toBe(true);
+    expect(inDistrict("520618", "nowhere")).toBe(true);
+  });
+});

--- a/apps/web/src/queries/ev-charging/locations.test.ts
+++ b/apps/web/src/queries/ev-charging/locations.test.ts
@@ -1,27 +1,5 @@
-import type { ConnectorRecord } from "@web/lib/ev-charging";
+import { connector } from "./fixtures";
 import { groupLocations, inDistrict } from "./locations";
-
-const connector = (
-  overrides: Partial<ConnectorRecord> & Pick<ConnectorRecord, "evCpId">,
-): ConnectorRecord => ({
-  locationId: "L1",
-  chargerId: null,
-  stationName: "Station",
-  address: null,
-  postalCode: "188537",
-  longitude: null,
-  latitude: null,
-  operator: null,
-  operationHours: null,
-  position: null,
-  plugType: null,
-  powerRating: "AC",
-  chargingSpeedKw: 7.4,
-  price: 0.7,
-  priceType: "$/kWh",
-  status: "available",
-  ...overrides,
-});
 
 describe("groupLocations", () => {
   it("should roll connectors up per location with counts, top speed and lowest price", () => {

--- a/apps/web/src/queries/ev-charging/locations.ts
+++ b/apps/web/src/queries/ev-charging/locations.ts
@@ -1,0 +1,76 @@
+import { getPostalDistrict } from "@web/config/postal-districts";
+import type { ConnectorRecord } from "@web/lib/ev-charging";
+
+export interface EvChargingLocation {
+  locationId: string;
+  stationName: string | null;
+  address: string | null;
+  postalCode: string | null;
+  operator: string | null;
+  connectors: number;
+  dcConnectors: number;
+  maxSpeedKw: number | null;
+  minPricePerKwh: number | null;
+}
+
+/** Only per-kWh tariffs are comparable; hourly and "free" ones are skipped. */
+export const PER_KWH = "$/kWh";
+
+/** Whether a postal code falls in the district, or in all of Singapore. */
+export const inDistrict = (
+  postalCode: string | null,
+  districtSlug: string | undefined,
+): boolean => {
+  if (!districtSlug) {
+    return true;
+  }
+  const district = getPostalDistrict(districtSlug);
+  if (!district) {
+    return true;
+  }
+  return (
+    postalCode != null && district.sectors.includes(postalCode.slice(0, 2))
+  );
+};
+
+/** Rolls connectors up to one entry per location, in feed order. */
+export const groupLocations = (
+  records: ConnectorRecord[],
+): EvChargingLocation[] => {
+  const byLocation = new Map<string, EvChargingLocation>();
+
+  for (const record of records) {
+    const location = byLocation.get(record.locationId) ?? {
+      locationId: record.locationId,
+      stationName: record.stationName,
+      address: record.address,
+      postalCode: record.postalCode,
+      operator: record.operator,
+      connectors: 0,
+      dcConnectors: 0,
+      maxSpeedKw: null,
+      minPricePerKwh: null,
+    };
+
+    location.connectors += 1;
+    if (record.powerRating === "DC") {
+      location.dcConnectors += 1;
+    }
+    if (record.chargingSpeedKw != null) {
+      location.maxSpeedKw = Math.max(
+        location.maxSpeedKw ?? 0,
+        record.chargingSpeedKw,
+      );
+    }
+    if (record.priceType === PER_KWH && record.price != null) {
+      location.minPricePerKwh = Math.min(
+        location.minPricePerKwh ?? Number.POSITIVE_INFINITY,
+        record.price,
+      );
+    }
+
+    byLocation.set(record.locationId, location);
+  }
+
+  return [...byLocation.values()];
+};

--- a/apps/web/src/queries/ev-charging/price-rankings.test.ts
+++ b/apps/web/src/queries/ev-charging/price-rankings.test.ts
@@ -1,0 +1,121 @@
+vi.mock("./snapshot", () => ({ getEvChargingSnapshot: vi.fn() }));
+
+import { connector } from "./fixtures";
+import { getEvChargingPriceRankings } from "./price-rankings";
+import { getEvChargingSnapshot } from "./snapshot";
+
+const records = [
+  connector({ evCpId: "A", locationId: "L1", stationName: "Beta", price: 0.7 }),
+  connector({ evCpId: "B", locationId: "L1", price: 0.65 }),
+  connector({
+    evCpId: "C",
+    locationId: "L2",
+    stationName: "Alpha",
+    price: 0.7,
+  }),
+  connector({
+    evCpId: "D",
+    locationId: "L3",
+    stationName: "Fast",
+    powerRating: "DC",
+    chargingSpeedKw: 120,
+    price: 0.5,
+  }),
+  connector({
+    evCpId: "E",
+    locationId: "L3",
+    powerRating: "DC",
+    chargingSpeedKw: 50,
+    price: 0.55,
+  }),
+  connector({
+    evCpId: "F",
+    locationId: "L4",
+    stationName: "Hourly",
+    price: 3,
+    priceType: "$/h",
+  }),
+  connector({
+    evCpId: "G",
+    locationId: "L5",
+    stationName: "East",
+    postalCode: "520618",
+    price: 0.9,
+  }),
+  connector({ evCpId: "H", locationId: "L6", price: null }),
+];
+
+describe("getEvChargingPriceRankings", () => {
+  beforeEach(() => {
+    vi.mocked(getEvChargingSnapshot).mockResolvedValue({
+      observedAt: null,
+      records,
+    });
+  });
+
+  it("should rank AC locations cheapest first by their lowest price, ties by name", async () => {
+    const rows = await getEvChargingPriceRankings({
+      powerRating: "AC",
+      order: "cheapest",
+    });
+
+    expect(rows.map((row) => [row.locationId, row.pricePerKwh])).toEqual([
+      ["L1", 0.65],
+      ["L2", 0.7],
+      ["L5", 0.9],
+    ]);
+    expect(rows[0]).toMatchObject({ connectors: 2, speedKw: 7.4 });
+  });
+
+  it("should rank priciest first using each location's highest price", async () => {
+    const rows = await getEvChargingPriceRankings({
+      powerRating: "AC",
+      order: "priciest",
+      limit: 2,
+    });
+
+    expect(rows.map((row) => [row.locationId, row.pricePerKwh])).toEqual([
+      ["L5", 0.9],
+      ["L2", 0.7],
+    ]);
+  });
+
+  it("should only count connectors of the requested rating", async () => {
+    const rows = await getEvChargingPriceRankings({
+      powerRating: "DC",
+      order: "cheapest",
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      locationId: "L3",
+      pricePerKwh: 0.5,
+      speedKw: 120,
+      connectors: 2,
+    });
+  });
+
+  it("should filter by district", async () => {
+    const rows = await getEvChargingPriceRankings({
+      powerRating: "AC",
+      order: "cheapest",
+      district: "tampines-pasir-ris",
+    });
+
+    expect(rows.map((row) => row.locationId)).toEqual(["L5"]);
+  });
+
+  it("should tolerate connectors without a speed", async () => {
+    vi.mocked(getEvChargingSnapshot).mockResolvedValueOnce({
+      observedAt: null,
+      records: [connector({ evCpId: "A", chargingSpeedKw: null })],
+    });
+
+    const [row] = await getEvChargingPriceRankings({
+      powerRating: "AC",
+      order: "cheapest",
+    });
+
+    expect(row.speedKw).toBeNull();
+  });
+});

--- a/apps/web/src/queries/ev-charging/price-rankings.ts
+++ b/apps/web/src/queries/ev-charging/price-rankings.ts
@@ -1,0 +1,81 @@
+import {
+  type EvChargingLocation,
+  groupLocations,
+  inDistrict,
+  PER_KWH,
+} from "./locations";
+import { getEvChargingSnapshot } from "./snapshot";
+
+export type PowerRating = "AC" | "DC";
+export type PriceOrder = "cheapest" | "priciest";
+
+export interface PriceRankingOptions {
+  powerRating: PowerRating;
+  order: PriceOrder;
+  district?: string;
+  limit?: number;
+}
+
+export interface EvChargingPricedLocation extends EvChargingLocation {
+  /** Advertised $/kWh for the requested power rating at this location. */
+  pricePerKwh: number;
+  /** Highest connector speed of that rating at this location. */
+  speedKw: number | null;
+}
+
+/**
+ * Locations ranked by advertised per-kWh price for one power rating.
+ *
+ * Only connectors of the requested rating count, so a site's AC price does
+ * not stand in for its DC one. Ties break alphabetically by station name.
+ */
+export async function getEvChargingPriceRankings({
+  powerRating,
+  order,
+  district,
+  limit = 10,
+}: PriceRankingOptions): Promise<EvChargingPricedLocation[]> {
+  const { records } = await getEvChargingSnapshot();
+  const matching = records.filter(
+    (record) =>
+      record.powerRating === powerRating &&
+      record.priceType === PER_KWH &&
+      record.price != null &&
+      inDistrict(record.postalCode, district),
+  );
+
+  const pick = order === "cheapest" ? Math.min : Math.max;
+  const priceByLocation = new Map<string, number>();
+  const speedByLocation = new Map<string, number>();
+  for (const record of matching) {
+    const price = record.price as number;
+    priceByLocation.set(
+      record.locationId,
+      pick(priceByLocation.get(record.locationId) ?? price, price),
+    );
+    if (record.chargingSpeedKw != null) {
+      speedByLocation.set(
+        record.locationId,
+        Math.max(
+          speedByLocation.get(record.locationId) ?? 0,
+          record.chargingSpeedKw,
+        ),
+      );
+    }
+  }
+
+  return groupLocations(matching)
+    .map((location) => ({
+      ...location,
+      pricePerKwh: priceByLocation.get(location.locationId) as number,
+      speedKw: speedByLocation.get(location.locationId) ?? null,
+    }))
+    .sort(
+      (left, right) =>
+        (order === "cheapest"
+          ? left.pricePerKwh - right.pricePerKwh
+          : right.pricePerKwh - left.pricePerKwh) ||
+        (left.stationName ?? "").localeCompare(right.stationName ?? ""),
+    )
+    .slice(0, limit);
+}

--- a/apps/web/src/queries/ev-charging/snapshot.test.ts
+++ b/apps/web/src/queries/ev-charging/snapshot.test.ts
@@ -1,0 +1,58 @@
+vi.mock("@web/lib/ev-charging", () => ({
+  extractLastUpdated: vi.fn(),
+  fetchBatch: vi.fn(),
+  parseBatch: vi.fn(),
+}));
+
+import {
+  extractLastUpdated,
+  fetchBatch,
+  parseBatch,
+} from "@web/lib/ev-charging";
+import { cacheLifeMock } from "../test-utils";
+import { getEvChargingSnapshot } from "./snapshot";
+
+describe("getEvChargingSnapshot", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("should return an empty snapshot without an account key", async () => {
+    vi.stubEnv("LTA_DATAMALL_ACCOUNT_KEY", "");
+
+    await expect(getEvChargingSnapshot()).resolves.toEqual({
+      observedAt: null,
+      records: [],
+    });
+    expect(fetchBatch).not.toHaveBeenCalled();
+    expect(cacheLifeMock).toHaveBeenCalledWith("minutes");
+  });
+
+  it("should fetch, parse and stamp the feed time", async () => {
+    vi.stubEnv("LTA_DATAMALL_ACCOUNT_KEY", "key");
+    vi.mocked(fetchBatch).mockResolvedValueOnce({ raw: true });
+    vi.mocked(parseBatch).mockReturnValueOnce([{ evCpId: "A" } as never]);
+    vi.mocked(extractLastUpdated).mockReturnValueOnce(
+      new Date("2026-09-03T12:55:00Z"),
+    );
+
+    await expect(getEvChargingSnapshot()).resolves.toEqual({
+      observedAt: "2026-09-03T12:55:00.000Z",
+      records: [{ evCpId: "A" }],
+    });
+    expect(fetchBatch).toHaveBeenCalledWith("key");
+  });
+
+  it("should leave observedAt null when the feed carries no time", async () => {
+    vi.stubEnv("LTA_DATAMALL_ACCOUNT_KEY", "key");
+    vi.mocked(fetchBatch).mockResolvedValueOnce({});
+    vi.mocked(parseBatch).mockReturnValueOnce([]);
+    vi.mocked(extractLastUpdated).mockReturnValueOnce(null);
+
+    await expect(getEvChargingSnapshot()).resolves.toEqual({
+      observedAt: null,
+      records: [],
+    });
+  });
+});

--- a/apps/web/src/queries/ev-charging/snapshot.ts
+++ b/apps/web/src/queries/ev-charging/snapshot.ts
@@ -1,0 +1,40 @@
+import {
+  type ConnectorRecord,
+  extractLastUpdated,
+  fetchBatch,
+  parseBatch,
+} from "@web/lib/ev-charging";
+import { cacheLife } from "next/cache";
+
+export interface EvChargingSnapshot {
+  /** ISO timestamp the feed reports for itself; `null` when unavailable. */
+  observedAt: string | null;
+  records: ConnectorRecord[];
+}
+
+const EMPTY: EvChargingSnapshot = { observedAt: null, records: [] };
+
+/**
+ * The current state of every public connector, straight from LTA DataMall's
+ * five-minute batch file.
+ *
+ * Nothing is stored: every live figure on the site derives from this one
+ * cached download. The built-in `minutes` profile matches the feed's own
+ * refresh rate, so a visitor sees at most a few minutes of staleness. Without
+ * an account key the snapshot is empty and the pages show their empty state.
+ */
+export async function getEvChargingSnapshot(): Promise<EvChargingSnapshot> {
+  "use cache";
+  cacheLife("minutes");
+
+  const accountKey = process.env.LTA_DATAMALL_ACCOUNT_KEY;
+  if (!accountKey) {
+    return EMPTY;
+  }
+
+  const payload = await fetchBatch(accountKey);
+  return {
+    observedAt: extractLastUpdated(payload)?.toISOString() ?? null,
+    records: parseBatch(payload),
+  };
+}


### PR DESCRIPTION
- Fetches LTA DataMall's EV Charging Points Batch file on demand inside a `"use cache"` query with the built-in `minutes` profile; nothing is stored
- Parser verified against a real download (11,417 connectors, 2,752 locations); handles both the batch file shape and the API guide's per-postal-code shape
- In-memory queries for the live island-wide or per-district summary and cheapest/priciest per-kWh rankings by AC or DC
- Adds the 28 postal districts with sectors and regions in `config/postal-districts.ts`
- Needs `LTA_DATAMALL_ACCOUNT_KEY`, already set in Vercel for production and preview; returns an empty snapshot without it
- Bottom of stack #977: feed → live-ui → history-schema → history-ingest → history-ui. The first two need no ingestion; the last three add history and can wait for Vercel Pro