### PR TITLE
Land the EV charging page SEO work on main

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-faq.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-faq.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Accordion, Typography } from "@heroui/react";
+import { ChevronDown } from "lucide-react";
+import type { Faq } from "./faq-data";
+
+/** The FAQ accordion; the questions arrive from the server with live figures. */
+export function ChargingFaq({ faqs }: { faqs: Faq[] }) {
+  return (
+    <section
+      className="grid scroll-mt-24 items-start gap-8 lg:grid-cols-[300px_1fr] lg:gap-14"
+      id="faq"
+    >
+      <Typography.Heading level={2}>Common questions</Typography.Heading>
+      <Accordion
+        className="w-full"
+        defaultExpandedKeys={[faqs[0]?.question ?? ""]}
+        variant="surface"
+      >
+        {faqs.map(({ answer, question }) => (
+          <Accordion.Item id={question} key={question}>
+            <Accordion.Heading>
+              <Accordion.Trigger className="font-bold text-lg tracking-tight">
+                {question}
+                <Accordion.Indicator>
+                  <ChevronDown />
+                </Accordion.Indicator>
+              </Accordion.Trigger>
+            </Accordion.Heading>
+            <Accordion.Panel>
+              <Accordion.Body className="max-w-prose text-base text-muted leading-relaxed">
+                {answer}
+              </Accordion.Body>
+            </Accordion.Panel>
+          </Accordion.Item>
+        ))}
+      </Accordion>
+    </section>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-overview.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-overview.tsx
@@ -1,0 +1,71 @@
+import { Typography } from "@heroui/react";
+import { StructuredData } from "@web/components/structured-data";
+import { generateFAQPageSchema } from "@web/lib/metadata";
+import { getEvChargingSnapshot } from "@web/queries/ev-charging";
+import { ChargingFaq } from "./charging-faq";
+import { buildChargingFaqs } from "./faq-data";
+import { deriveChargingStats, formatPerKwh } from "./price-stats";
+
+const formatObservedAt = (iso: string) =>
+  new Date(iso).toLocaleString("en-SG", {
+    timeZone: "Asia/Singapore",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+/**
+ * The plain-prose summary of the page for readers and crawlers: a direct
+ * answer up top with the current figures and their source, then the FAQ,
+ * whose answers are also emitted as FAQPage structured data.
+ */
+export async function ChargingIntro() {
+  const { observedAt, records } = await getEvChargingSnapshot();
+  if (records.length === 0) {
+    return null;
+  }
+  const stats = deriveChargingStats(records);
+
+  return (
+    <div className="flex max-w-prose flex-col gap-3">
+      <Typography.Paragraph className="leading-relaxed">
+        Singapore has {stats.connectors.toLocaleString("en-SG")} public EV
+        charging connectors across {stats.locations.toLocaleString("en-SG")}{" "}
+        locations. The median advertised rate is{" "}
+        {formatPerKwh(stats.medianPerKwh)}, with AC charging from{" "}
+        {formatPerKwh(stats.cheapestAc)} and DC fast charging from{" "}
+        {formatPerKwh(stats.cheapestDc)}. Availability and prices below come
+        from the Land Transport Authority's DataMall feed and refresh every five
+        minutes.
+      </Typography.Paragraph>
+      {observedAt ? (
+        <Typography.Paragraph color="muted" size="sm">
+          Last updated {formatObservedAt(observedAt)} SGT · Source: LTA DataMall
+          EV Charging Points
+        </Typography.Paragraph>
+      ) : null}
+    </div>
+  );
+}
+
+export async function ChargingQuestions() {
+  const { records } = await getEvChargingSnapshot();
+  if (records.length === 0) {
+    return null;
+  }
+  const faqs = buildChargingFaqs(deriveChargingStats(records));
+
+  return (
+    <>
+      <StructuredData
+        data={{
+          "@context": "https://schema.org",
+          ...generateFAQPageSchema([{ items: faqs }]),
+        }}
+      />
+      <ChargingFaq faqs={faqs} />
+    </>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/faq-data.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/faq-data.ts
@@ -1,0 +1,37 @@
+import { type ChargingStats, formatPerKwh } from "./price-stats";
+
+export interface Faq {
+  answer: string;
+  question: string;
+}
+
+const count = (value: number) => value.toLocaleString("en-SG");
+
+/**
+ * Questions people ask search engines about charging in Singapore, answered
+ * with the figures on the page so the accordion and the FAQPage schema quote
+ * the same live numbers. Each answer is kept to a self-contained 40–60 words.
+ */
+export const buildChargingFaqs = (stats: ChargingStats): Faq[] => [
+  {
+    question: "How much does it cost to charge an EV in Singapore?",
+    answer: `Public charging in Singapore is priced per kWh. Across ${count(stats.locations)} public locations the median advertised rate is ${formatPerKwh(stats.medianPerKwh)}, with AC charging from ${formatPerKwh(stats.cheapestAc)} and DC fast charging from ${formatPerKwh(stats.cheapestDc)}. Rates vary by operator and even between neighbouring car parks, so it pays to compare before plugging in.`,
+  },
+  {
+    question: "Where is the cheapest public EV charger in Singapore?",
+    answer: `The cheapest advertised AC rate is currently ${formatPerKwh(stats.cheapestAc)} and the cheapest DC rate is ${formatPerKwh(stats.cheapestDc)}. The lists on this page rank every location by price, for all of Singapore or one postal district, using the rates operators publish to LTA DataMall.`,
+  },
+  {
+    question: "What is the difference between AC and DC charging?",
+    answer: `AC chargers, typically 7 to 22 kW, use the car's onboard charger and suit overnight or workplace parking. DC fast chargers, from 30 kW to 180 kW, bypass it and can add most of a battery in under an hour. ${count(stats.dcLocations)} of Singapore's ${count(stats.locations)} public locations offer DC charging, usually at a higher rate.`,
+  },
+  {
+    question: "How many public EV chargers are there in Singapore?",
+    answer: `LTA DataMall lists ${count(stats.connectors)} public charging connectors across ${count(stats.locations)} locations, run by ${count(stats.operators)} operators. The figure counts individual connectors rather than charging stations, so a station with two plugs contributes two.`,
+  },
+  {
+    question: "How current is the availability shown here?",
+    answer:
+      "Availability comes from LTA DataMall's EV Charging Points feed, which operators update and LTA republishes every five minutes. This page refreshes on the same cadence, so a connector shown as free was free within the last few minutes. Prices are the operators' advertised rates, including GST.",
+  },
+];

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/price-stats.test.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/price-stats.test.ts
@@ -1,0 +1,79 @@
+import type { ConnectorRecord } from "@web/lib/ev-charging";
+import { deriveChargingStats, formatPerKwh } from "./price-stats";
+
+const connector = (
+  overrides: Partial<ConnectorRecord> & Pick<ConnectorRecord, "evCpId">,
+): ConnectorRecord => ({
+  locationId: "L1",
+  chargerId: null,
+  stationName: null,
+  address: null,
+  postalCode: null,
+  longitude: null,
+  latitude: null,
+  operator: "Op A",
+  operationHours: null,
+  position: null,
+  plugType: null,
+  powerRating: "AC",
+  chargingSpeedKw: null,
+  price: 0.7,
+  priceType: "$/kWh",
+  status: "available",
+  ...overrides,
+});
+
+describe("deriveChargingStats", () => {
+  it("should count connectors, locations, DC sites and operators", () => {
+    const stats = deriveChargingStats([
+      connector({ evCpId: "A" }),
+      connector({
+        evCpId: "B",
+        locationId: "L2",
+        powerRating: "DC",
+        price: 0.5,
+      }),
+      connector({
+        evCpId: "C",
+        locationId: "L3",
+        operator: "Op B",
+        price: 0.9,
+      }),
+    ]);
+
+    expect(stats).toEqual({
+      connectors: 3,
+      locations: 3,
+      dcLocations: 1,
+      operators: 2,
+      cheapestAc: 0.7,
+      cheapestDc: 0.5,
+      medianPerKwh: 0.7,
+    });
+  });
+
+  it("should ignore hourly tariffs and return nulls without prices", () => {
+    const stats = deriveChargingStats([
+      connector({ evCpId: "A", price: 2, priceType: "$/h" }),
+    ]);
+
+    expect(stats.cheapestAc).toBeNull();
+    expect(stats.medianPerKwh).toBeNull();
+  });
+
+  it("should average the two middle values for an even count", () => {
+    const stats = deriveChargingStats([
+      connector({ evCpId: "A", price: 0.4 }),
+      connector({ evCpId: "B", locationId: "L2", price: 0.8 }),
+    ]);
+
+    expect(stats.medianPerKwh).toBeCloseTo(0.6);
+  });
+});
+
+describe("formatPerKwh", () => {
+  it("should format to two decimals and handle missing prices", () => {
+    expect(formatPerKwh(0.4)).toBe("$0.40/kWh");
+    expect(formatPerKwh(null)).toBe("not advertised");
+  });
+});

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/price-stats.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/price-stats.ts
@@ -1,0 +1,63 @@
+import type { ConnectorRecord } from "@web/lib/ev-charging";
+import { groupLocations, PER_KWH } from "@web/queries/ev-charging";
+
+export interface ChargingStats {
+  connectors: number;
+  locations: number;
+  dcLocations: number;
+  operators: number;
+  /** Lowest advertised $/kWh among AC connectors, or `null`. */
+  cheapestAc: number | null;
+  /** Lowest advertised $/kWh among DC connectors, or `null`. */
+  cheapestDc: number | null;
+  /** Median of each location's lowest $/kWh, or `null`. */
+  medianPerKwh: number | null;
+}
+
+const lowest = (records: ConnectorRecord[], powerRating: string) =>
+  records.reduce<number | null>((best, record) => {
+    if (
+      record.powerRating !== powerRating ||
+      record.priceType !== PER_KWH ||
+      record.price == null
+    ) {
+      return best;
+    }
+    return best == null ? record.price : Math.min(best, record.price);
+  }, null);
+
+const median = (values: number[]): number | null => {
+  if (values.length === 0) {
+    return null;
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+};
+
+/** The figures the intro and FAQ quote, derived from one snapshot. */
+export const deriveChargingStats = (
+  records: ConnectorRecord[],
+): ChargingStats => {
+  const locations = groupLocations(records);
+  return {
+    connectors: records.length,
+    locations: locations.length,
+    dcLocations: locations.filter((location) => location.dcConnectors > 0)
+      .length,
+    operators: new Set(records.map((record) => record.operator).filter(Boolean))
+      .size,
+    cheapestAc: lowest(records, "AC"),
+    cheapestDc: lowest(records, "DC"),
+    medianPerKwh: median(
+      locations
+        .map((location) => location.minPricePerKwh)
+        .filter((price): price is number => price != null),
+    ),
+  };
+};
+
+export const formatPerKwh = (price: number | null): string =>
+  price == null ? "not advertised" : `$${price.toFixed(2)}/kWh`;

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/page.tsx
@@ -1,5 +1,9 @@
 import { Skeleton } from "@heroui/react";
 import { BusyHours } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/busy-hours";
+import {
+  ChargingIntro,
+  ChargingQuestions,
+} from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-overview";
 import { DistrictSelect } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/district-select";
 import { LiveStatus } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/live-status";
 import { PriceList } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/price-list";
@@ -14,7 +18,10 @@ import { EmptyState } from "@web/components/shared/empty-state";
 import { PageHead } from "@web/components/shared/page-head";
 import { StructuredData } from "@web/components/structured-data";
 import { SITE_TITLE, SITE_URL } from "@web/config";
-import { generateBreadcrumbSchema } from "@web/lib/metadata";
+import {
+  generateBreadcrumbSchema,
+  generateDatasetSchema,
+} from "@web/lib/metadata";
 import { getEvChargingSnapshot } from "@web/queries/ev-charging";
 import { PlugZap } from "lucide-react";
 import type { Metadata } from "next";
@@ -23,7 +30,7 @@ import { Suspense } from "react";
 import type { WebPage, WithContext } from "schema-dts";
 
 export const metadata: Metadata = {
-  title: "EV Charging in Singapore",
+  title: "Singapore EV Charging Prices and Availability",
   description:
     "Live public EV charger availability across Singapore, with the cheapest and most expensive charging rates, busiest hours and locations, and new chargers this week.",
   openGraph: {
@@ -74,6 +81,12 @@ export default function ChargingPage({ searchParams }: PageProps) {
       <StructuredData
         data={{
           "@context": "https://schema.org",
+          ...generateDatasetSchema("ev-charging"),
+        }}
+      />
+      <StructuredData
+        data={{
+          "@context": "https://schema.org",
           ...generateBreadcrumbSchema([
             { name: "Home", path: "/" },
             { name: "Cars", path: "/cars" },
@@ -92,6 +105,10 @@ export default function ChargingPage({ searchParams }: PageProps) {
         title="EV charging"
       />
 
+      <Suspense fallback={<Skeleton className="h-16 max-w-prose rounded-lg" />}>
+        <ChargingIntro />
+      </Suspense>
+
       <Suspense
         fallback={
           <Bento>
@@ -102,6 +119,10 @@ export default function ChargingPage({ searchParams }: PageProps) {
         }
       >
         <ChargingBento searchParams={searchParams} />
+      </Suspense>
+
+      <Suspense fallback={null}>
+        <ChargingQuestions />
       </Suspense>
     </>
   );

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -98,7 +98,9 @@ ${popularMakes.map(({ make }) => make).join(", ")}
 - [PARF Calculator](${SITE_URL}/cars/parf): Calculate PARF rebate values
 - [Cars by Make](${SITE_URL}/cars/makes): Browse registrations by manufacturer
 - [All Makes Directory](${SITE_URL}/cars/makes): Complete list of car manufacturers
-- [Electric Vehicles](${SITE_URL}/cars/fuel-types/electric): BEV registration data
+- [Electric Vehicles](${SITE_URL}/cars/electric-vehicles): BEV, PHEV and hybrid adoption trends and market share
+- [EV Charging](${SITE_URL}/cars/electric-vehicles/charging): Live public charger availability, cheapest and most expensive per-kWh rates, filterable by postal district
+- [Electric Vehicles by Fuel Type](${SITE_URL}/cars/fuel-types/electric): BEV registration data
 - [Hybrid Vehicles](${SITE_URL}/cars/fuel-types/petrol-electric): Petrol-electric hybrid data
 - [Plug-in Hybrids](${SITE_URL}/cars/fuel-types/petrol-electric-plug-in): PHEV statistics
 - [Diesel Vehicles](${SITE_URL}/cars/fuel-types/diesel): Diesel registration data
@@ -107,6 +109,13 @@ ${popularMakes.map(({ make }) => make).join(", ")}
 - [Sedans](${SITE_URL}/cars/vehicle-types/sedan): Sedan registration statistics
 - [Hatchbacks](${SITE_URL}/cars/vehicle-types/hatchback): Hatchback vehicle data
 - [MPVs](${SITE_URL}/cars/vehicle-types/multi-purpose-vehicle): Multi-purpose vehicle statistics
+
+## EV Charging (Live)
+
+Singapore's public EV charger network, from LTA DataMall's EV Charging Points feed (refreshed every five minutes). Figures are live and per-kWh prices are the operators' advertised rates including GST.
+
+- [EV Charging Overview](${SITE_URL}/cars/electric-vehicles/charging): Connectors in use, cheapest and most expensive AC and DC charging by district, common questions answered with current figures
+- Filter by district with the query parameter district=<slug> (for example ${SITE_URL}/cars/electric-vehicles/charging?district=jurong-boon-lay-tuas) and by power rating with power=AC or power=DC
 
 ## COE Bidding Results
 

--- a/apps/web/src/lib/metadata/structured-data.ts
+++ b/apps/web/src/lib/metadata/structured-data.ts
@@ -69,7 +69,8 @@ type DatasetType =
   | "coe-pqp"
   | "deregistrations"
   | "annual"
-  | "electric-vehicles";
+  | "electric-vehicles"
+  | "ev-charging";
 
 interface DatasetConfig {
   name: string;
@@ -177,6 +178,19 @@ const DATASET_CONFIGS: Record<DatasetType, DatasetConfig> = {
       "EV market share percentage",
       "BEV vs PHEV vs HEV breakdown",
       "EV adoption growth rate",
+    ],
+  },
+  "ev-charging": {
+    name: "Singapore Public EV Charger Availability and Prices",
+    description:
+      "Live status of every public electric vehicle charging connector in Singapore, with advertised per-kWh prices, AC and DC power ratings and operator, refreshed every five minutes from LTA DataMall.",
+    path: "/cars/electric-vehicles/charging",
+    temporalCoverage: "2026-09/..",
+    variableMeasured: [
+      "Connectors available, occupied and out of service",
+      "Advertised charging price per kWh by location",
+      "AC and DC charging speed in kW",
+      "Charging locations by postal district and operator",
     ],
   },
 };


### PR DESCRIPTION
- Re-applies the intro, FAQ and Dataset schema work from #978 and #979, which merged into `ev-charging/live-ui` after that branch had already merged to main and so never reached it
- Adds a prose intro answering the page's question directly with the live connector count, median and cheapest AC/DC rates, a last-updated line in SGT and the LTA DataMall source
- Adds five common questions answered in self-contained 40-60 word blocks from the same live figures, rendered as an accordion and emitted as FAQPage structured data
- Registers an `ev-charging` Dataset schema and lists the page and its district and power query parameters in `llms.txt`
- Rebuilt on current main, so the page keeps the busy hours, busiest, quietest and this-week cards that #976 added

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791042419&installation_model_id=21947&pr_number=981&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F981&signature=bb1b4946dd0efc28eb51bc888893f423ba81f56165fecbd37d8054ad0c138340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->