### PR TITLE
Ingest EV charger snapshots for history

### DIFF
--- a/apps/web/src/app/api/workflows/ev-charging-live/route.ts
+++ b/apps/web/src/app/api/workflows/ev-charging-live/route.ts
@@ -1,0 +1,17 @@
+import { WORKFLOW_REGION } from "@web/config/workflow";
+import { evChargingLiveWorkflow } from "@web/workflows/ev-charging-live";
+import { start } from "workflow/api";
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const run = await start(evChargingLiveWorkflow, { region: WORKFLOW_REGION });
+
+  return Response.json(
+    { message: "Workflow started", runId: run.runId },
+    { headers: { "X-Run-Id": run.runId } },
+  );
+}

--- a/apps/web/src/workflows/ev-charging-live/index.ts
+++ b/apps/web/src/workflows/ev-charging-live/index.ts
@@ -1,0 +1,43 @@
+import {
+  type IngestResult,
+  ingestLiveSnapshot,
+} from "@web/workflows/ev-charging-live/steps/ingest";
+import { emitEvent } from "@web/workflows/shared";
+
+/**
+ * Live EV charger availability workflow using Vercel WDK.
+ *
+ * Runs every five minutes against LTA DataMall's EV Charging Points Batch
+ * API and records the current state of every connector, the transitions
+ * since the last run, and per-location hourly utilisation counters.
+ *
+ * Reads served from these tables use short cache profiles rather than tag
+ * revalidation, since the data changes on every run by design.
+ */
+export async function evChargingLiveWorkflow(): Promise<{ message: string }> {
+  "use workflow";
+
+  await emitEvent({ type: "step:start", step: "ingestEvChargingLive" });
+  const result = await ingestSnapshot();
+  await emitEvent({
+    type: "data:processed",
+    step: "ingestEvChargingLive",
+    data: { recordsProcessed: result.connectors },
+  });
+
+  if (result.skipped) {
+    return {
+      message:
+        "[EV CHARGING LIVE] LTA_DATAMALL_ACCOUNT_KEY is not set. Skipped.",
+    };
+  }
+
+  return {
+    message: `[EV CHARGING LIVE] ${result.connectors} connectors across ${result.locations} locations, ${result.events} changes at ${result.observedAt}`,
+  };
+}
+
+async function ingestSnapshot(): Promise<IngestResult> {
+  "use step";
+  return ingestLiveSnapshot();
+}

