### PR TITLE
Simplify the updater and derive batch size from column count

### DIFF
--- a/apps/web/src/lib/updater/download-file.test.ts
+++ b/apps/web/src/lib/updater/download-file.test.ts
@@ -1,7 +1,4 @@
-import {
-  downloadFile,
-  fetchAndExtractZip,
-} from "@web/lib/updater/services/download-file";
+import { fetchAndExtractZip } from "@web/lib/updater/services/download-file";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@web/config/workflow", () => ({
@@ -39,108 +36,6 @@ vi.mock("adm-zip", () => {
       }
     },
   };
-});
-
-describe("downloadFile", () => {
-  const mockUrl = "https://example.com/test.zip";
-
-  beforeEach(() => {
-    vi.resetAllMocks();
-
-    // Mock successful fetch response
-    vi.mocked(global.fetch).mockResolvedValue({
-      ok: true,
-      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
-    } as unknown as Response);
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("should fetch and extract files from a zip", async () => {
-    const result = await downloadFile(mockUrl);
-
-    expect(global.fetch).toHaveBeenCalledWith(mockUrl);
-    expect(result).toBe("test.csv"); // Should return first file
-  });
-
-  it("should return the specific file when csvFile parameter is provided", async () => {
-    const result = await downloadFile(mockUrl, "data");
-
-    expect(global.fetch).toHaveBeenCalledWith(mockUrl);
-    expect(result).toBe("data.csv");
-  });
-
-  it("should handle HTTP errors and log detailed error information", async () => {
-    const mockErrorBody = "<html><body>Not Found</body></html>";
-    const consoleErrorSpy = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-
-    vi.mocked(global.fetch).mockResolvedValue({
-      ok: false,
-      status: 404,
-      statusText: "Not Found",
-      text: vi.fn().mockResolvedValue(mockErrorBody),
-    } as unknown as Response);
-
-    await expect(downloadFile(mockUrl)).rejects.toThrow(
-      "HTTP error! status: 404",
-    );
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Download failed:",
-      expect.objectContaining({
-        status: 404,
-        statusText: "Not Found",
-        url: mockUrl,
-        errorBody: mockErrorBody,
-        timestamp: expect.any(String),
-      }),
-    );
-
-    consoleErrorSpy.mockRestore();
-  });
-
-  it("should handle 403 forbidden errors with detailed logging", async () => {
-    const mockErrorBody =
-      "<html><body>403 Forbidden - Access Denied</body></html>";
-    const consoleErrorSpy = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-
-    vi.mocked(global.fetch).mockResolvedValue({
-      ok: false,
-      status: 403,
-      statusText: "Forbidden",
-      text: vi.fn().mockResolvedValue(mockErrorBody),
-    } as unknown as Response);
-
-    await expect(downloadFile(mockUrl)).rejects.toThrow(
-      "HTTP error! status: 403",
-    );
-
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Download failed:",
-      expect.objectContaining({
-        status: 403,
-        statusText: "Forbidden",
-        url: mockUrl,
-        errorBody: mockErrorBody,
-        timestamp: expect.any(String),
-      }),
-    );
-
-    consoleErrorSpy.mockRestore();
-  });
-
-  it("should handle fetch failures", async () => {
-    const mockError = new Error("Network error");
-    vi.mocked(global.fetch).mockRejectedValue(mockError);
-
-    await expect(downloadFile(mockUrl)).rejects.toThrow(mockError);
-  });
 });
 
 describe("fetchAndExtractZip", () => {

--- a/apps/web/src/lib/updater/index.ts
+++ b/apps/web/src/lib/updater/index.ts
@@ -1,4 +1,3 @@
-export * as Services from "./services";
 export type {
   UpdaterConfig,
   UpdaterOptions,

--- a/apps/web/src/lib/updater/process-csv.test.ts
+++ b/apps/web/src/lib/updater/process-csv.test.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs";
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { processCsv } from "@web/lib/updater/services/process-csv";
@@ -20,9 +20,9 @@ describe("processCSV", () => {
     vi.clearAllMocks();
 
     // Set up mock implementations for each test
-    const _readFileSyncMock = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue("mock csv content");
+    const _readFileMock = vi
+      .spyOn(fs, "readFile")
+      .mockResolvedValue("mock csv content");
 
     const _parseMock = vi.spyOn(Papa, "parse").mockReturnValue({
       data: [
@@ -39,9 +39,9 @@ describe("processCSV", () => {
   });
 
   it("should read a CSV file and parse it", async () => {
-    const readFileSyncMock = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue("mock csv content");
+    const readFileMock = vi
+      .spyOn(fs, "readFile")
+      .mockResolvedValue("mock csv content");
     const parseMock = vi.spyOn(Papa, "parse").mockReturnValue({
       data: [
         { name: " John Doe ", age: "25", active: "true" },
@@ -53,15 +53,15 @@ describe("processCSV", () => {
 
     const result = await processCsv<TestRecord>(filePath);
 
-    expect(readFileSyncMock).toHaveBeenCalledWith(filePath, "utf-8");
+    expect(readFileMock).toHaveBeenCalledWith(filePath, "utf-8");
     expect(parseMock).toHaveBeenCalled();
     expect(result).toHaveLength(2);
   });
 
   it("should use Papa.parse with correct options", async () => {
-    const _readFileSyncMock = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue("mock csv content");
+    const _readFileMock = vi
+      .spyOn(fs, "readFile")
+      .mockResolvedValue("mock csv content");
     const parseMock = vi.spyOn(Papa, "parse").mockReturnValue({
       data: [],
       errors: [],
@@ -83,9 +83,9 @@ describe("processCSV", () => {
   });
 
   it("should apply custom field transformations when provided", async () => {
-    const _readFileSyncMock = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue("mock csv content");
+    const _readFileMock = vi
+      .spyOn(fs, "readFile")
+      .mockResolvedValue("mock csv content");
     const parseMock = vi.spyOn(Papa, "parse").mockReturnValue({
       data: [{ name: " JOHN DOE ", age: 30 }],
       errors: [],
@@ -112,8 +112,8 @@ describe("processCSV", () => {
 
   it("should handle file read errors", async () => {
     const errorMsg = "File not found";
-    const _readFileSyncMock = vi
-      .spyOn(fs, "readFileSync")
+    const _readFileMock = vi
+      .spyOn(fs, "readFile")
       .mockImplementationOnce(() => {
         throw new Error(errorMsg);
       });
@@ -122,9 +122,9 @@ describe("processCSV", () => {
   });
 
   it("should handle parsing errors", async () => {
-    const _readFileSyncMock = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue("mock csv content");
+    const _readFileMock = vi
+      .spyOn(fs, "readFile")
+      .mockResolvedValue("mock csv content");
     const _parseMock = vi.spyOn(Papa, "parse").mockImplementationOnce(() => {
       throw new Error("Parse error");
     });
@@ -133,7 +133,7 @@ describe("processCSV", () => {
   });
 
   it("should apply transformHeader to rename columns via columnMapping", async () => {
-    vi.spyOn(fs, "readFileSync").mockReturnValue("mock csv content");
+    vi.spyOn(fs, "readFile").mockResolvedValue("mock csv content");
     const parseMock = vi.spyOn(Papa, "parse").mockReturnValue({
       data: [],
       errors: [],
@@ -152,7 +152,7 @@ describe("processCSV", () => {
   });
 
   it("should apply transform with field handler when provided", async () => {
-    vi.spyOn(fs, "readFileSync").mockReturnValue("mock csv content");
+    vi.spyOn(fs, "readFile").mockResolvedValue("mock csv content");
     const parseMock = vi.spyOn(Papa, "parse").mockReturnValue({
       data: [],
       errors: [],
@@ -169,7 +169,7 @@ describe("processCSV", () => {
   });
 
   it("should trim string values without a field handler", async () => {
-    vi.spyOn(fs, "readFileSync").mockReturnValue("mock csv content");
+    vi.spyOn(fs, "readFile").mockResolvedValue("mock csv content");
     const parseMock = vi.spyOn(Papa, "parse").mockReturnValue({
       data: [],
       errors: [],
@@ -185,7 +185,7 @@ describe("processCSV", () => {
   });
 
   it("should pass dynamicTyping through when disabled", async () => {
-    vi.spyOn(fs, "readFileSync").mockReturnValue("mock csv content");
+    vi.spyOn(fs, "readFile").mockResolvedValue("mock csv content");
     const parseMock = vi.spyOn(Papa, "parse").mockReturnValue({
       data: [],
       errors: [],
@@ -201,7 +201,7 @@ describe("processCSV", () => {
   });
 
   it("should pass non-string values through transform untouched", async () => {
-    vi.spyOn(fs, "readFileSync").mockReturnValue("mock csv content");
+    vi.spyOn(fs, "readFile").mockResolvedValue("mock csv content");
     const parseMock = vi.spyOn(Papa, "parse").mockReturnValue({
       data: [],
       errors: [],
@@ -217,9 +217,9 @@ describe("processCSV", () => {
   });
 
   it("should return an empty array if no records are found", async () => {
-    const _readFileSyncMock = vi
-      .spyOn(fs, "readFileSync")
-      .mockReturnValue("mock csv content");
+    const _readFileMock = vi
+      .spyOn(fs, "readFile")
+      .mockResolvedValue("mock csv content");
     const _parseMock = vi.spyOn(Papa, "parse").mockReturnValueOnce({
       data: [],
       errors: [],

--- a/apps/web/src/lib/updater/services/download-file.ts
+++ b/apps/web/src/lib/updater/services/download-file.ts
@@ -2,46 +2,12 @@ import path from "node:path";
 import { WORKFLOW_TEMP_DIR } from "@web/config/workflow";
 import AdmZip from "adm-zip";
 
-export const downloadFile = async (url: string, csvFile?: string) => {
-  try {
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      const errorBody = await response.text();
-      console.error("Download failed:", {
-        status: response.status,
-        statusText: response.statusText,
-        url,
-        errorBody: errorBody.substring(0, 500),
-        timestamp: new Date().toISOString(),
-      });
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const arrayBuffer = await response.arrayBuffer();
-    const zip = new AdmZip(Buffer.from(arrayBuffer));
-    const fileNames: string[] = [];
-
-    for (const entry of zip.getEntries()) {
-      if (!entry.isDirectory) {
-        console.log("Found file in ZIP:", entry.entryName);
-        fileNames.push(entry.entryName);
-
-        // Extract to file system with full path
-        zip.extractEntryTo(entry, WORKFLOW_TEMP_DIR, true, true);
-      }
-    }
-
-    return (
-      (csvFile && fileNames.find((fileName) => fileName.includes(csvFile))) ||
-      fileNames[0]
-    );
-  } catch (error) {
-    console.error("Error downloading or extracting file:", error);
-    throw error;
-  }
-};
-
+/**
+ * Downloads a ZIP archive and extracts every file into the workflow temp
+ * directory.
+ *
+ * @returns Map of file basename to its extracted absolute path
+ */
 export async function fetchAndExtractZip(
   url: string,
 ): Promise<Map<string, string>> {
@@ -59,6 +25,8 @@ export async function fetchAndExtractZip(
     throw new Error(`HTTP error! status: ${response.status}`);
   }
 
+  // The whole archive is buffered in memory. LTA DataMall archives are a few
+  // megabytes at most, so streaming extraction is not worth the complexity.
   const arrayBuffer = await response.arrayBuffer();
   const zip = new AdmZip(Buffer.from(arrayBuffer));
   const extracted = new Map<string, string>();

--- a/apps/web/src/lib/updater/services/download-file.ts
+++ b/apps/web/src/lib/updater/services/download-file.ts
@@ -25,8 +25,6 @@ export async function fetchAndExtractZip(
     throw new Error(`HTTP error! status: ${response.status}`);
   }
 
-  // The whole archive is buffered in memory. LTA DataMall archives are a few
-  // megabytes at most, so streaming extraction is not worth the complexity.
   const arrayBuffer = await response.arrayBuffer();
   const zip = new AdmZip(Buffer.from(arrayBuffer));
   const extracted = new Map<string, string>();

--- a/apps/web/src/lib/updater/services/index.ts
+++ b/apps/web/src/lib/updater/services/index.ts
@@ -1,5 +1,0 @@
-export { Checksum } from "@web/utils/checksum";
-export { calculateChecksum } from "./calculate-checksum";
-export { downloadFile, fetchAndExtractZip } from "./download-file";
-export type { CSVTransformOptions } from "./process-csv";
-export { processCsv } from "./process-csv";

--- a/apps/web/src/lib/updater/services/process-csv.ts
+++ b/apps/web/src/lib/updater/services/process-csv.ts
@@ -1,9 +1,14 @@
-import fs from "node:fs";
+import fs from "node:fs/promises";
 import Papa, { type ParseConfig } from "papaparse";
 
-export interface CSVTransformOptions<_T> {
-  fields?: Record<string, (value: string) => unknown>;
-  columnMapping?: Record<string, string>;
+export interface CSVTransformOptions<T> {
+  /**
+   * Per-column parsers keyed by the mapped (camelCase) column name. PapaParse
+   * runs these before dynamic typing, so the raw value is always a string.
+   */
+  fields?: { [K in keyof T]?: (value: string) => T[K] };
+  /** Maps CSV header names to row property names. */
+  columnMapping?: Record<string, keyof T & string>;
   /**
    * PapaParse dynamic typing. Defaults to true. Disable for files where
    * numeric-looking strings must survive intact, such as postal codes with
@@ -16,9 +21,13 @@ export async function processCsv<T>(
   filePath: string,
   options: CSVTransformOptions<T> = {},
 ) {
-  const fileContent = fs.readFileSync(filePath, "utf-8");
+  const fileContent = await fs.readFile(filePath, "utf-8");
 
-  const { fields = {}, columnMapping = {}, dynamicTyping = true } = options;
+  const {
+    fields = {} as NonNullable<CSVTransformOptions<T>["fields"]>,
+    columnMapping = {},
+    dynamicTyping = true,
+  } = options;
 
   const parseConfig: ParseConfig<T> = {
     header: true,
@@ -26,10 +35,10 @@ export async function processCsv<T>(
     skipEmptyLines: true,
     transformHeader: (header) => columnMapping[header] || header,
     transform: (value, field) => {
-      const fieldKey = String(field);
+      const parser = fields[field as keyof T];
 
-      if (fields[fieldKey]) {
-        return fields[fieldKey](value);
+      if (parser) {
+        return parser(value);
       }
 
       return typeof value === "string" ? value.trim() : value;

--- a/apps/web/src/lib/updater/services/process-csv.ts
+++ b/apps/web/src/lib/updater/services/process-csv.ts
@@ -21,6 +21,12 @@ export async function processCsv<T>(
   filePath: string,
   options: CSVTransformOptions<T> = {},
 ) {
+  // The whole file is read and parsed into an array of row objects. The
+  // parsed rows dominate memory, not the download: the largest DataMall CSV
+  // (cars by make, ~3.5 MB, ~61k rows) parses to ~13 MB of objects on a
+  // ~250 KB archive. Well within function memory, and several workflow crons
+  // share an instance at 10:00 under Fluid Compute. Switch to a streaming
+  // parse before buffering here if a source grows by an order of magnitude.
   const fileContent = await fs.readFile(filePath, "utf-8");
 
   const {

--- a/apps/web/src/lib/updater/updater.test.ts
+++ b/apps/web/src/lib/updater/updater.test.ts
@@ -1,13 +1,11 @@
-import path from "node:path";
 import { db, type PgTable } from "@motormetrics/database";
-import { WORKFLOW_TEMP_DIR } from "@web/config/workflow";
 import {
   type UpdaterConfig,
   type UpdaterOptions,
   update,
 } from "@web/lib/updater";
 import { calculateChecksum } from "@web/lib/updater/services/calculate-checksum";
-import { downloadFile } from "@web/lib/updater/services/download-file";
+import { fetchAndExtractZip } from "@web/lib/updater/services/download-file";
 import { processCsv } from "@web/lib/updater/services/process-csv";
 import type { Checksum } from "@web/utils/checksum";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -26,6 +24,7 @@ vi.mock("@motormetrics/database", async (importOriginal) => {
   return {
     ...actual,
     getTableName: vi.fn(() => "test_table"),
+    getTableColumns: vi.fn(() => ({ month: {}, make: {}, fuel_type: {} })),
     db: {
       insert: vi.fn(),
       $cache: {
@@ -48,10 +47,9 @@ type TestRecord = {
   fuel_type: string;
 };
 
-const createInsertMock = (returnedRows: unknown[] = [{}, {}]) => ({
+const createInsertMock = (rowCount = 2) => ({
   values: vi.fn().mockReturnThis(),
-  onConflictDoNothing: vi.fn().mockReturnThis(),
-  returning: vi.fn().mockResolvedValue(returnedRows),
+  onConflictDoNothing: vi.fn().mockResolvedValue({ rowCount }),
 });
 
 type InsertMock = ReturnType<typeof createInsertMock>;
@@ -88,7 +86,9 @@ describe("update", () => {
     };
 
     // Default mock implementations
-    vi.mocked(downloadFile).mockResolvedValue("test-file.csv");
+    vi.mocked(fetchAndExtractZip).mockResolvedValue(
+      new Map([["test-file.csv", "/tmp/test-file.csv"]]),
+    );
     vi.mocked(calculateChecksum).mockResolvedValue("abc123");
     vi.mocked(processCsv).mockResolvedValue(mockData);
 
@@ -116,13 +116,10 @@ describe("update", () => {
       timestamp: expect.any(String),
     });
 
-    expect(downloadFile).toHaveBeenCalledWith(
+    expect(fetchAndExtractZip).toHaveBeenCalledWith(
       "https://example.com/data.zip",
-      undefined,
     );
-    expect(calculateChecksum).toHaveBeenCalledWith(
-      path.join(WORKFLOW_TEMP_DIR, "test-file.csv"),
-    );
+    expect(calculateChecksum).toHaveBeenCalledWith("/tmp/test-file.csv");
     expect(mockChecksum.cacheChecksum).toHaveBeenCalledWith(
       "test-file.csv",
       "abc123",
@@ -153,13 +150,12 @@ describe("update", () => {
     const insertMock = vi.mocked(db.insert).mock.results[0].value as InsertMock;
     expect(insertMock.values).toHaveBeenCalled();
     expect(insertMock.onConflictDoNothing).toHaveBeenCalled();
-    expect(insertMock.returning).toHaveBeenCalled();
   });
 
   it("should return 0 when all records conflict", async () => {
     vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue("different123");
 
-    const mockInsert = createInsertMock([]);
+    const mockInsert = createInsertMock(0);
     vi.mocked(db.insert).mockReturnValue(mockInsert as never);
 
     const result = await update(updaterConfig, updaterOptions);
@@ -176,7 +172,7 @@ describe("update", () => {
   it("should still cache the checksum when all records conflict", async () => {
     vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue("different123");
 
-    const mockInsert = createInsertMock([]);
+    const mockInsert = createInsertMock(0);
     vi.mocked(db.insert).mockReturnValue(mockInsert as never);
 
     await update(updaterConfig, updaterOptions);
@@ -191,7 +187,7 @@ describe("update", () => {
     vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue("different123");
 
     const mockInsert = createInsertMock();
-    mockInsert.returning.mockRejectedValue(
+    mockInsert.onConflictDoNothing.mockRejectedValue(
       new Error("Database request failed"),
     );
     vi.mocked(db.insert).mockReturnValue(mockInsert as never);
@@ -228,10 +224,10 @@ describe("update", () => {
     vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue(null);
 
     const mockInsert = createInsertMock();
-    mockInsert.returning
-      .mockResolvedValueOnce([{}, {}])
-      .mockResolvedValueOnce([{}, {}])
-      .mockResolvedValueOnce([{}]);
+    mockInsert.onConflictDoNothing
+      .mockResolvedValueOnce({ rowCount: 2 })
+      .mockResolvedValueOnce({ rowCount: 2 })
+      .mockResolvedValueOnce({ rowCount: 1 });
     vi.mocked(db.insert).mockReturnValue(mockInsert as never);
 
     const result = await update(updaterConfig, updaterOptions);
@@ -240,41 +236,54 @@ describe("update", () => {
     expect(db.insert).toHaveBeenCalledTimes(3);
   });
 
+  it("should derive the batch size from the column count when not given", async () => {
+    const largeDataSet = Array(20_001)
+      .fill(null)
+      .map((_, index) => ({
+        month: "2024-01",
+        make: `MAKE_${index}`,
+        fuel_type: "Petrol",
+      }));
+
+    vi.mocked(processCsv).mockResolvedValue(largeDataSet);
+    vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue(null);
+
+    // 3 mocked columns -> floor(30,000 / 3) = 10,000 rows per batch
+    await update(updaterConfig, { checksum: mockChecksum });
+
+    expect(db.insert).toHaveBeenCalledTimes(3);
+  });
+
+  it("should throw when the ZIP contains no files", async () => {
+    vi.mocked(fetchAndExtractZip).mockResolvedValue(new Map());
+
+    await expect(update(updaterConfig, updaterOptions)).rejects.toThrow(
+      "No files found in ZIP",
+    );
+  });
+
   it("should propagate errors from download", async () => {
-    vi.mocked(downloadFile).mockRejectedValue(new Error("Download failed"));
+    vi.mocked(fetchAndExtractZip).mockRejectedValue(
+      new Error("Download failed"),
+    );
 
     await expect(update(updaterConfig, updaterOptions)).rejects.toThrow(
       "Download failed",
     );
   });
 
-  it("should use csvFile parameter when provided", async () => {
-    vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue(null);
-
-    const configWithCsvFile = {
-      ...updaterConfig,
-      csvFile: "specific-file.csv",
-    };
-
-    await update(configWithCsvFile, updaterOptions);
-
-    expect(downloadFile).toHaveBeenCalledWith(
-      "https://example.com/data.zip",
-      "specific-file.csv",
-    );
-  });
-
   it("should skip download when filePath is provided", async () => {
     vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue(null);
 
-    const configWithFilePath = {
-      ...updaterConfig,
+    const configWithFilePath: UpdaterConfig<TestRecord> = {
+      table: mockTable,
       filePath: "/tmp/pre-extracted.csv",
+      csvTransformOptions: {},
     };
 
     await update(configWithFilePath, updaterOptions);
 
-    expect(downloadFile).not.toHaveBeenCalled();
+    expect(fetchAndExtractZip).not.toHaveBeenCalled();
     expect(calculateChecksum).toHaveBeenCalledWith("/tmp/pre-extracted.csv");
     expect(mockChecksum.cacheChecksum).toHaveBeenCalledWith(
       "pre-extracted.csv",

--- a/apps/web/src/lib/updater/updater.ts
+++ b/apps/web/src/lib/updater/updater.ts
@@ -1,21 +1,26 @@
 import path from "node:path";
-import { db, getTableName, type PgTable } from "@motormetrics/database";
-import { WORKFLOW_TEMP_DIR } from "@web/config/workflow";
+import {
+  db,
+  getTableColumns,
+  getTableName,
+  type PgTable,
+} from "@motormetrics/database";
 import { calculateChecksum } from "@web/lib/updater/services/calculate-checksum";
-import { downloadFile } from "@web/lib/updater/services/download-file";
+import { fetchAndExtractZip } from "@web/lib/updater/services/download-file";
 import {
   type CSVTransformOptions,
   processCsv,
 } from "@web/lib/updater/services/process-csv";
 import { Checksum } from "@web/utils/checksum";
 
-export interface UpdaterConfig<T> {
+type UpdaterSource =
+  | { url: string; filePath?: never }
+  | { filePath: string; url?: never };
+
+export type UpdaterConfig<T> = UpdaterSource & {
   table: PgTable;
-  url: string;
-  csvFile?: string;
-  filePath?: string;
   csvTransformOptions?: CSVTransformOptions<T>;
-}
+};
 
 export interface UpdaterResult {
   table: string;
@@ -26,29 +31,37 @@ export interface UpdaterResult {
 }
 
 export interface UpdaterOptions {
+  /** Rows per INSERT. Defaults to the largest batch that fits Neon's limit. */
   batchSize?: number;
   checksum?: Checksum;
 }
 
-const DEFAULT_BATCH_SIZE = 5000;
+// Neon's HTTP endpoint rejects statements with more than 32,767 bound
+// parameters (a signed 16-bit count). Leave headroom below that.
+const MAX_BOUND_PARAMETERS = 30_000;
 
 export async function update<T>(
   config: UpdaterConfig<T>,
   options: UpdaterOptions = {},
 ): Promise<UpdaterResult> {
-  const checksumService = options.checksum || new Checksum();
-  const batchSize = options.batchSize || DEFAULT_BATCH_SIZE;
-  const tableName = getTableName(config.table);
-
-  const { url, csvFile, csvTransformOptions = {} } = config;
+  const { table, csvTransformOptions = {} } = config;
+  const checksumService = options.checksum ?? new Checksum();
+  const columnCount = Object.keys(getTableColumns(table)).length;
+  const batchSize =
+    options.batchSize ?? Math.floor(MAX_BOUND_PARAMETERS / columnCount);
+  const tableName = getTableName(table);
 
   // === Download and verify ===
   let destinationPath: string;
-  if (config.filePath) {
+  if (config.url === undefined) {
     destinationPath = config.filePath;
   } else {
-    const extractedFileName = await downloadFile(url, csvFile);
-    destinationPath = path.join(WORKFLOW_TEMP_DIR, extractedFileName);
+    const extractedFiles = await fetchAndExtractZip(config.url);
+    const [firstFile] = extractedFiles.values();
+    if (!firstFile) {
+      throw new Error(`No files found in ZIP at ${config.url}`);
+    }
+    destinationPath = firstFile;
   }
   console.log("Destination path:", destinationPath);
 
@@ -82,21 +95,18 @@ export async function update<T>(
   );
 
   // === Insert records (idempotent via unique constraints) ===
-  const { table } = config;
-
   let totalInserted = 0;
   const start = performance.now();
 
-  for (let i = 0; i < processedData.length; i += batchSize) {
-    const batch = processedData.slice(i, i + batchSize);
-    const inserted = await db
+  for (let index = 0; index < processedData.length; index += batchSize) {
+    const batch = processedData.slice(index, index + batchSize);
+    const { rowCount } = await db
       .insert(table)
       .values(batch)
-      .onConflictDoNothing()
-      .returning();
-    totalInserted += inserted.length;
+      .onConflictDoNothing();
+    totalInserted += rowCount;
     console.log(
-      `Inserted batch of ${inserted.length} records. Total: ${totalInserted}`,
+      `Inserted batch of ${rowCount} records. Total: ${totalInserted}`,
     );
   }
 

--- a/apps/web/src/workflows/cars/steps/process-data.ts
+++ b/apps/web/src/workflows/cars/steps/process-data.ts
@@ -22,7 +22,7 @@ export const updateCars = () => {
           cleanSpecialChars(value, { separator: "." }).toUpperCase(),
         vehicleType: (value: string) =>
           cleanSpecialChars(value, { separator: "/", joinSeparator: "/" }),
-        number: (value: string | number) => (value === "" ? 0 : Number(value)),
+        number: (value: string) => (value === "" ? 0 : Number(value)),
       },
     },
   });

--- a/apps/web/src/workflows/coe/steps/process-data.test.ts
+++ b/apps/web/src/workflows/coe/steps/process-data.test.ts
@@ -151,7 +151,7 @@ describe("updateCoe", () => {
 
     const coeConfig = vi.mocked(update).mock.calls[0][0] as {
       csvTransformOptions?: {
-        fields?: Record<string, (value: string | number) => number>;
+        fields?: Record<string, (value: string) => number>;
       };
     };
 
@@ -159,7 +159,6 @@ describe("updateCoe", () => {
     expect(quotaTransform).toBeDefined();
     expect(quotaTransform?.("1,234")).toBe(1234);
     expect(quotaTransform?.("100")).toBe(100);
-    expect(quotaTransform?.(50)).toBe(50);
   });
 
   it("should parse all numeric COE fields", async () => {
@@ -189,7 +188,7 @@ describe("updateCoe", () => {
 
     const pqpConfig = vi.mocked(update).mock.calls[1][0] as {
       csvTransformOptions?: {
-        fields?: Record<string, (value: string | number) => number>;
+        fields?: Record<string, (value: string) => number>;
       };
     };
     const pqpTransform = pqpConfig.csvTransformOptions?.fields?.pqp;

--- a/apps/web/src/workflows/coe/steps/process-data.ts
+++ b/apps/web/src/workflows/coe/steps/process-data.ts
@@ -8,13 +8,8 @@ export async function updateCoe() {
   const filename = "COE Bidding Results.zip";
   const url = `${LTA_DATAMALL_BASE_URL}/${filename}`;
 
-  const parseNumericString = (value: string | number) => {
-    if (typeof value === "string") {
-      return Number.parseInt(value.replace(/,/g, ""), 10);
-    }
-
-    return value;
-  };
+  const parseNumericString = (value: string) =>
+    Number.parseInt(value.replace(/,/g, ""), 10);
 
   // Download and extract ZIP once for both tables
   const extractedFiles = await fetchAndExtractZip(url);
@@ -28,16 +23,8 @@ export async function updateCoe() {
   }
 
   // Update COE bidding results
-  const coeParseNumericFields: Array<keyof COE> = [
-    "quota",
-    "bidsSuccess",
-    "bidsReceived",
-    "premium",
-  ];
-
   const coeResult = await update<COE>({
     table: coe,
-    url,
     filePath: coeCsvPath,
     csvTransformOptions: {
       columnMapping: {
@@ -46,27 +33,27 @@ export async function updateCoe() {
         bids_success: "bidsSuccess",
         bids_received: "bidsReceived",
       },
-      fields: Object.fromEntries(
-        coeParseNumericFields.map((field) => [field, parseNumericString]),
-      ),
+      fields: {
+        quota: parseNumericString,
+        bidsSuccess: parseNumericString,
+        bidsReceived: parseNumericString,
+        premium: parseNumericString,
+      },
     },
   });
   console.log("[COE]", coeResult);
 
   // Update COE PQP (Prevailing Quota Premium)
-  const pqpParseNumericFields: Array<keyof PQP> = ["pqp"];
-
   const pqpResult = await update<PQP>({
     table: pqp,
-    url,
     filePath: pqpCsvPath,
     csvTransformOptions: {
       columnMapping: {
         vehicle_class: "vehicleClass",
       },
-      fields: Object.fromEntries(
-        pqpParseNumericFields.map((field) => [field, parseNumericString]),
-      ),
+      fields: {
+        pqp: parseNumericString,
+      },
     },
   });
   console.log("[COE PQP]", pqpResult);

--- a/apps/web/src/workflows/ev-charging/steps/process-data.ts
+++ b/apps/web/src/workflows/ev-charging/steps/process-data.ts
@@ -34,49 +34,41 @@ export const toPubliclyAccessible = (value: string): boolean =>
   value.trim().toLowerCase() === "yes";
 
 export const updateEvChargingPoints = () =>
-  update<EvChargingPoint>(
-    {
-      table: evChargingPoints,
-      url: EV_CHARGING_POINTS_URL,
-      csvTransformOptions: {
-        // Postal codes carry leading zeros, so keep every value a string and
-        // convert the numeric columns explicitly below.
-        dynamicTyping: false,
-        columnMapping: {
-          "EV Charger Registration Code": "registrationCode",
-          "No. of Charging Outlets": "outlets",
-          "charging Speed": "chargingSpeedKw",
-          PostalCode: "postalCode",
-          "Block/House No": "blockHouseNo",
-          "Street Name": "streetName",
-          "Building Name": "buildingName",
-          "Floor No": "floorNo",
-          "Lot No": "lotNo",
-          "Is the charger publicly accessible?": "publiclyAccessible",
-          "Registration Date": "registrationDate",
-          "Type of Parking Lot": "parkingLotType",
-        },
-        fields: {
-          outlets: toOutlets,
-          chargingSpeedKw: toNumberOrNull,
-          postalCode: toTextOrNull,
-          blockHouseNo: toTextOrNull,
-          streetName: toTextOrNull,
-          buildingName: toTextOrNull,
-          floorNo: toTextOrNull,
-          lotNo: toTextOrNull,
-          publiclyAccessible: toPubliclyAccessible,
-          longitude: toNumberOrNull,
-          latitude: toNumberOrNull,
-          registrationDate: toIsoDate,
-          parkingLotType: toTextOrNull,
-        },
+  update<EvChargingPoint>({
+    table: evChargingPoints,
+    url: EV_CHARGING_POINTS_URL,
+    csvTransformOptions: {
+      // Postal codes carry leading zeros, so keep every value a string and
+      // convert the numeric columns explicitly below.
+      dynamicTyping: false,
+      columnMapping: {
+        "EV Charger Registration Code": "registrationCode",
+        "No. of Charging Outlets": "outlets",
+        "charging Speed": "chargingSpeedKw",
+        PostalCode: "postalCode",
+        "Block/House No": "blockHouseNo",
+        "Street Name": "streetName",
+        "Building Name": "buildingName",
+        "Floor No": "floorNo",
+        "Lot No": "lotNo",
+        "Is the charger publicly accessible?": "publiclyAccessible",
+        "Registration Date": "registrationDate",
+        "Type of Parking Lot": "parkingLotType",
+      },
+      fields: {
+        outlets: toOutlets,
+        chargingSpeedKw: toNumberOrNull,
+        postalCode: toTextOrNull,
+        blockHouseNo: toTextOrNull,
+        streetName: toTextOrNull,
+        buildingName: toTextOrNull,
+        floorNo: toTextOrNull,
+        lotNo: toTextOrNull,
+        publiclyAccessible: toPubliclyAccessible,
+        longitude: toNumberOrNull,
+        latitude: toNumberOrNull,
+        registrationDate: toIsoDate,
+        parkingLotType: toTextOrNull,
       },
     },
-    {
-      // Neon's HTTP endpoint rejects statements with more than 32,767 bound
-      // parameters (a signed 16-bit count, half Postgres' own cap), so keep
-      // 17 columns x rows comfortably under it.
-      batchSize: 1500,
-    },
-  );
+  });

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -6,6 +6,7 @@ export {
   count,
   desc,
   eq,
+  getTableColumns,
   getTableName,
   gt,
   gte,


### PR DESCRIPTION
- Merge the two duplicated ZIP download paths into `fetchAndExtractZip` and drop the unused `csvFile` option and `Services` barrel
- Derive the default insert batch size from the table's column count so no table can exceed Neon's 32,767 bound-parameter cap, removing the hand-tuned override in the ev-charging workflow
- Count inserted rows via `rowCount` instead of `.returning()` every column
- Type `CSVTransformOptions` against the row type so field parsers and column mappings are checked at compile time
- Make the updater config a `url` or `filePath` union, and tidy the COE, cars, and ev-charging callers to match

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791214633&installation_model_id=21947&pr_number=1042&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1042&signature=76faa038a24e8c50e87fa47693bdd706fab5434329bb98da55dd7e4697def937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->