### PR TITLE
Add heatmap mode and site locator to the EV charging map

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map-view.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map-view.tsx
@@ -1,12 +1,16 @@
 "use client";
 
+import { SearchField, Typography } from "@heroui/react";
+import { Segment } from "@heroui-pro/react";
 // biome-ignore lint/suspicious/noShadowRestrictedNames: HeroUI Pro Map component
 import { Map, type MapClusterLayerProps, useMap } from "@heroui-pro/react/map";
+import { siteParam } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/search-params";
 import { inDistrict } from "@web/queries/ev-charging/locations";
 import type { EvChargingMapSite } from "@web/queries/ev-charging/map-sites";
 import type { FeatureCollection, Point } from "geojson";
 import { type LngLatBoundsLike, setWorkerUrl } from "maplibre-gl";
-import { useEffect, useMemo, useState } from "react";
+import { useQueryState } from "nuqs";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { describeConnectors } from "./location-row";
 
 setWorkerUrl("/maplibre/maplibre-gl-worker.mjs");
@@ -16,9 +20,31 @@ const MAP_STYLES = {
   dark: "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
 };
 
+const MAP_MODES = [
+  { key: "availability", label: "Live availability" },
+  { key: "utilisation", label: "Busiest sites" },
+] as const;
+
+type MapMode = (typeof MAP_MODES)[number]["key"];
+
+const MODE_LEGENDS: Record<MapMode, string> = {
+  availability:
+    "Green has free connectors · amber is full · grey is out of service",
+  utilisation:
+    "Warmer areas were occupied more often over the past week · sites under a day old are left out",
+};
+
+/** How many matches the locator card lists before asking for more letters. */
+const LOCATOR_LIMIT = 5;
+
+const siteTitle = (site: EvChargingMapSite) =>
+  site.stationName ?? site.address ?? site.locationId;
+
 /** Singapore, framed with a little sea on every side. */
 const ISLAND_CENTER: [number, number] = [103.82, 1.36];
 const ISLAND_ZOOM = 10.5;
+/** Close enough to see the block a chosen site sits on. */
+const SITE_ZOOM = 15;
 
 /** MapLibre paints cannot read CSS variables, so tokens are resolved once. */
 const readTokens = () => {
@@ -32,6 +58,7 @@ const readTokens = () => {
     cluster: read("--accent", "#4e7c9b"),
     clusterStrong: read("--accent-strong", "#33586f"),
     clusterDeep: read("--accent-deep", "#16323f"),
+    busy: read("--danger", "#e96e6e"),
   };
 };
 
@@ -57,6 +84,113 @@ const toFeatureCollection = (
     properties: site,
   })),
 });
