### PR TITLE
Add a contact page and complete the Organization schema

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/page.tsx
@@ -18,7 +18,7 @@ import { SectionErrorBoundary } from "@web/components/error-boundary";
 import { Bento, RAIL_CLASS } from "@web/components/shared/bento";
 import { PageHead } from "@web/components/shared/page-head";
 import { StructuredData } from "@web/components/structured-data";
-import { LOGO_URL, SITE_TITLE, SITE_URL } from "@web/config";
+import { LOGO_URL, SITE_TITLE, SITE_URL, SUPPORT_EMAIL } from "@web/config";
 import { brandSameAs } from "@web/config/socials";
 import { socialLinks } from "@web/flags";
 import type { Metadata } from "next";
@@ -90,6 +90,13 @@ async function OrganizationStructuredData() {
         logo: LOGO_URL,
         description:
           "A platform for exploring Singapore car registration statistics, COE bidding results, and market data.",
+        contactPoint: {
+          "@type": "ContactPoint",
+          contactType: "customer support",
+          email: SUPPORT_EMAIL,
+          url: `${SITE_URL}/contact`,
+        },
+        address: { "@type": "PostalAddress", addressCountry: "SG" },
         ...(sameAs.length > 0 ? { sameAs } : {}),
       }}
     />

--- a/apps/web/src/app/(main)/(site)/about/page.tsx
+++ b/apps/web/src/app/(main)/(site)/about/page.tsx
@@ -8,7 +8,7 @@ import { MissionSection } from "@web/app/(main)/(site)/about/components/mission-
 import { StatsSection } from "@web/app/(main)/(site)/about/components/stats-section";
 import { SitePage } from "@web/components/shared/site-page";
 import { StructuredData } from "@web/components/structured-data";
-import { LOGO_URL, SITE_TITLE, SITE_URL } from "@web/config";
+import { LOGO_URL, SITE_TITLE, SITE_URL, SUPPORT_EMAIL } from "@web/config";
 import { brandSameAs, SOCIAL_HANDLE } from "@web/config/socials";
 import { socialLinks } from "@web/flags";
 import type { Metadata } from "next";