--- a/apps/web/src/workflows/ev-charging-live/steps/diff-snapshot.test.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/diff-snapshot.test.ts
@@ -1,0 +1,178 @@
+import type { ConnectorRecord } from "@web/lib/ev-charging";
+import { diffSnapshot, formatPrice, truncateToHour } from "./diff-snapshot";
+
+const observedAt = new Date("2026-09-03T10:07:00+08:00");
+const earlier = new Date("2026-09-03T08:00:00+08:00");
+
+const connector = (
+  overrides: Partial<ConnectorRecord> & Pick<ConnectorRecord, "evCpId">,
+): ConnectorRecord => ({
+  locationId: "L1",
+  chargerId: null,
+  stationName: null,
+  address: null,
+  postalCode: null,
+  longitude: null,
+  latitude: null,
+  operator: null,
+  operationHours: null,
+  position: null,
+  plugType: null,
+  powerRating: null,
+  chargingSpeedKw: null,
+  price: 0.7,
+  priceType: "$/kWh",
+  status: "available",
+  ...overrides,
+});
+
+describe("diffSnapshot", () => {
+  it("should record a status event for connectors seen for the first time", () => {
+    const diff = diffSnapshot(
+      [connector({ evCpId: "A" })],
+      new Map(),
+      observedAt,
+    );
+
+    expect(diff.events).toEqual([
+      {
+        evCpId: "A",
+        locationId: "L1",
+        kind: "status",
+        previousValue: null,
+        value: "available",
+        observedAt,
+      },
+    ]);
+    expect(diff.statusChangedAt.get("A")).toBe(observedAt);
+  });
+
+  it("should carry statusChangedAt forward when the status holds", () => {
+    const previous = new Map([
+      [
+        "A",
+        {
+          evCpId: "A",
+          status: "available" as const,
+          statusChangedAt: earlier,
+          price: 0.7,
+          priceType: "$/kWh",
+        },
+      ],
+    ]);
+
+    const diff = diffSnapshot(
+      [connector({ evCpId: "A" })],
+      previous,
+      observedAt,
+    );
+
+    expect(diff.events).toEqual([]);
+    expect(diff.statusChangedAt.get("A")).toBe(earlier);
+  });
+
+  it("should record status and price transitions", () => {
+    const previous = new Map([
+      [
+        "A",
+        {
+          evCpId: "A",
+          status: "available" as const,
+          statusChangedAt: earlier,
+          price: 0.7,
+          priceType: "$/kWh",
+        },
+      ],
+    ]);
+
+    const diff = diffSnapshot(
+      [connector({ evCpId: "A", status: "occupied", price: 0.75 })],
+      previous,
+      observedAt,
+    );
+
+    expect(diff.events).toEqual([
+      expect.objectContaining({
+        kind: "status",
+        previousValue: "available",
+        value: "occupied",
+      }),
+      expect.objectContaining({
+        kind: "price",
+        previousValue: "0.7 $/kWh",
+        value: "0.75 $/kWh",
+      }),
+    ]);
+  });
+
+  it("should ignore a price disappearing from the feed", () => {
+    const previous = new Map([
+      [
+        "A",
+        {
+          evCpId: "A",
+          status: "available" as const,
+          statusChangedAt: earlier,
+          price: 0.7,
+          priceType: "$/kWh",
+        },
+      ],
+    ]);
+
+    const diff = diffSnapshot(
+      [connector({ evCpId: "A", price: null })],
+      previous,
+      observedAt,
+    );
+
+    expect(diff.events).toEqual([]);
+  });
+
+  it("should roll connectors up into one hourly sample per location", () => {
+    const diff = diffSnapshot(
+      [
+        connector({ evCpId: "A", status: "occupied" }),
+        connector({ evCpId: "B", status: "unavailable" }),
+        connector({ evCpId: "C" }),
+        connector({ evCpId: "D", locationId: "L2" }),
+      ],
+      new Map(),
+      observedAt,
+    );
+
+    expect(diff.hourly).toEqual([
+      {
+        locationId: "L1",
+        hour: new Date("2026-09-03T02:00:00.000Z"),
+        samples: 1,
+        connectorSamples: 3,
+        occupiedSamples: 1,
+        unavailableSamples: 1,
+      },
+      {
+        locationId: "L2",
+        hour: new Date("2026-09-03T02:00:00.000Z"),
+        samples: 1,
+        connectorSamples: 1,
+        occupiedSamples: 0,
+        unavailableSamples: 0,
+      },
+    ]);
+  });
+});
+
+describe("formatPrice", () => {
+  it("should join price and unit, tolerating a missing unit", () => {
+    expect(formatPrice(0.7, "$/kWh")).toBe("0.7 $/kWh");
+    expect(formatPrice(0.7, null)).toBe("0.7");
+    expect(formatPrice(null, "$/kWh")).toBeNull();
+  });
+});
+
+describe("truncateToHour", () => {
+  it("should zero minutes, seconds and milliseconds in UTC", () => {
+    expect(truncateToHour(new Date("2026-09-03T02:59:59.999Z"))).toEqual(
+      new Date("2026-09-03T02:00:00.000Z"),
+    );
+  });
+});

