### PR TITLE
Cache updater checksum only after inserts succeed

### DIFF
--- a/apps/web/src/lib/updater/updater.test.ts
+++ b/apps/web/src/lib/updater/updater.test.ts
@@ -173,6 +173,48 @@ describe("update", () => {
     });
   });
 
+  it("should still cache the checksum when all records conflict", async () => {
+    vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue("different123");
+
+    const mockInsert = createInsertMock([]);
+    vi.mocked(db.insert).mockReturnValue(mockInsert as never);
+
+    await update(updaterConfig, updaterOptions);
+
+    expect(mockChecksum.cacheChecksum).toHaveBeenCalledWith(
+      "test-file.csv",
+      "abc123",
+    );
+  });
+
+  it("should not cache the checksum when the insert fails", async () => {
+    vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue("different123");
+
+    const mockInsert = createInsertMock();
+    mockInsert.returning.mockRejectedValue(
+      new Error("Database request failed"),
+    );
+    vi.mocked(db.insert).mockReturnValue(mockInsert as never);
+
+    await expect(update(updaterConfig, updaterOptions)).rejects.toThrow(
+      "Database request failed",
+    );
+
+    expect(mockChecksum.cacheChecksum).not.toHaveBeenCalled();
+  });
+
+  it("should not cache the checksum when CSV processing fails", async () => {
+    vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue(null);
+    vi.mocked(processCsv).mockRejectedValue(new Error("Malformed CSV"));
+
+    await expect(update(updaterConfig, updaterOptions)).rejects.toThrow(
+      "Malformed CSV",
+    );
+
+    expect(mockChecksum.cacheChecksum).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
   it("should process data in batches", async () => {
     const largeDataSet = Array(5)
       .fill(null)

--- a/apps/web/src/lib/updater/updater.ts
+++ b/apps/web/src/lib/updater/updater.ts
@@ -61,7 +61,6 @@ export async function update<T>(
 
   if (!cachedChecksum) {
     console.log("No cached checksum found. This might be the first run.");
-    await checksumService.cacheChecksum(checksumKey, checksum);
   } else if (cachedChecksum === checksum) {
     console.log(
       `File has not changed since last update (Checksum: ${checksum})`,
@@ -72,10 +71,9 @@ export async function update<T>(
       message: "File has not changed since last update",
       timestamp: new Date().toISOString(),
     };
+  } else {
+    console.log("Checksum has been changed.");
   }
-
-  await checksumService.cacheChecksum(checksumKey, checksum);
-  console.log("Checksum has been changed.");
 
   // === Process CSV ===
   const processedData = await processCsv<T>(
@@ -106,6 +104,10 @@ export async function update<T>(
   console.log(
     `Inserted ${totalInserted} record(s) in ${Math.round(end - start)}ms`,
   );
+
+  // Cache the checksum only after the insert succeeds, so a failed run is
+  // retried instead of being skipped as "unchanged" next time.
+  await checksumService.cacheChecksum(checksumKey, checksum);
 
   if (totalInserted === 0) {
     return {


### PR DESCRIPTION
- Move the Redis checksum write in the shared updater to after the batch insert loop, so a step that fails mid-run is retried by the workflow instead of being skipped as unchanged
- Still cache the checksum when the file changed but every row already existed, so already-loaded files are skipped on later runs
- Add tests covering the zero-insert path and insert or CSV parse failures leaving the checksum uncached

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791045279&installation_model_id=21947&pr_number=983&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F983&signature=6b74c374c880763fa11342141fef26f2104f26695097853dace6a9f05bbde6d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->