@@ -57,6 +57,13 @@ async function OrganizationStructuredData() {
     logo: LOGO_URL,
     description:
       "A platform for exploring Singapore car registration statistics, COE bidding results, and market data.",
+    contactPoint: {
+      "@type": "ContactPoint",
+      contactType: "customer support",
+      email: SUPPORT_EMAIL,
+      url: `${SITE_URL}/contact`,
+    },
+    address: { "@type": "PostalAddress", addressCountry: "SG" },
     ...(sameAs.length > 0 ? { sameAs } : {}),
     founder: {
       "@type": "Person",

--- a/apps/web/src/app/(main)/(site)/contact/page.tsx
+++ b/apps/web/src/app/(main)/(site)/contact/page.tsx
@@ -1,0 +1,99 @@
+import {
+  GITHUB_REPO_URL,
+  SITE_TITLE,
+  SITE_URL,
+  SUPPORT_EMAIL,
+} from "@web/config";
+import { advertisePage } from "@web/flags";
+import type { Metadata } from "next";
+import { Suspense } from "react";
+
+const title = `Contact ${SITE_TITLE}`;
+const description = `How to reach ${SITE_TITLE} about Singapore car registration data, COE results, corrections, partnerships and press enquiries.`;
+
+export const metadata: Metadata = {
+  title: { absolute: title },
+  description,
+  openGraph: {
+    title,
+    description,
+    url: `${SITE_URL}/contact`,
+    siteName: SITE_TITLE,
+    locale: "en_SG",
+    type: "website",
+  },
+  alternates: {
+    canonical: "/contact",
+  },
+};
+
+async function AdvertisingSection() {
+  const showAdvertisePage = await advertisePage();
+  if (!showAdvertisePage) {
+    return null;
+  }
+
+  return (
+    <section>
+      <h2>Advertising</h2>
+      <p>
+        Sponsorship and placement enquiries have their own page. See{" "}
+        <a href="/advertise">Advertise</a> for the rules and rates.
+      </p>
+    </section>
+  );
+}
+
+export default function ContactPage() {
+  return (
+    <article className="prose prose-neutral max-w-none">
+      <header className="mb-8">
+        <h1>Contact</h1>
+        <p className="text-muted">
+          {SITE_TITLE} is an independent, open-source project that publishes
+          Singapore car registration statistics and COE bidding results.
+        </p>
+      </header>
+
+      <section>
+        <h2>Email</h2>
+        <p>
+          For questions about the data, corrections, partnerships or press
+          enquiries, write to{" "}
+          <a href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a>. We read every
+          message and usually reply within a few working days. Please include
+          the page URL and the month or bidding exercise you are asking about so
+          we can look it up quickly.
+        </p>
+      </section>
+
+      <section>
+        <h2>Bugs and feature requests</h2>
+        <p>
+          The codebase is public. If a chart is wrong, a page fails to load or
+          you would like to see a new breakdown, open an issue on the{" "}
+          <a href={GITHUB_REPO_URL} rel="noopener noreferrer" target="_blank">
+            GitHub repository
+          </a>
+          . Pull requests are welcome.
+        </p>
+      </section>
+
+      <Suspense>
+        <AdvertisingSection />
+      </Suspense>
+
+      <section>
+        <h2>About the data</h2>
+        <p>
+          All figures come from the Land Transport Authority and are refreshed
+          as new monthly and bidding data is published. {SITE_TITLE} is not
+          affiliated with the Land Transport Authority or any car dealer, and
+          cannot help with individual COE bids, vehicle registration or
+          licensing matters. For those, contact the Land Transport Authority
+          directly.
+        </p>
+      </section>
+    </article>
+  );
+}

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -150,6 +150,7 @@ ${recentPosts.map((post) => `- [${post.title}](${SITE_URL}/blog/${post.slug})`).
 
 - [About](${SITE_URL}/about): About ${SITE_TITLE} platform
 - [Learn](${SITE_URL}/learn): Educational hub with FAQs, terminology, guides and data sources
+- [Contact](${SITE_URL}/contact): How to reach the team about data, corrections or partnerships
 
 ## Guides
 

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -114,6 +114,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: new Date(),
       changeFrequency: "monthly" as const,
     },
+    {
+      url: `${SITE_URL}/contact`,
+      lastModified: new Date(),
+      changeFrequency: "yearly" as const,
+    },
     ...getAllGuideSlugs().map((slug) => ({
       url: `${SITE_URL}/learn/${slug}`,
       lastModified: new Date(),

--- a/apps/web/src/components/__snapshots__/footer.test.tsx.snap
+++ b/apps/web/src/components/__snapshots__/footer.test.tsx.snap
@@ -66,6 +66,14 @@ exports[`Footer > should render the shell footer with navigation and version inf
         <li>
           <a
             class="font-semibold text-muted text-sm transition-colors hover:text-accent-strong"
+            href="/contact"
+          >
+            Contact
+          </a>
+        </li>
+        <li>
+          <a
+            class="font-semibold text-muted text-sm transition-colors hover:text-accent-strong"
             href="/legal/privacy-policy"
           >
             Privacy

--- a/apps/web/src/config/index.ts
+++ b/apps/web/src/config/index.ts
@@ -25,6 +25,9 @@ export const SITE_URL =
 
 export const LOGO_URL = `${SITE_URL}/icon.png`;
 
+export const SUPPORT_EMAIL = "support@motormetrics.app";
+export const GITHUB_REPO_URL = "https://github.com/motormetrics/motormetrics";
+
 // =============================================================================
 // API Configuration
 // =============================================================================

--- a/apps/web/src/config/navigation.ts
+++ b/apps/web/src/config/navigation.ts
@@ -250,6 +250,7 @@ export const BLOG_MORE_ITEM: NavigationItem = {
 export const FOOTER_NAV_ITEMS = [
   { href: "/about", label: "About" },
   { href: "/learn", label: "Learn" },
+  { href: "/contact", label: "Contact" },
   { href: "/legal/privacy-policy", label: "Privacy" },
   { href: "/legal/terms-of-service", label: "Terms" },
 ] as const satisfies readonly NavItem[];

--- a/apps/web/src/utils/__tests__/flagged-nav.test.ts
+++ b/apps/web/src/utils/__tests__/flagged-nav.test.ts
@@ -24,6 +24,7 @@ describe("footerNavItems", () => {
     ).toEqual([
       "/about",
       "/learn",
+      "/contact",
       "/legal/privacy-policy",
       "/legal/terms-of-service",
     ]);
@@ -35,6 +36,7 @@ describe("footerNavItems", () => {
         "/about",
         "/learn",
         "/advertise",
+        "/contact",
         "/legal/privacy-policy",
         "/legal/terms-of-service",
       ],


### PR DESCRIPTION
- Add a static \`/contact\` page (no form) with email, GitHub issues and data-scope guidance; the Advertising section renders only when the existing \`advertise-page\` flag is on
- Add \`contactPoint\` and a country-only \`PostalAddress\` to the Organization JSON-LD on the homepage and about page
- Share \`SUPPORT_EMAIL\` and \`GITHUB_REPO_URL\` from the web config
- Link the page from the footer, sitemap and llms.txt; update the footer nav test expectations

Closes the "trust anchor pages" and "Organization schema completeness" gaps from the is-agentic scan of motormetrics.app.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791043191&installation_model_id=21947&pr_number=982&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F982&signature=5e95d2a91e4375c7dfc28d988703b3f8accfa1ace6aedcd69efeca955e8cb42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->