+
+/** Heat stops need translucency, which only a six-digit hex token can take. */
+const withAlpha = (hex: string, alpha: string) =>
+  /^#[0-9a-f]{6}$/i.test(hex) ? `${hex}${alpha}` : hex;
+
+const HEATMAP_SOURCE_ID = "charging-utilisation-source";
+const HEATMAP_LAYER_ID = "charging-utilisation-layer";
+
+/**
+ * Weekly occupancy as a heat layer, drawn beneath the basemap's labels.
+ *
+ * MapLibre has no React wrapper for heatmaps, so the layer is added to the
+ * style by hand and removed again when the mode changes.
+ */
+function UtilisationHeatmap({
+  collection,
+  tokens,
+}: {
+  collection: FeatureCollection<Point, EvChargingMapSite>;
+  tokens: MapTokens;
+}) {
+  const { isLoaded, map } = useMap();
+
+  useEffect(() => {
+    if (!isLoaded || !map) {
+      return;
+    }
+
+    const addLayers = () => {
+      if (map.getSource(HEATMAP_SOURCE_ID)) {
+        return;
+      }
+      const beforeId = map
+        .getStyle()
+        .layers?.find((layer) => layer.type === "symbol")?.id;
+
+      map.addSource(HEATMAP_SOURCE_ID, {
+        type: "geojson",
+        data: {
+          ...collection,
+          features: collection.features.filter(
+            (feature) => feature.properties.utilisationPercent != null,
+          ),
+        },
+      });
+      map.addLayer(
+        {
+          id: HEATMAP_LAYER_ID,
+          type: "heatmap",
+          source: HEATMAP_SOURCE_ID,
+          paint: {
+            "heatmap-weight": [
+              "/",
+              ["coalesce", ["get", "utilisationPercent"], 0],
+              100,
+            ],
+            "heatmap-intensity": 0.9,
+            "heatmap-opacity": 0.8,
+            "heatmap-radius": [
+              "interpolate",
+              ["linear"],
+              ["zoom"],
+              10,
+              18,
+              14,
+              40,
+            ],
+            "heatmap-color": [
+              "interpolate",
+              ["linear"],
+              ["heatmap-density"],
+              0,
+              withAlpha(tokens.cluster, "00"),
+              0.25,
+              withAlpha(tokens.cluster, "66"),
+              0.5,
+              withAlpha(tokens.available, "8c"),
+              0.75,
+              withAlpha(tokens.full, "b3"),
+              1,
+              withAlpha(tokens.busy, "d9"),
+            ],
+          },
+        },
+        beforeId,
+      );
+    };
+
+    if (map.isStyleLoaded()) {
+      addLayers();
+    } else {
+      map.once("idle", addLayers);
+    }
+
+    return () => {
+      map.off("idle", addLayers);
+      if (map.getLayer(HEATMAP_LAYER_ID)) {
+        map.removeLayer(HEATMAP_LAYER_ID);
+      }
+      if (map.getSource(HEATMAP_SOURCE_ID)) {
+        map.removeSource(HEATMAP_SOURCE_ID);
+      }
+    };
+  }, [collection, isLoaded, map, tokens]);
+
+  return null;
+}
 
 /** Zooms to the chosen district's sites, or back out to the whole island. */
 function DistrictFocus({
@@ -91,6 +225,102 @@ function DistrictFocus({
   return null;
 }
 
+/** Search card over the map that jumps to a site by name or address. */
+function SiteLocator({
+  onPick,
+  sites,
+}: {
+  onPick: (site: EvChargingMapSite) => void;
+  sites: EvChargingMapSite[];
+}) {
+  const [query, setQuery] = useState("");
+  const needle = query.trim().toLowerCase();
+  const matches = useMemo(() => {
+    if (needle.length < 2) {
+      return [];
+    }
+    return sites
+      .filter((site) =>
+        [site.stationName, site.address, site.operator]
+          .filter(Boolean)
+          .some((text) => text?.toLowerCase().includes(needle)),
+      )
+      .slice(0, LOCATOR_LIMIT);
+  }, [needle, sites]);
+
+  return (
+    <div className="absolute top-3 left-3 z-10 flex w-64 max-w-[calc(100%-1.5rem)] flex-col gap-2 rounded-2xl bg-overlay p-3 shadow-overlay">
+      <SearchField
+        aria-label="Find a charging site"
+        fullWidth
+        onChange={setQuery}
+        value={query}
+        variant="secondary"
+      >
+        <SearchField.Group>
+          <SearchField.SearchIcon />
+          <SearchField.Input placeholder="Find a site or address" />
+          <SearchField.ClearButton />
+        </SearchField.Group>
+      </SearchField>
+
+      {needle.length >= 2 ? (
+        matches.length === 0 ? (
+          <Typography.Paragraph className="px-1" color="muted" size="xs">
+            No sites match.
+          </Typography.Paragraph>
+        ) : (
+          <ul className="flex flex-col">
+            {matches.map((site) => (
+              <li key={site.locationId}>
+                <button
+                  className="flex w-full cursor-pointer flex-col rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-surface-tertiary"
+                  onClick={() => {
+                    onPick(site);
+                    setQuery("");
+                  }}
+                  type="button"
+                >
+                  <span className="truncate font-semibold text-xs">
+                    {siteTitle(site)}
+                  </span>
+                  <span className="truncate text-muted text-xs">
+                    {site.available} free · {site.operator ?? site.address}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+/** Flies to the site named in the URL and hands it back to open its popup. */
+function SiteFocus({
+  onFocus,
+  site,
+}: {
+  onFocus: (site: EvChargingMapSite) => void;
+  site: EvChargingMapSite | undefined;
+}) {
+  const { isLoaded, map } = useMap();
+
+  useEffect(() => {
+    if (!isLoaded || !map || !site) {
+      return;
+    }
+    map.easeTo({
+      center: [site.longitude, site.latitude],
+      zoom: Math.max(map.getZoom(), SITE_ZOOM),
+    });
+    onFocus(site);
+  }, [isLoaded, map, onFocus, site]);
+
+  return null;
+}
+
 export function ChargingMapView({
   district,
   sites,
@@ -99,8 +329,30 @@ export function ChargingMapView({
   sites: EvChargingMapSite[];
 }) {
   const [tokens, setTokens] = useState<MapTokens | null>(null);
+  const [mode, setMode] = useState<MapMode>("availability");
   const [selected, setSelected] = useState<SelectedSite | null>(null);
+  const [siteId, setSiteId] = useQueryState("site", siteParam);
   const collection = useMemo(() => toFeatureCollection(sites), [sites]);
+  const focusedSite = useMemo(
+    () =>
+      siteId ? sites.find((site) => site.locationId === siteId) : undefined,
+    [siteId, sites],
+  );
+  // Read through a ref so a district change does not re-run the site focus.
+  const districtRef = useRef(district);
+  districtRef.current = district;
+  const focusSite = useCallback((site: EvChargingMapSite) => {
+    setMode("availability");
+    setSelected({
+      site,
+      coordinates: [site.longitude, site.latitude],
+      district: districtRef.current,
+    });
+  }, []);
+  const closePopup = () => {
+    setSelected(null);
+    setSiteId(null);
+  };
 
   useEffect(() => {
     setTokens(readTokens());
@@ -118,56 +370,93 @@ export function ChargingMapView({
     : undefined;
 
   return (
-    <div className="relative h-[480px] w-full overflow-hidden rounded-3xl">
-      <Map
-        center={ISLAND_CENTER}
-        styles={MAP_STYLES}
-        theme="light"
-        zoom={ISLAND_ZOOM}
+    <>
+      <Segment
+        aria-label="Map view"
+        className="w-fit"
+        onSelectionChange={(key) => {
+          setMode(key as MapMode);
+          closePopup();
+        }}
+        selectedKey={mode}
       >
-        <DistrictFocus district={district} sites={sites} />
+        {MAP_MODES.map((option) => (
+          <Segment.Item id={option.key} key={option.key}>
+            {option.label}
+          </Segment.Item>
+        ))}
+      </Segment>
 
-        {tokens ? (
-          <Map.ClusterLayer<EvChargingMapSite>
-            clusterColors={[
-              tokens.cluster,
-              tokens.clusterStrong,
-              tokens.clusterDeep,
-            ]}
-            clusterRadius={44}
-            clusterThresholds={[10, 50]}
-            data={collection}
-            onPointClick={(feature, coordinates) => {
-              setSelected({ site: feature.properties, coordinates, district });
-            }}
-            pointColor={pointColor}
-          />
-        ) : null}
+      <div className="relative h-[480px] w-full overflow-hidden rounded-3xl">
+        <Map
+          center={ISLAND_CENTER}
+          styles={MAP_STYLES}
+          theme="light"
+          zoom={ISLAND_ZOOM}
+        >
+          <DistrictFocus district={district} sites={sites} />
+          <SiteFocus onFocus={focusSite} site={focusedSite} />
 
-        {selected && selected.district === district ? (
-          <Map.Popup
-            closeButton
-            closeOnClick={false}
-            focusAfterOpen={false}
-            latitude={selected.coordinates[1]}
-            longitude={selected.coordinates[0]}
-            offset={12}
-            onClose={() => setSelected(null)}
-          >
-            <SitePopup site={selected.site} />
-          </Map.Popup>
-        ) : null}
+          {tokens && mode === "utilisation" ? (
+            <UtilisationHeatmap collection={collection} tokens={tokens} />
+          ) : null}
 
-        <Map.Controls>
-          <Map.ZoomControl />
-        </Map.Controls>
-      </Map>
-    </div>
+          {tokens && mode === "availability" ? (
+            <Map.ClusterLayer<EvChargingMapSite>
+              clusterColors={[
+                tokens.cluster,
+                tokens.clusterStrong,
+                tokens.clusterDeep,
+              ]}
+              clusterRadius={44}
+              clusterThresholds={[10, 50]}
+              data={collection}
+              onPointClick={(feature, coordinates) => {
+                setSelected({
+                  site: feature.properties,
+                  coordinates,
+                  district,
+                });
+              }}
+              pointColor={pointColor}
+            />
+          ) : null}
+
+          {selected && selected.district === district ? (
+            <Map.Popup
+              closeButton
+              closeOnClick={false}
+              focusAfterOpen={false}
+              latitude={selected.coordinates[1]}
+              longitude={selected.coordinates[0]}
+              offset={12}
+              onClose={closePopup}
+            >
+              <SitePopup site={selected.site} />
+            </Map.Popup>
+          ) : null}
+
+          <Map.Controls>
+            <Map.LocateControl />
+            <Map.ZoomControl />
+          </Map.Controls>
+        </Map>
+
+        <SiteLocator
+          onPick={(site) => setSiteId(site.locationId)}
+          sites={sites}
+        />
+      </div>
+
+      <Typography.Paragraph color="muted" size="xs">
+        {MODE_LEGENDS[mode]}
+      </Typography.Paragraph>
+    </>
   );
 }
 
 function SitePopup({ site }: { site: EvChargingMapSite }) {
-  const title = site.stationName ?? site.address ?? site.locationId;
+  const title = siteTitle(site);
   const usable = site.connectors - site.unavailable;
 
   return (

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map.tsx
@@ -1,4 +1,5 @@
 import { Typography } from "@heroui/react";
+import { MAP_ANCHOR_ID } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/search-params";
 import { SurfaceCard } from "@web/components/shared/bento";
 import { getPostalDistrict } from "@web/config/postal-districts";
 import { getEvChargingMapSites } from "@web/queries/ev-charging";
@@ -13,19 +14,17 @@ export async function ChargingMap({ district }: { district: string }) {
   const scope = getPostalDistrict(district)?.name ?? "Singapore";
 
   return (
-    <SurfaceCard className="gap-4 p-7">
-      <div className="flex flex-col gap-1">
-        <Typography.Paragraph className="text-muted">
-          Live availability by site
-        </Typography.Paragraph>
-        <Typography.Heading level={3}>Chargers in {scope}</Typography.Heading>
-      </div>
+    <div className="scroll-mt-6" id={MAP_ANCHOR_ID}>
+      <SurfaceCard className="gap-4 p-7">
+        <div className="flex flex-col gap-1">
+          <Typography.Paragraph className="text-muted">
+            Live availability by site
+          </Typography.Paragraph>
+          <Typography.Heading level={3}>Chargers in {scope}</Typography.Heading>
+        </div>
 
-      <ChargingMapView district={district} sites={sites} />
-
-      <Typography.Paragraph color="muted" size="xs">
-        Green has free connectors · amber is full · grey is out of service
-      </Typography.Paragraph>
-    </SurfaceCard>
+        <ChargingMapView district={district} sites={sites} />
+      </SurfaceCard>
+    </div>
   );
 }

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/location-row.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/location-row.tsx
@@ -1,6 +1,13 @@
+"use client";
+
 import { Typography } from "@heroui/react";
+import {
+  MAP_ANCHOR_ID,
+  siteParam,
+} from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/search-params";
 import { districtForPostalCode } from "@web/config/postal-districts";
 import type { EvChargingLocation } from "@web/queries/ev-charging";
+import { useQueryState } from "nuqs";
 import type { ReactNode } from "react";
 
 /** "2× DC 120 kW" style summary of what a location offers. */
@@ -10,7 +17,12 @@ export const describeConnectors = (location: EvChargingLocation): string => {
   return `${location.connectors}× ${rating}${speed}`;
 };
 
-/** A location line item shared by the ranked lists on the charging page. */
+/**
+ * A location line item shared by the ranked lists on the charging page.
+ *
+ * Clicking a row selects the site in the URL, which the map picks up to fly
+ * there and open its popup.
+ */
 export function LocationRow({
   index,
   location,
@@ -21,30 +33,42 @@ export function LocationRow({
   /** Right-aligned figure: a price, a percentage, or a date. */
   trailing: ReactNode;
 }) {
+  const [, setSite] = useQueryState("site", siteParam);
   const district = districtForPostalCode(location.postalCode);
   const title = location.stationName ?? location.address ?? location.locationId;
 
   return (
-    <li className="flex items-center gap-3">
-      <span className="flex size-[26px] shrink-0 items-center justify-center rounded-full bg-accent/15 font-extrabold text-accent-strong text-xs tabular-nums">
-        {index + 1}
-      </span>
-      <div className="flex min-w-0 flex-col">
-        <Typography.Paragraph
-          size="sm"
-          className="truncate font-semibold text-foreground/85"
-        >
-          {title}
-        </Typography.Paragraph>
-        <Typography.Paragraph color="muted" size="xs" className="truncate">
-          {[district?.name, describeConnectors(location)]
-            .filter(Boolean)
-            .join(" · ")}
-        </Typography.Paragraph>
-      </div>
-      <span className="ml-auto shrink-0 font-extrabold text-sm tabular-nums">
-        {trailing}
-      </span>
+    <li>
+      <button
+        className="flex w-full cursor-pointer items-center gap-3 rounded-xl text-left transition-colors hover:bg-default/60"
+        onClick={() => {
+          setSite(location.locationId);
+          document
+            .getElementById(MAP_ANCHOR_ID)
+            ?.scrollIntoView({ behavior: "smooth", block: "start" });
+        }}
+        type="button"
+      >
+        <span className="flex size-[26px] shrink-0 items-center justify-center rounded-full bg-accent/15 font-extrabold text-accent-strong text-xs tabular-nums">
+          {index + 1}
+        </span>
+        <div className="flex min-w-0 flex-col">
+          <Typography.Paragraph
+            size="sm"
+            className="truncate font-semibold text-foreground/85"
+          >
+            {title}
+          </Typography.Paragraph>
+          <Typography.Paragraph color="muted" size="xs" className="truncate">
+            {[district?.name, describeConnectors(location)]
+              .filter(Boolean)
+              .join(" · ")}
+          </Typography.Paragraph>
+        </div>
+        <span className="ml-auto shrink-0 font-extrabold text-sm tabular-nums">
+          {trailing}
+        </span>
+      </button>
     </li>
   );
 }

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/search-params.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/search-params.ts
@@ -3,6 +3,12 @@ import { createLoader, parseAsString, parseAsStringLiteral } from "nuqs/server";
 /** Which power rating the price rankings list. */
 export const POWER_RATINGS = ["AC", "DC"] as const;
 
+/** Site a list row picked out for the map; client-only, never read on the server. */
+export const siteParam = parseAsString.withDefault("");
+
+/** DOM id the map card carries so a list row can scroll it into view. */
+export const MAP_ANCHOR_ID = "charging-map";
+
 export const chargingSearchParams = {
   /** Postal district slug from `config/postal-districts`; empty means all. */
   district: parseAsString.withDefault(""),

--- a/apps/web/src/queries/ev-charging/map-sites.test.ts
+++ b/apps/web/src/queries/ev-charging/map-sites.test.ts
@@ -1,8 +1,12 @@
 import { connector } from "./fixtures";
+import { getEvChargingLocationUtilisation } from "./location-utilisation";
 import { getEvChargingMapSites } from "./map-sites";
 import { getEvChargingSnapshot } from "./snapshot";
 
 vi.mock("./snapshot", () => ({ getEvChargingSnapshot: vi.fn() }));
+vi.mock("./location-utilisation", () => ({
+  getEvChargingLocationUtilisation: vi.fn().mockResolvedValue([]),
+}));
 
 describe("getEvChargingMapSites", () => {
   it("should place each location once with its status counts", async () => {
@@ -43,8 +47,26 @@ describe("getEvChargingMapSites", () => {
         available: 1,
         occupied: 1,
         unavailable: 1,
+        utilisationPercent: null,
       }),
     ]);
+  });
+
+  it("should attach the weekly utilisation where a location has one", async () => {
+    vi.mocked(getEvChargingSnapshot).mockResolvedValue({
+      observedAt: null,
+      records: [connector({ evCpId: "A", latitude: 1.3, longitude: 103.8 })],
+    });
+    vi.mocked(getEvChargingLocationUtilisation).mockResolvedValueOnce([
+      {
+        ...connector({ evCpId: "A" }),
+        utilisationPercent: 42.5,
+        samples: 300,
+      } as never,
+    ]);
+
+    const [site] = await getEvChargingMapSites();
+    expect(site).toMatchObject({ utilisationPercent: 42.5 });
   });
 
   it("should use the first connector that carries coordinates", async () => {

--- a/apps/web/src/queries/ev-charging/map-sites.ts
+++ b/apps/web/src/queries/ev-charging/map-sites.ts
@@ -1,3 +1,4 @@
+import { getEvChargingLocationUtilisation } from "./location-utilisation";
 import { type EvChargingLocation, groupLocations } from "./locations";
 import { getEvChargingSnapshot } from "./snapshot";
 
@@ -7,6 +8,8 @@ export interface EvChargingMapSite extends EvChargingLocation {
   available: number;
   occupied: number;
   unavailable: number;
+  /** Average occupancy over the past week, or null without enough samples. */
+  utilisationPercent: number | null;
 }
 
 interface SiteExtras {
@@ -24,7 +27,13 @@ interface SiteExtras {
  * Locations without coordinates are dropped rather than guessed at.
  */
 export async function getEvChargingMapSites(): Promise<EvChargingMapSite[]> {
-  const { records } = await getEvChargingSnapshot();
+  const [{ records }, utilisation] = await Promise.all([
+    getEvChargingSnapshot(),
+    getEvChargingLocationUtilisation({ order: "busiest", limit: 10_000 }),
+  ]);
+  const utilisationByLocation = new Map(
+    utilisation.map((row) => [row.locationId, row.utilisationPercent]),
+  );
 
   const extrasByLocation = new Map<string, SiteExtras>();
   for (const record of records) {
@@ -60,6 +69,8 @@ export async function getEvChargingMapSites(): Promise<EvChargingMapSite[]> {
       available: extras.available,
       occupied: extras.occupied,
       unavailable: extras.unavailable,
+      utilisationPercent:
+        utilisationByLocation.get(location.locationId) ?? null,
     });
   }
   return sites;


### PR DESCRIPTION
- Add a Busiest sites mode to the charger map that draws weekly utilisation as a MapLibre heatmap, with a segmented switcher and a mode-aware legend
- Add a search card over the map that finds a site by name, address or operator and flies to it, plus the locate-me control
- Make rows in the price and utilisation lists clickable so they scroll to the map and open that site's popup, via a shared `site` search param
- Attach weekly utilisation to each map site by joining the existing location utilisation query

Coverage Zones is deferred to #991.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791122727&installation_model_id=21947&pr_number=992&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F992&signature=3100ba113d75b3b85553873d2838bb2c211e135817b55169f15544d13aff1af0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->