### PR TITLE
Keep a logo manifest in Blob and read it under use cache

### DIFF
--- a/apps/web/src/lib/cache-tags/index.ts
+++ b/apps/web/src/lib/cache-tags/index.ts
@@ -2,4 +2,5 @@ export * from "./cars";
 export * from "./coe";
 export * from "./deregistrations";
 export * from "./ev-charging";
+export * from "./logos";
 export * from "./posts";

--- a/apps/web/src/lib/cache-tags/logos.ts
+++ b/apps/web/src/lib/cache-tags/logos.ts
@@ -1,0 +1,1 @@
+export const LOGOS_CACHE_TAG = "logos";

--- a/apps/web/src/queries/logos.test.ts
+++ b/apps/web/src/queries/logos.test.ts
@@ -1,173 +1,84 @@
 import { describe, expect, it, vi } from "vitest";
 
-const {
-  redisGet,
-  redisSet,
-  getLogoMock,
-  listLogosMock,
-  downloadLogoMock,
-  normaliseMakeMock,
-} = vi.hoisted(() => ({
-  redisGet: vi.fn(),
-  redisSet: vi.fn(),
-  getLogoMock: vi.fn(),
-  listLogosMock: vi.fn(),
-  downloadLogoMock: vi.fn(),
-  normaliseMakeMock: vi.fn((value: string) => value.toLowerCase()),
+const { readManifestMock, cacheLifeMock, cacheTagMock } = vi.hoisted(() => ({
+  readManifestMock: vi.fn(),
+  cacheLifeMock: vi.fn(),
+  cacheTagMock: vi.fn(),
 }));
 
-vi.mock("@motormetrics/utils", () => ({
-  redis: {
-    get: redisGet,
-    set: redisSet,
-  },
+vi.mock("@motormetrics/logos", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@motormetrics/logos")>()),
+  readManifest: readManifestMock,
 }));
 
-vi.mock("@motormetrics/logos", () => ({
-  getLogo: getLogoMock,
-  listLogos: listLogosMock,
-  downloadLogo: downloadLogoMock,
-  normaliseMake: normaliseMakeMock,
+vi.mock("next/cache", () => ({
+  cacheLife: cacheLifeMock,
+  cacheTag: cacheTagMock,
 }));
 
-import { getAllCarLogos, getCarLogo } from "./logos";
+import { getAllCarLogos } from "./logos";
 
-describe("car logo queries", () => {
+const entry = (make: string, status: "found" | "missing") => ({
+  make,
+  status,
+  url: status === "found" ? `https://blob/logos/${make}.png` : null,
+  pathname: status === "found" ? `logos/${make}.png` : null,
+  sourceUrl: null,
+  checkedAt: "2026-09-05T00:00:00.000Z",
+  lastError: null,
+});
+
+describe("getAllCarLogos", () => {
   beforeEach(() => {
-    redisGet.mockReset();
-    redisSet.mockReset();
-    getLogoMock.mockReset();
-    listLogosMock.mockReset();
-    downloadLogoMock.mockReset();
-    normaliseMakeMock.mockClear();
+    readManifestMock.mockReset();
+    cacheLifeMock.mockClear();
+    cacheTagMock.mockClear();
   });
 
-  it("returns cached logos immediately", async () => {
-    const cachedLogo = { make: "tesla", filename: "logo.svg", url: "/logo" };
-    redisGet.mockResolvedValueOnce(cachedLogo);
-
-    const logo = await getCarLogo("Tesla");
-
-    expect(logo).toEqual(cachedLogo);
-    expect(getLogoMock).not.toHaveBeenCalled();
-    expect(normaliseMakeMock).toHaveBeenCalledWith("Tesla");
-  });
-
-  it("downloads and caches a logo when cache/blob miss", async () => {
-    redisGet.mockResolvedValueOnce(undefined);
-    getLogoMock.mockResolvedValueOnce(undefined);
-    downloadLogoMock.mockResolvedValueOnce({
-      success: true,
-      logo: { make: "tesla", filename: "tesla.svg", url: "/blob/tesla.svg" },
+  it("maps the manifest to logos and tags the cache", async () => {
+    readManifestMock.mockResolvedValueOnce({
+      version: 1,
+      updatedAt: "",
+      logos: {
+        toyota: entry("toyota", "found"),
+        zeekr: entry("zeekr", "missing"),
+      },
     });
-    redisSet.mockResolvedValue(undefined);
-
-    const logo = await getCarLogo("Tesla");
-
-    expect(logo).toEqual({
-      make: "tesla",
-      filename: "tesla.svg",
-      url: "/blob/tesla.svg",
-    });
-    expect(redisSet).toHaveBeenCalledWith("logo:tesla", JSON.stringify(logo));
-  });
-
-  it("caches negative results when a download fails", async () => {
-    redisGet.mockResolvedValueOnce(undefined);
-    getLogoMock.mockResolvedValueOnce(undefined);
-    downloadLogoMock.mockResolvedValueOnce({ success: false });
-
-    const logo = await getCarLogo("Unknown");
-
-    expect(logo).toEqual({
-      make: "unknown",
-      filename: "",
-      url: "",
-    });
-    expect(redisSet).toHaveBeenLastCalledWith(
-      "logo:unknown",
-      JSON.stringify(logo),
-    );
-  });
-
-  it("returns cached logo lists when available", async () => {
-    const cached = [{ make: "tesla", filename: "logo.svg", url: "/logo" }];
-    redisGet.mockResolvedValueOnce(cached);
 
     const result = await getAllCarLogos();
 
-    expect(result).toEqual({ logos: cached });
-    expect(listLogosMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      logos: [
+        {
+          make: "toyota",
+          url: "https://blob/logos/toyota.png",
+          filename: "toyota.png",
+        },
+      ],
+    });
+    expect(cacheLifeMock).toHaveBeenCalledWith("max");
+    expect(cacheTagMock).toHaveBeenCalledWith("logos");
+  });
+
+  it("returns an empty list when no manifest exists yet", async () => {
+    readManifestMock.mockResolvedValueOnce(null);
+
+    expect(await getAllCarLogos()).toEqual({ logos: [] });
   });
 
   it("returns an error when blob access fails", async () => {
-    redisGet.mockResolvedValueOnce(undefined);
-    listLogosMock.mockRejectedValueOnce(new Error("blob error"));
-
-    const result = await getAllCarLogos();
-
-    expect(result).toEqual({ error: "blob error" });
-  });
-
-  it("should return undefined when getCarLogo throws an error", async () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    redisGet.mockRejectedValueOnce(new Error("Redis connection failed"));
+    readManifestMock.mockRejectedValueOnce(new Error("blob error"));
 
-    const logo = await getCarLogo("Tesla");
-
-    expect(logo).toBeUndefined();
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "Error fetching logo:",
-      expect.any(Error),
-    );
+    expect(await getAllCarLogos()).toEqual({ error: "blob error" });
     consoleSpy.mockRestore();
   });
 
-  it("should fetch from blob storage and cache when cache misses for getAllCarLogos", async () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const logos = [
-      { make: "toyota", filename: "toyota.svg", url: "/blob/toyota.svg" },
-      { make: "honda", filename: "honda.svg", url: "/blob/honda.svg" },
-    ];
-    redisGet.mockResolvedValueOnce(undefined);
-    listLogosMock.mockResolvedValueOnce(logos);
-    redisSet.mockResolvedValueOnce(undefined);
-
-    const result = await getAllCarLogos();
-
-    expect(result).toEqual({ logos });
-    expect(listLogosMock).toHaveBeenCalled();
-    expect(redisSet).toHaveBeenCalledWith("logos:all", JSON.stringify(logos));
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "Cache miss, fetching from blob storage",
-    );
-    expect(consoleSpy).toHaveBeenCalledWith("Cached logos list");
-    consoleSpy.mockRestore();
-  });
-
-  it("should return logo from blob storage without downloading when found", async () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const blobLogo = { make: "bmw", filename: "bmw.svg", url: "/blob/bmw.svg" };
-    redisGet.mockResolvedValueOnce(undefined);
-    getLogoMock.mockResolvedValueOnce(blobLogo);
-    redisSet.mockResolvedValueOnce(undefined);
-
-    const logo = await getCarLogo("BMW");
-
-    expect(logo).toEqual(blobLogo);
-    expect(downloadLogoMock).not.toHaveBeenCalled();
-    expect(redisSet).toHaveBeenCalledWith("logo:bmw", JSON.stringify(blobLogo));
-    consoleSpy.mockRestore();
-  });
-
-  it("should handle non-Error objects in getAllCarLogos catch block", async () => {
+  it("handles non-Error rejections", async () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    redisGet.mockResolvedValueOnce(undefined);
-    listLogosMock.mockRejectedValueOnce("string error");
+    readManifestMock.mockRejectedValueOnce("string error");
 
-    const result = await getAllCarLogos();
-
-    expect(result).toEqual({ error: "Failed to fetch logos" });
+    expect(await getAllCarLogos()).toEqual({ error: "Failed to fetch logos" });
     consoleSpy.mockRestore();
   });
 });

--- a/apps/web/src/queries/logos/index.ts
+++ b/apps/web/src/queries/logos/index.ts
@@ -1,91 +1,27 @@
 import {
   type CarLogo,
-  downloadLogo,
-  getLogo,
-  listLogos,
-  normaliseMake,
+  manifestToLogos,
+  readManifest,
 } from "@motormetrics/logos";
-import { redis } from "@motormetrics/utils";
+import { LOGOS_CACHE_TAG } from "@web/lib/cache-tags";
 import { cacheLife, cacheTag } from "next/cache";
 
 /**
- * Get a single car logo by make
- * Implements cache-aside pattern with automatic download fallback
+ * Every logo with an image, read from the Blob manifest.
  *
- * @param make - The car make (will be normalized automatically)
- * @returns Logo object with actual values or empty strings if not found/download fails
- */
-export async function getCarLogo(make: string): Promise<CarLogo | undefined> {
-  "use cache";
-  cacheLife("max");
-  cacheTag(`logos:make:${make}`);
-
-  try {
-    const normalisedMake = normaliseMake(make);
-    const cacheKey = `logo:${normalisedMake}`;
-
-    // Check cache first
-    const cachedLogo = await redis.get<CarLogo>(cacheKey);
-    if (cachedLogo) {
-      console.log(`Cache hit for ${normalisedMake}`);
-      return cachedLogo;
-    }
-
-    // Cache miss - try to get from blob storage or download
-    console.log(`Cache miss for ${normalisedMake}`);
-    let logo = await getLogo(normalisedMake);
-
-    // Auto-download if not found in blob storage
-    if (!logo) {
-      const downloadResult = await downloadLogo(normalisedMake);
-
-      if (downloadResult.success && downloadResult.logo) {
-        logo = downloadResult.logo;
-      } else {
-        // Cache negative result to avoid repeated download attempts
-        logo = {
-          make: normalisedMake,
-          filename: "",
-          url: "",
-        };
-      }
-    }
-
-    // Cache the result (success or failure)
-    await redis.set(cacheKey, JSON.stringify(logo));
-
-    return logo;
-  } catch (error) {
-    console.error("Error fetching logo:", error);
-    return;
-  }
-}
-
-/**
- * Get all available car logos with caching
- *
- * @returns Array of all logos or error
+ * Cached until the logos workflow revalidates the tag, so Blob is touched
+ * once per manifest change rather than once per render.
  */
 export async function getAllCarLogos(): Promise<
   { logos: CarLogo[] } | { error: string }
 > {
+  "use cache";
+  cacheLife("max");
+  cacheTag(LOGOS_CACHE_TAG);
+
   try {
-    // Check cache first
-    const cachedLogos = await redis.get<CarLogo[]>("logos:all");
-    if (cachedLogos) {
-      console.log("Using cached logos list");
-      return { logos: cachedLogos };
-    }
-
-    // Cache miss - fetch from blob storage
-    console.log("Cache miss, fetching from blob storage");
-    const logos = await listLogos();
-
-    // Cache the result
-    await redis.set("logos:all", JSON.stringify(logos));
-    console.log("Cached logos list");
-
-    return { logos };
+    const manifest = await readManifest();
+    return { logos: manifest ? manifestToLogos(manifest) : [] };
   } catch (error) {
     console.error("Error fetching logos:", error);
 

--- a/packages/logos/CLAUDE.md
+++ b/packages/logos/CLAUDE.md
@@ -7,11 +7,15 @@ Guidance for Claude Code when working in `packages/logos`.
 Utility package for car make logos. It talks to Vercel Blob directly and has no routes,
 no caching, and no build step. Consumed from `src/index.ts` by `apps/web`.
 
+The goal is as few Blob operations as possible. `logos/manifest.json` is the source of
+truth for which logos exist; readers fetch it once and never call `list` or `head`.
+
 ## Layout
 
-- `src/services/blob.ts`: `uploadLogo`, `listLogos`, `getLogo`, `deleteLogo` over `@vercel/blob`
-- `src/services/scraper.ts`: `downloadLogo`, fetches `<BASE_URL>/<make>-logo.png` and uploads it
-- `src/utils/normalise-make.ts`: make name to kebab-case key, the only tested module
+- `src/services/manifest.ts`: `readManifest`, `writeManifest`, `bootstrapManifest`, `manifestToLogos`
+- `src/services/blob.ts`: `uploadLogo` with `allowOverwrite`
+- `src/services/scraper.ts`: `downloadLogo`, fetches `<BASE_URL>/<make>-logo.png` and uploads it; does not check for an existing image
+- `src/utils/normalise-make.ts`: make name to kebab-case key
 - `src/utils/file-utils.ts`: extension and MIME helpers
 - `src/config/index.ts`: `BASE_URL` for carlogos.org
 - `src/types/index.ts`: `CarLogo`
@@ -20,8 +24,9 @@ no caching, and no build step. Consumed from `src/index.ts` by `apps/web`.
 
 - Import by package name from other workspaces: `@motormetrics/logos`. Relative imports inside.
 - British English spelling (`normalise`, not `normalize`).
-- Caching belongs to the consumer. The web app's Redis layer lives in `apps/web/src/queries/logos`.
-- `getLogo` lists the whole prefix and scans for a match. Fine at current volume.
+- Caching belongs to the consumer. The web app reads the manifest under `"use cache"` with the `logos` tag.
+- The logos workflow in `apps/web` is the only writer of the manifest. Do not write it from elsewhere.
+- `bootstrapManifest` is the only caller of `list`. It runs once, when no manifest exists.
 
 ## Environment
 

--- a/packages/logos/README.md
+++ b/packages/logos/README.md
@@ -5,48 +5,64 @@ Car make logo storage and retrieval for the MotorMetrics monorepo.
 ## What it does
 
 - Stores logo images in Vercel Blob under the `logos/` prefix, public, with a 1-year cache header
-- Downloads a missing logo on demand from carlogos.org
+- Keeps a manifest at `logos/manifest.json` that is the source of truth for which logos exist
+- Downloads a logo from carlogos.org and stores it
 - Normalises make names into consistent kebab-case storage keys
 
-The web app wraps these functions with its own Redis cache in `apps/web/src/queries/logos`.
-Pages call that query directly; there is no HTTP API in front of this package.
+Readers never list Blob. They read the manifest, one operation, and the web app caches that
+under the `logos` tag in `apps/web/src/queries/logos`. The logos workflow is the only writer.
 
 ## Usage
 
 ```typescript
 import {
   type CarLogo,
-  deleteLogo,
+  type LogoManifest,
+  bootstrapManifest,
   downloadLogo,
-  getLogo,
-  listLogos,
+  manifestToLogos,
   normaliseMake,
+  readManifest,
+  writeManifest,
 } from "@motormetrics/logos";
 
-const logos = await listLogos();
-const logo = await getLogo("Mercedes-Benz");
+const manifest = (await readManifest()) ?? (await bootstrapManifest());
+const logos = manifestToLogos(manifest);
 const result = await downloadLogo("BYD");
 normaliseMake("Mercedes-Benz"); // "mercedes-benz"
 ```
 
 ## Exports
 
-| Function        | Purpose                                                               |
-| --------------- | --------------------------------------------------------------------- |
-| `listLogos`     | List every stored logo                                                |
-| `getLogo`       | Find one logo by make, or `null`                                      |
-| `uploadLogo`    | Store an image buffer for a make                                      |
-| `deleteLogo`    | Remove a make's logo                                                  |
-| `downloadLogo`  | Fetch from carlogos.org and store, returning `{ success, logo?, error? }` |
-| `normaliseMake` | Strip `logo` affixes and slugify                                      |
+| Function            | Blob ops | Purpose                                                        |
+| ------------------- | -------- | -------------------------------------------------------------- |
+| `readManifest`      | 1        | Fetch the manifest, or `null` if none has been written         |
+| `writeManifest`     | 1        | Overwrite the manifest                                         |
+| `bootstrapManifest` | 1 per 1000 blobs | Build a manifest from existing images, first run only  |
+| `manifestToLogos`   | 0        | Entries with an image, as `CarLogo[]`                          |
+| `downloadLogo`      | 1        | Fetch from carlogos.org and store, overwriting any existing    |
+| `uploadLogo`        | 1        | Store an image buffer for a make                               |
+| `normaliseMake`     | 0        | Strip `logo` affixes and slugify                               |
 
 ```typescript
-interface CarLogo {
+interface CarLogo { make: string; url: string; filename: string }
+
+type LogoStatus = "found" | "missing" | "manual";
+
+interface LogoEntry {
   make: string;
-  url: string;
-  filename: string;
+  status: LogoStatus;
+  url: string | null;
+  pathname: string | null;
+  sourceUrl: string | null;
+  checkedAt: string;
+  lastError: string | null;
 }
+
+interface LogoManifest { version: 1; updatedAt: string; logos: Record<string, LogoEntry> }
 ```
+
+`missing` entries are never retried by the workflow. `manual` entries are never overwritten.
 
 ## Environment
 

--- a/packages/logos/src/services/blob.ts
+++ b/packages/logos/src/services/blob.ts
@@ -1,102 +1,29 @@
-import { del, list, put } from "@vercel/blob";
-import type { CarLogo } from "../types";
+import { put } from "@vercel/blob";
 import { getFileExtension } from "../utils/file-utils";
 import { normaliseMake } from "../utils/normalise-make";
 
-const BLOB_PREFIX = "logos/";
+const LOGO_PREFIX = "logos/";
 
 /**
- * Upload a logo to Vercel Blob storage
+ * Upload a logo image. One operation. Overwrites any existing image for the
+ * make so a refresh does not need a delete first.
  */
 export const uploadLogo = async (
   make: string,
   buffer: ArrayBuffer,
   contentType: string,
-): Promise<{ url: string; filename: string } | null> => {
+): Promise<{ url: string; pathname: string; filename: string }> => {
   const normalisedMake = normaliseMake(make);
   const extension = getFileExtension(contentType);
   const filename = `${normalisedMake}.${extension}`;
-  const pathname = `${BLOB_PREFIX}${filename}`;
+  const pathname = `${LOGO_PREFIX}${filename}`;
 
-  try {
-    const blob = await put(pathname, buffer, {
-      access: "public",
-      contentType,
-      cacheControlMaxAge: 31536000, // 1 year
-    });
+  const blob = await put(pathname, buffer, {
+    access: "public",
+    contentType,
+    allowOverwrite: true,
+    cacheControlMaxAge: 31536000, // 1 year
+  });
 
-    return { url: blob.url, filename };
-  } catch (error) {
-    console.error("[uploadLogo] Error uploading to Vercel Blob:", error);
-    return null;
-  }
-};
-
-export const listLogos = async (): Promise<CarLogo[]> => {
-  try {
-    const { blobs } = await list({ prefix: BLOB_PREFIX });
-
-    return blobs.map((blob) => {
-      const filename = blob.pathname.replace(BLOB_PREFIX, "");
-      const make = filename.replace(/\.[^/.]+$/, "");
-
-      return {
-        make,
-        filename,
-        url: blob.url,
-      };
-    });
-  } catch (error) {
-    console.error("[listLogos] Error listing from Vercel Blob:", error);
-    return [];
-  }
-};
-
-export const getLogo = async (make: string): Promise<CarLogo | null> => {
-  const normalisedMake = normaliseMake(make);
-
-  try {
-    const { blobs } = await list({ prefix: BLOB_PREFIX });
-
-    const blob = blobs.find((b) => {
-      const filename = b.pathname.replace(BLOB_PREFIX, "");
-      const blobMake = filename.replace(/\.[^/.]+$/, "");
-      return blobMake === normalisedMake;
-    });
-
-    if (!blob) {
-      return null;
-    }
-
-    const filename = blob.pathname.replace(BLOB_PREFIX, "");
-    return {
-      make: normalisedMake,
-      filename,
-      url: blob.url,
-    };
-  } catch (error) {
-    console.error(
-      `[getLogo] Error fetching logo for ${normalisedMake}:`,
-      error,
-    );
-    return null;
-  }
-};
-
-export const deleteLogo = async (make: string): Promise<boolean> => {
-  const normalisedMake = normaliseMake(make);
-
-  try {
-    const logo = await getLogo(normalisedMake);
-    if (!logo) {
-      return true;
-    }
-
-    await del(logo.url);
-
-    return true;
-  } catch (error) {
-    console.error("[deleteLogo] Error deleting logo:", error);
-    return false;
-  }
+  return { url: blob.url, pathname: blob.pathname, filename };
 };

--- a/packages/logos/src/services/index.ts
+++ b/packages/logos/src/services/index.ts
@@ -1,2 +1,3 @@
 export * from "./blob";
+export * from "./manifest";
 export * from "./scraper";

--- a/packages/logos/src/services/manifest.test.ts
+++ b/packages/logos/src/services/manifest.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { LogoManifest } from "../types";
+import { manifestToLogos } from "./manifest";
+
+const manifest: LogoManifest = {
+  version: 1,
+  updatedAt: "2026-09-05T00:00:00.000Z",
+  logos: {
+    toyota: {
+      make: "toyota",
+      status: "found",
+      url: "https://blob/logos/toyota.png",
+      pathname: "logos/toyota.png",
+      sourceUrl: "https://source/toyota-logo.png",
+      checkedAt: "2026-09-05T00:00:00.000Z",
+      lastError: null,
+    },
+    byd: {
+      make: "byd",
+      status: "manual",
+      url: "https://blob/logos/byd.png",
+      pathname: "logos/byd.png",
+      sourceUrl: null,
+      checkedAt: "2026-09-05T00:00:00.000Z",
+      lastError: null,
+    },
+    zeekr: {
+      make: "zeekr",
+      status: "missing",
+      url: null,
+      pathname: null,
+      sourceUrl: "https://source/zeekr-logo.png",
+      checkedAt: "2026-09-05T00:00:00.000Z",
+      lastError: "Failed to fetch logo: 404",
+    },
+  },
+};
+
+describe("manifestToLogos", () => {
+  it("keeps found and manual entries, drops missing, sorts by make", () => {
+    expect(manifestToLogos(manifest)).toEqual([
+      { make: "byd", url: "https://blob/logos/byd.png", filename: "byd.png" },
+      {
+        make: "toyota",
+        url: "https://blob/logos/toyota.png",
+        filename: "toyota.png",
+      },
+    ]);
+  });
+
+  it("returns an empty list for an empty manifest", () => {
+    expect(manifestToLogos({ version: 1, updatedAt: "", logos: {} })).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/logos/src/services/manifest.ts
+++ b/packages/logos/src/services/manifest.ts
@@ -1,0 +1,103 @@
+import { get, list, put } from "@vercel/blob";
+import type { CarLogo, LogoEntry, LogoManifest } from "../types";
+
+export const MANIFEST_PATHNAME = "logos/manifest.json";
+const LOGO_PREFIX = "logos/";
+
+const createEmptyManifest = (): LogoManifest => ({
+  version: 1,
+  updatedAt: new Date().toISOString(),
+  logos: {},
+});
+
+/**
+ * Read the manifest from Blob. One operation. Returns null when no manifest
+ * has been written yet so the caller can bootstrap one.
+ */
+export const readManifest = async (): Promise<LogoManifest | null> => {
+  const result = await get(MANIFEST_PATHNAME, {
+    access: "public",
+    useCache: false,
+  });
+
+  if (!result || result.statusCode !== 200) {
+    return null;
+  }
+
+  const text = await new Response(result.stream).text();
+  return JSON.parse(text) as LogoManifest;
+};
+
+/**
+ * Overwrite the manifest. One operation. The workflow is the only writer.
+ */
+export const writeManifest = async (
+  manifest: LogoManifest,
+): Promise<LogoManifest> => {
+  const next: LogoManifest = {
+    ...manifest,
+    updatedAt: new Date().toISOString(),
+  };
+
+  await put(MANIFEST_PATHNAME, JSON.stringify(next, null, 2), {
+    access: "public",
+    contentType: "application/json",
+    allowOverwrite: true,
+    cacheControlMaxAge: 60,
+  });
+
+  return next;
+};
+
+/**
+ * Build a manifest from whatever images already exist under the prefix.
+ * Pages through `list`, so it costs one operation per 1000 blobs. Meant to
+ * run once, the first time no manifest is found.
+ */
+export const bootstrapManifest = async (): Promise<LogoManifest> => {
+  const manifest = createEmptyManifest();
+  let cursor: string | undefined;
+
+  do {
+    const page = await list({ prefix: LOGO_PREFIX, cursor, limit: 1000 });
+
+    for (const blob of page.blobs) {
+      if (blob.pathname === MANIFEST_PATHNAME) continue;
+
+      const filename = blob.pathname.replace(LOGO_PREFIX, "");
+      const make = filename.replace(/\.[^/.]+$/, "");
+
+      manifest.logos[make] = {
+        make,
+        status: "found",
+        url: blob.url,
+        pathname: blob.pathname,
+        sourceUrl: null,
+        checkedAt: manifest.updatedAt,
+        lastError: null,
+      };
+    }
+
+    cursor = page.hasMore ? page.cursor : undefined;
+  } while (cursor);
+
+  return manifest;
+};
+
+/**
+ * The entries that have an image, in the shape pages consume.
+ */
+export const manifestToLogos = (manifest: LogoManifest): CarLogo[] =>
+  Object.values(manifest.logos)
+    .filter(
+      (entry): entry is LogoEntry & { url: string; pathname: string } =>
+        entry.status !== "missing" &&
+        entry.url !== null &&
+        entry.pathname !== null,
+    )
+    .map((entry) => ({
+      make: entry.make,
+      url: entry.url,
+      filename: entry.pathname.replace(LOGO_PREFIX, ""),
+    }))
+    .sort((left, right) => left.make.localeCompare(right.make));

--- a/packages/logos/src/services/scraper.ts
+++ b/packages/logos/src/services/scraper.ts
@@ -1,40 +1,33 @@
 import { BASE_URL } from "../config";
-import type { CarLogo } from "../types";
 import { extractFileExtension, getContentType } from "../utils/file-utils";
 import { normaliseMake } from "../utils/normalise-make";
-import * as blobStorage from "./blob";
+import { uploadLogo } from "./blob";
 
-export interface ScrapeResult {
-  success: boolean;
-  logo?: CarLogo;
-  error?: string;
-}
+export type ScrapeResult =
+  | {
+      success: true;
+      make: string;
+      url: string;
+      pathname: string;
+      sourceUrl: string;
+    }
+  | { success: false; make: string; sourceUrl: string; error: string };
 
 /**
- * Download a logo from external source and store in Vercel Blob
- * Returns the existing logo if one is already stored
+ * Fetch a logo from the external source and store it. Does not check whether
+ * one already exists; the manifest is the source of truth for that.
  */
 export const downloadLogo = async (make: string): Promise<ScrapeResult> => {
+  const normalisedMake = normaliseMake(make);
+  const sourceUrl = `${BASE_URL}/${normalisedMake}-logo.png`;
+
   try {
-    const normalisedMake = normaliseMake(make);
-
-    // Check if already exists
-    const existing = await blobStorage.getLogo(make);
-
-    if (existing) {
-      return {
-        success: true,
-        logo: existing,
-      };
-    }
-
-    // Download logo using direct URL pattern
-    const logoUrl = `${BASE_URL}/${normalisedMake}-logo.png`;
-
-    const response = await fetch(logoUrl);
+    const response = await fetch(sourceUrl);
     if (!response.ok) {
       return {
         success: false,
+        make: normalisedMake,
+        sourceUrl,
         error: `Failed to fetch logo: ${response.status}`,
       };
     }
@@ -44,39 +37,29 @@ export const downloadLogo = async (make: string): Promise<ScrapeResult> => {
     if (arrayBuffer.byteLength < 100) {
       return {
         success: false,
+        make: normalisedMake,
+        sourceUrl,
         error: "Downloaded image is too small, likely corrupted",
       };
     }
 
-    // Determine content type
-    const extension = extractFileExtension(logoUrl);
+    const extension = extractFileExtension(sourceUrl);
     const contentType = getContentType(`${normalisedMake}.${extension}`);
-
-    // Upload to Vercel Blob
-    const result = await blobStorage.uploadLogo(make, arrayBuffer, contentType);
-
-    if (!result) {
-      return {
-        success: false,
-        error: "Failed to upload logo to storage",
-      };
-    }
+    const stored = await uploadLogo(normalisedMake, arrayBuffer, contentType);
 
     return {
       success: true,
-      logo: {
-        make: normalisedMake,
-        filename: result.filename,
-        url: result.url,
-      },
+      make: normalisedMake,
+      url: stored.url,
+      pathname: stored.pathname,
+      sourceUrl,
     };
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
-
     return {
       success: false,
-      error: errorMessage,
+      make: normalisedMake,
+      sourceUrl,
+      error: error instanceof Error ? error.message : "Unknown error",
     };
   }
 };

--- a/packages/logos/src/types/index.ts
+++ b/packages/logos/src/types/index.ts
@@ -3,3 +3,25 @@ export interface CarLogo {
   url: string;
   filename: string;
 }
+
+/**
+ * `found`: fetched and stored. `missing`: the source had nothing, do not retry.
+ * `manual`: uploaded by hand, never overwritten by the workflow.
+ */
+export type LogoStatus = "found" | "missing" | "manual";
+
+export interface LogoEntry {
+  make: string;
+  status: LogoStatus;
+  url: string | null;
+  pathname: string | null;
+  sourceUrl: string | null;
+  checkedAt: string;
+  lastError: string | null;
+}
+
+export interface LogoManifest {
+  version: 1;
+  updatedAt: string;
+  logos: Record<string, LogoEntry>;
+}


### PR DESCRIPTION
- Add `logos/manifest.json` as the source of truth for which logos exist, with `readManifest`, `writeManifest`, and a one-time `bootstrapManifest` that pages through the existing blobs
- Drop `getLogo`, `listLogos`, and `deleteLogo`; readers never call `list` or `head` again
- `uploadLogo` sets `allowOverwrite` so a refresh no longer fails with an unhelpful Blob error
- `downloadLogo` stops checking for an existing image and returns the pathname and source URL for the manifest
- `getAllCarLogos` reads the manifest under `"use cache"` with the `logos` tag; the Redis layer and the dead `getCarLogo` are gone
- A warm render costs zero Blob operations; a cold one costs a single `get`