### PR TITLE
Add a daily workflow that fills gaps in the logo manifest

### DIFF
--- a/apps/web/src/app/api/workflows/logos/route.ts
+++ b/apps/web/src/app/api/workflows/logos/route.ts
@@ -1,0 +1,17 @@
+import { WORKFLOW_REGION } from "@web/config/workflow";
+import { logosWorkflow } from "@web/workflows/logos";
+import { start } from "workflow/api";
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const run = await start(logosWorkflow, { region: WORKFLOW_REGION });
+
+  return Response.json(
+    { message: "Workflow started", runId: run.runId },
+    { headers: { "X-Run-Id": run.runId } },
+  );
+}

--- a/apps/web/src/workflows/logos/index.ts
+++ b/apps/web/src/workflows/logos/index.ts
@@ -10,7 +10,6 @@ import {
 import { LOGOS_CACHE_TAG } from "@web/lib/cache-tags";
 import { getDistinctMakes } from "@web/queries/cars/filter-options";
 import { revalidateTag } from "next/cache";
-import { fetch } from "workflow";
 
 interface LogosWorkflowResult {
   message: string;
@@ -30,8 +29,6 @@ interface LogosWorkflowResult {
  */
 export async function logosWorkflow(): Promise<LogosWorkflowResult> {
   "use workflow";
-
-  globalThis.fetch = fetch;
 
   const manifest = await loadManifest();
   const makes = await listMakes();

--- a/apps/web/src/workflows/logos/index.ts
+++ b/apps/web/src/workflows/logos/index.ts
@@ -1,0 +1,160 @@
+import {
+  bootstrapManifest,
+  downloadLogo,
+  type LogoEntry,
+  type LogoManifest,
+  normaliseMake,
+  readManifest,
+  writeManifest,
+} from "@motormetrics/logos";
+import { LOGOS_CACHE_TAG } from "@web/lib/cache-tags";
+import { getDistinctMakes } from "@web/queries/cars/filter-options";
+import { revalidateTag } from "next/cache";
+import { fetch } from "workflow";
+
+interface LogosWorkflowResult {
+  message: string;
+  fetched: number;
+  missing: number;
+  skipped: number;
+}
+
+/**
+ * Fill gaps in the logo manifest.
+ *
+ * Reads the manifest once, diffs it against the makes in the cars data, and
+ * fetches only the makes it has never seen. A make the source lacks is
+ * recorded as `missing` and never retried; any other failure is left out of
+ * the manifest so the next run tries again. Existing entries are never
+ * touched, so a run with nothing new costs a single Blob read.
+ */
+export async function logosWorkflow(): Promise<LogosWorkflowResult> {
+  "use workflow";
+
+  globalThis.fetch = fetch;
+
+  const manifest = await loadManifest();
+  const makes = await listMakes();
+  const pending = makes.filter((make) => !manifest.logos[make]);
+
+  if (pending.length === 0) {
+    return {
+      message: "[LOGOS] Manifest already covers every make",
+      fetched: 0,
+      missing: 0,
+      skipped: 0,
+    };
+  }
+
+  const entries: LogoEntry[] = [];
+  let skipped = 0;
+
+  // Sequential on purpose: one request at a time to the source.
+  for (const make of pending) {
+    const entry = await fetchLogo(make);
+    if (entry) {
+      entries.push(entry);
+    } else {
+      skipped += 1;
+    }
+  }
+
+  const fetched = entries.filter((entry) => entry.status === "found").length;
+  const missing = entries.length - fetched;
+
+  if (entries.length > 0) {
+    await saveManifest(manifest, entries);
+    await revalidateLogosCache();
+  }
+
+  return {
+    message: `[LOGOS] ${fetched} fetched, ${missing} missing, ${skipped} skipped`,
+    fetched,
+    missing,
+    skipped,
+  };
+}
+
+/**
+ * The manifest, or one built from the images already in Blob if none exists.
+ * Bootstrapping writes straight away so the list is never repeated.
+ */
+async function loadManifest(): Promise<LogoManifest> {
+  "use step";
+
+  const existing = await readManifest();
+  if (existing) {
+    return existing;
+  }
+
+  console.log("[LOGOS] No manifest found, bootstrapping from existing blobs");
+  return writeManifest(await bootstrapManifest());
+}
+
+async function listMakes(): Promise<string[]> {
+  "use step";
+
+  const rows = await getDistinctMakes();
+  return [...new Set(rows.map((row) => normaliseMake(row.make)))].sort();
+}
+
+/**
+ * One make, one step, so a retry re-fetches only this image. Returns null
+ * for a failure other than a 404 so the make is retried on the next run.
+ */
+async function fetchLogo(make: string): Promise<LogoEntry | null> {
+  "use step";
+
+  const result = await downloadLogo(make);
+  const checkedAt = new Date().toISOString();
+
+  if (result.success) {
+    console.log(`[LOGOS] Fetched ${make}`);
+    return {
+      make,
+      status: "found",
+      url: result.url,
+      pathname: result.pathname,
+      sourceUrl: result.sourceUrl,
+      checkedAt,
+      lastError: null,
+    };
+  }
+
+  if (result.error.endsWith(" 404")) {
+    console.log(`[LOGOS] No logo at source for ${make}`);
+    return {
+      make,
+      status: "missing",
+      url: null,
+      pathname: null,
+      sourceUrl: result.sourceUrl,
+      checkedAt,
+      lastError: result.error,
+    };
+  }
+
+  console.warn(`[LOGOS] Skipping ${make} this run: ${result.error}`);
+  return null;
+}
+
+async function saveManifest(
+  manifest: LogoManifest,
+  entries: LogoEntry[],
+): Promise<void> {
+  "use step";
+
+  const logos = { ...manifest.logos };
+  for (const entry of entries) {
+    logos[entry.make] = entry;
+  }
+
+  await writeManifest({ ...manifest, logos });
+}
+
+async function revalidateLogosCache(): Promise<void> {
+  "use step";
+
+  revalidateTag(LOGOS_CACHE_TAG, "max");
+  console.log("[LOGOS] Cache revalidated");
+}

--- a/apps/web/src/workflows/logos/logos.test.ts
+++ b/apps/web/src/workflows/logos/logos.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@motormetrics/logos", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@motormetrics/logos")>()),
+  bootstrapManifest: vi.fn(),
+  downloadLogo: vi.fn(),
+  readManifest: vi.fn(),
+  writeManifest: vi.fn(),
+}));
+
+vi.mock("@web/queries/cars/filter-options", () => ({
+  getDistinctMakes: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidateTag: vi.fn(),
+}));
+
+vi.mock("workflow", () => ({
+  fetch: vi.fn(),
+}));
+
+import {
+  bootstrapManifest,
+  downloadLogo,
+  type LogoManifest,
+  readManifest,
+  writeManifest,
+} from "@motormetrics/logos";
+import { getDistinctMakes } from "@web/queries/cars/filter-options";
+import { revalidateTag } from "next/cache";
+import { logosWorkflow } from "./index";
+
+const found = (make: string) => ({
+  make,
+  status: "found" as const,
+  url: `https://blob/logos/${make}.png`,
+  pathname: `logos/${make}.png`,
+  sourceUrl: null,
+  checkedAt: "2026-09-05T00:00:00.000Z",
+  lastError: null,
+});
+
+const manifestWith = (...makes: string[]): LogoManifest => ({
+  version: 1,
+  updatedAt: "2026-09-05T00:00:00.000Z",
+  logos: Object.fromEntries(makes.map((make) => [make, found(make)])),
+});
+
+describe("logosWorkflow", () => {
+  beforeEach(() => {
+    vi.mocked(readManifest).mockReset();
+    vi.mocked(bootstrapManifest).mockReset();
+    vi.mocked(downloadLogo).mockReset();
+    vi.mocked(writeManifest).mockReset();
+    vi.mocked(getDistinctMakes).mockReset();
+    vi.mocked(revalidateTag).mockReset();
+    vi.mocked(writeManifest).mockImplementation(async (manifest) => manifest);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("does nothing when the manifest already covers every make", async () => {
+    vi.mocked(readManifest).mockResolvedValue(manifestWith("toyota", "bmw"));
+    vi.mocked(getDistinctMakes).mockResolvedValue([
+      { make: "TOYOTA" },
+      { make: "BMW" },
+    ]);
+
+    const result = await logosWorkflow();
+
+    expect(result.fetched).toBe(0);
+    expect(downloadLogo).not.toHaveBeenCalled();
+    expect(writeManifest).not.toHaveBeenCalled();
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it("fetches only unseen makes, records misses, and revalidates", async () => {
+    vi.mocked(readManifest).mockResolvedValue(manifestWith("toyota"));
+    vi.mocked(getDistinctMakes).mockResolvedValue([
+      { make: "TOYOTA" },
+      { make: "BYD" },
+      { make: "ZEEKR" },
+    ]);
+    vi.mocked(downloadLogo).mockImplementation(async (make) =>
+      make === "byd"
+        ? {
+            success: true,
+            make,
+            url: "https://blob/logos/byd.png",
+            pathname: "logos/byd.png",
+            sourceUrl: "https://source/byd-logo.png",
+          }
+        : {
+            success: false,
+            make,
+            sourceUrl: "https://source/zeekr-logo.png",
+            error: "Failed to fetch logo: 404",
+          },
+    );
+
+    const result = await logosWorkflow();
+
+    expect(result).toMatchObject({ fetched: 1, missing: 1, skipped: 0 });
+    expect(downloadLogo).toHaveBeenCalledTimes(2);
+    const written = vi.mocked(writeManifest).mock.calls[0][0];
+    expect(Object.keys(written.logos).sort()).toEqual([
+      "byd",
+      "toyota",
+      "zeekr",
+    ]);
+    expect(written.logos.zeekr.status).toBe("missing");
+    expect(written.logos.byd.status).toBe("found");
+    expect(revalidateTag).toHaveBeenCalledWith("logos", "max");
+  });
+
+  it("leaves a make out of the manifest on a non-404 failure", async () => {
+    vi.mocked(readManifest).mockResolvedValue(manifestWith());
+    vi.mocked(getDistinctMakes).mockResolvedValue([{ make: "BYD" }]);
+    vi.mocked(downloadLogo).mockResolvedValue({
+      success: false,
+      make: "byd",
+      sourceUrl: "https://source/byd-logo.png",
+      error: "fetch failed",
+    });
+
+    const result = await logosWorkflow();
+
+    expect(result).toMatchObject({ fetched: 0, missing: 0, skipped: 1 });
+    expect(writeManifest).not.toHaveBeenCalled();
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it("bootstraps and writes a manifest when none exists", async () => {
+    vi.mocked(readManifest).mockResolvedValue(null);
+    vi.mocked(bootstrapManifest).mockResolvedValue(manifestWith("toyota"));
+    vi.mocked(getDistinctMakes).mockResolvedValue([{ make: "TOYOTA" }]);
+
+    await logosWorkflow();
+
+    expect(bootstrapManifest).toHaveBeenCalledTimes(1);
+    expect(writeManifest).toHaveBeenCalledTimes(1);
+    expect(downloadLogo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/workflows/logos/logos.test.ts
+++ b/apps/web/src/workflows/logos/logos.test.ts
@@ -16,10 +16,6 @@ vi.mock("next/cache", () => ({
   revalidateTag: vi.fn(),
 }));
 
-vi.mock("workflow", () => ({
-  fetch: vi.fn(),
-}));
-
 import {
   bootstrapManifest,
   downloadLogo,

--- a/apps/web/vercel.ts
+++ b/apps/web/vercel.ts
@@ -38,6 +38,11 @@ export const config: VercelConfig = {
       schedule: "0 10 * * *",
     },
     {
+      // After the cars run so newly registered makes are in the database.
+      path: "/api/workflows/logos",
+      schedule: "0 11 * * *",
+    },
+    {
       path: "/api/workflows/ev-charging-live",
       // TODO: The DataMall batch refreshes every 5 minutes, but Hobby caps
       // crons at once a day. Change to "*/5 * * * *" once the project is on


### PR DESCRIPTION
- New `logosWorkflow` reads the manifest once, diffs it against distinct makes in the cars data, and fetches only makes it has never seen
- One step per make, sequential, so a retry re-fetches a single image and the source sees one request at a time
- A 404 is recorded as `missing` and never retried; any other failure is left out so the next run tries again
- Writes the manifest and revalidates the `logos` tag only when something changed, so a quiet run is one Blob read
- Bootstraps the manifest from existing blobs on first run
- Cron-secret-guarded route at `/api/workflows/logos`, scheduled daily at 11:00 after the cars run