--- a/apps/web/src/workflows/ev-charging-live/steps/diff-snapshot.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/diff-snapshot.ts
@@ -1,0 +1,105 @@
+import type {
+  InsertEvChargingEvent,
+  InsertEvLocationHourly,
+} from "@motormetrics/database";
+import type { ConnectorRecord, ConnectorStatus } from "@web/lib/ev-charging";
+
+/** The subset of the stored row a diff needs: what was last seen. */
+export interface PreviousConnectorState {
+  evCpId: string;
+  status: ConnectorStatus;
+  statusChangedAt: Date;
+  price: number | null;
+  priceType: string | null;
+}
+
+export interface SnapshotDiff {
+  events: InsertEvChargingEvent[];
+  /** `statusChangedAt` carried forward for connectors whose status held. */
+  statusChangedAt: Map<string, Date>;
+  hourly: InsertEvLocationHourly[];
+}
+
+export const formatPrice = (
+  price: number | null,
+  priceType: string | null,
+): string | null => {
+  if (price == null) {
+    return null;
+  }
+  return priceType ? `${price} ${priceType}` : String(price);
+};
+
+export const truncateToHour = (date: Date): Date => {
+  const hour = new Date(date);
+  hour.setUTCMinutes(0, 0, 0);
+  return hour;
+};
+
+/**
+ * Compares a fresh batch against the last stored state and produces the
+ * events, carried-forward timestamps and hourly counters to write.
+ *
+ * A connector's first appearance records a status event with no previous
+ * value, so the log also captures when chargers come online. Prices are
+ * compared as formatted text so a change of unit counts as a change.
+ */
+export const diffSnapshot = (
+  records: ConnectorRecord[],
+  previous: Map<string, PreviousConnectorState>,
+  observedAt: Date,
+): SnapshotDiff => {
+  const events: InsertEvChargingEvent[] = [];
+  const statusChangedAt = new Map<string, Date>();
+  const hourlyByLocation = new Map<string, InsertEvLocationHourly>();
+  const hour = truncateToHour(observedAt);
+
+  for (const record of records) {
+    const last = previous.get(record.evCpId);
+
+    if (!last || last.status !== record.status) {
+      events.push({
+        evCpId: record.evCpId,
+        locationId: record.locationId,
+        kind: "status",
+        previousValue: last?.status ?? null,
+        value: record.status,
+        observedAt,
+      });
+      statusChangedAt.set(record.evCpId, observedAt);
+    } else {
+      statusChangedAt.set(record.evCpId, last.statusChangedAt);
+    }
+
+    const price = formatPrice(record.price, record.priceType);
+    const lastPrice = last ? formatPrice(last.price, last.priceType) : null;
+    if (last && price !== lastPrice && price !== null) {
+      events.push({
+        evCpId: record.evCpId,
+        locationId: record.locationId,
+        kind: "price",
+        previousValue: lastPrice,
+        value: price,
+        observedAt,
+      });
+    }
+
+    const bucket = hourlyByLocation.get(record.locationId) ?? {
+      locationId: record.locationId,
+      hour,
+      samples: 1,
+      connectorSamples: 0,
+      occupiedSamples: 0,
+      unavailableSamples: 0,
+    };
+    bucket.connectorSamples = (bucket.connectorSamples ?? 0) + 1;
+    if (record.status === "occupied") {
+      bucket.occupiedSamples = (bucket.occupiedSamples ?? 0) + 1;
+    } else if (record.status === "unavailable") {
+      bucket.unavailableSamples = (bucket.unavailableSamples ?? 0) + 1;
+    }
+    hourlyByLocation.set(record.locationId, bucket);
+  }
+
+  return { events, statusChangedAt, hourly: [...hourlyByLocation.values()] };
+};

--- a/apps/web/src/workflows/ev-charging-live/steps/ingest.test.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/ingest.test.ts
@@ -1,0 +1,23 @@
+vi.mock("@motormetrics/database", () => ({
+  db: {},
+  evChargingEvents: {},
+  evConnectorStatus: {},
+  evLocationHourly: {},
+  max: vi.fn(),
+  sql: vi.fn(),
+}));
+
+import { ingestLiveSnapshot } from "./ingest";
+
+describe("ingestLiveSnapshot", () => {
+  it("should skip when no account key is configured", async () => {
+    vi.stubEnv("LTA_DATAMALL_ACCOUNT_KEY", "");
+
+    await expect(ingestLiveSnapshot()).resolves.toMatchObject({
+      skipped: true,
+      connectors: 0,
+    });
+
+    vi.unstubAllEnvs();
+  });
+});

--- a/apps/web/src/workflows/ev-charging-live/steps/ingest.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/ingest.ts
@@ -1,0 +1,155 @@
+import {
+  db,
+  evChargingEvents,
+  evConnectorStatus,
+  evLocationHourly,
+  type InsertEvConnectorStatus,
+  max,
+  sql,
+} from "@motormetrics/database";
+import {
+  type ConnectorStatus,
+  extractLastUpdated,
+  fetchBatch,
+  parseBatch,
+} from "@web/lib/ev-charging";
+import {
+  diffSnapshot,
+  type PreviousConnectorState,
+} from "@web/workflows/ev-charging-live/steps/diff-snapshot";
+
+// Neon's HTTP endpoint caps a statement at 32,767 bound parameters. The status
+// upsert binds 19 columns a row, so 1,500 rows stays well under it.
+const BATCH_SIZE = 1500;
+
+export interface IngestResult {
+  skipped: boolean;
+  connectors: number;
+  locations: number;
+  events: number;
+  observedAt: string;
+}
+
+const chunk = <T>(items: T[], size: number): T[][] => {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+};
+
+const skipped = (observedAt: Date): IngestResult => ({
+  skipped: true,
+  connectors: 0,
+  locations: 0,
+  events: 0,
+  observedAt: observedAt.toISOString(),
+});
+
+export const ingestLiveSnapshot = async (): Promise<IngestResult> => {
+  const accountKey = process.env.LTA_DATAMALL_ACCOUNT_KEY;
+  if (!accountKey) {
+    return skipped(new Date());
+  }
+
+  const payload = await fetchBatch(accountKey);
+  // Stamp rows with the feed's own time so hourly buckets follow the data,
+  // not the cron.
+  const observedAt = extractLastUpdated(payload) ?? new Date();
+  const records = parseBatch(payload);
+  if (records.length === 0) {
+    throw new Error("EVCBatch file parsed to zero connectors");
+  }
+
+  // The file is regenerated every five minutes but the cron may land on the
+  // same one twice; counting it again would inflate the hourly samples.
+  const [latest] = await db
+    .select({ observedAt: max(evConnectorStatus.observedAt) })
+    .from(evConnectorStatus);
+  if (
+    latest?.observedAt &&
+    new Date(latest.observedAt).getTime() >= observedAt.getTime()
+  ) {
+    return skipped(observedAt);
+  }
+
+  const previousRows = await db
+    .select({
+      evCpId: evConnectorStatus.evCpId,
+      status: evConnectorStatus.status,
+      statusChangedAt: evConnectorStatus.statusChangedAt,
+      price: evConnectorStatus.price,
+      priceType: evConnectorStatus.priceType,
+    })
+    .from(evConnectorStatus);
+  const previous = new Map<string, PreviousConnectorState>(
+    previousRows.map((row) => [
+      row.evCpId,
+      { ...row, status: row.status as ConnectorStatus },
+    ]),
+  );
+
+  const diff = diffSnapshot(records, previous, observedAt);
+
+  const statusRows: InsertEvConnectorStatus[] = records.map((record) => ({
+    ...record,
+    statusChangedAt: diff.statusChangedAt.get(record.evCpId) ?? observedAt,
+    observedAt,
+  }));
+
+  for (const rows of chunk(statusRows, BATCH_SIZE)) {
+    await db
+      .insert(evConnectorStatus)
+      .values(rows)
+      .onConflictDoUpdate({
+        target: evConnectorStatus.evCpId,
+        set: {
+          locationId: sql`excluded.location_id`,
+          chargerId: sql`excluded.charger_id`,
+          stationName: sql`excluded.station_name`,
+          address: sql`excluded.address`,
+          postalCode: sql`excluded.postal_code`,
+          longitude: sql`excluded.longitude`,
+          latitude: sql`excluded.latitude`,
+          operator: sql`excluded.operator`,
+          operationHours: sql`excluded.operation_hours`,
+          position: sql`excluded.position`,
+          plugType: sql`excluded.plug_type`,
+          powerRating: sql`excluded.power_rating`,
+          chargingSpeedKw: sql`excluded.charging_speed_kw`,
+          price: sql`excluded.price`,
+          priceType: sql`excluded.price_type`,
+          status: sql`excluded.status`,
+          statusChangedAt: sql`excluded.status_changed_at`,
+          observedAt: sql`excluded.observed_at`,
+        },
+      });
+  }
+
+  for (const rows of chunk(diff.events, BATCH_SIZE)) {
+    await db.insert(evChargingEvents).values(rows);
+  }
+
+  for (const rows of chunk(diff.hourly, BATCH_SIZE)) {
+    await db
+      .insert(evLocationHourly)
+      .values(rows)
+      .onConflictDoUpdate({
+        target: [evLocationHourly.locationId, evLocationHourly.hour],
+        set: {
+          samples: sql`${evLocationHourly.samples} + excluded.samples`,
+          connectorSamples: sql`${evLocationHourly.connectorSamples} + excluded.connector_samples`,
+          occupiedSamples: sql`${evLocationHourly.occupiedSamples} + excluded.occupied_samples`,
+          unavailableSamples: sql`${evLocationHourly.unavailableSamples} + excluded.unavailable_samples`,
+        },
+      });
+  }
+
+  return {
+    skipped: false,
+    connectors: records.length,
+    locations: diff.hourly.length,
+    events: diff.events.length,
+    observedAt: observedAt.toISOString(),
+  };
+};

--- a/apps/web/vercel.ts
+++ b/apps/web/vercel.ts
@@ -37,6 +37,13 @@ export const config: VercelConfig = {
       path: "/api/workflows/ev-charging",
       schedule: "0 10 * * *",
     },
+    {
+      path: "/api/workflows/ev-charging-live",
+      // TODO: The DataMall batch refreshes every 5 minutes, but Hobby caps
+      // crons at once a day. Change to "*/5 * * * *" once the project is on
+      // Vercel Pro.
+      schedule: "0 22 * * *",
+    },
   ],
   regions: ["sin1"],
 };


### PR DESCRIPTION
- `ev-charging-live` workflow reuses the feed parser, diffs each batch against the last stored state and writes status, events and hourly counters in batches under the Neon parameter cap
- Rows are stamped with the feed's `LastUpdatedTime` and an already-ingested batch is skipped, so hourly counters cannot double count
- Cron daily at 22:00 UTC (6 am SGT) with a TODO in `vercel.ts` to move to every 5 minutes on Vercel Pro
- Skips cleanly when `LTA_DATAMALL_ACCOUNT_KEY` is unset
- Tests cover the diff and the skip path (not run in this session)