### PR TITLE
Fix missing car logos after the Blob manifest read

### DIFF
--- a/apps/web/src/workflows/logos/index.ts
+++ b/apps/web/src/workflows/logos/index.ts
@@ -97,7 +97,7 @@ async function listMakes(): Promise<string[]> {
 
 /**
  * One make, one step, so a retry re-fetches only this image. Returns null
- * for a failure other than a 404 so the make is retried on the next run.
+ * for a failure other than "not found" so the make is retried on the next run.
  */
 async function fetchLogo(make: string): Promise<LogoEntry | null> {
   "use step";
@@ -118,7 +118,7 @@ async function fetchLogo(make: string): Promise<LogoEntry | null> {
     };
   }
 
-  if (result.error.endsWith(" 404")) {
+  if (result.notFound) {
     console.log(`[LOGOS] No logo at source for ${make}`);
     return {
       make,

--- a/apps/web/src/workflows/logos/logos.test.ts
+++ b/apps/web/src/workflows/logos/logos.test.ts
@@ -92,6 +92,7 @@ describe("logosWorkflow", () => {
             make,
             sourceUrl: "https://source/zeekr-logo.png",
             error: "Failed to fetch logo: 404",
+            notFound: true,
           },
     );
 
@@ -110,7 +111,7 @@ describe("logosWorkflow", () => {
     expect(revalidateTag).toHaveBeenCalledWith("logos", "max");
   });
 
-  it("leaves a make out of the manifest on a non-404 failure", async () => {
+  it("leaves a make out of the manifest on a retryable failure", async () => {
     vi.mocked(readManifest).mockResolvedValue(manifestWith());
     vi.mocked(getDistinctMakes).mockResolvedValue([{ make: "BYD" }]);
     vi.mocked(downloadLogo).mockResolvedValue({
@@ -118,6 +119,7 @@ describe("logosWorkflow", () => {
       make: "byd",
       sourceUrl: "https://source/byd-logo.png",
       error: "fetch failed",
+      notFound: false,
     });
 
     const result = await logosWorkflow();

--- a/packages/logos/src/services/manifest.ts
+++ b/packages/logos/src/services/manifest.ts
@@ -15,10 +15,7 @@ const createEmptyManifest = (): LogoManifest => ({
  * has been written yet so the caller can bootstrap one.
  */
 export const readManifest = async (): Promise<LogoManifest | null> => {
-  const result = await get(MANIFEST_PATHNAME, {
-    access: "public",
-    useCache: false,
-  });
+  const result = await get(MANIFEST_PATHNAME, { access: "public" });
 
   if (!result || result.statusCode !== 200) {
     return null;

--- a/packages/logos/src/services/scraper.ts
+++ b/packages/logos/src/services/scraper.ts
@@ -11,7 +11,14 @@ export type ScrapeResult =
       pathname: string;
       sourceUrl: string;
     }
-  | { success: false; make: string; sourceUrl: string; error: string };
+  | {
+      success: false;
+      make: string;
+      sourceUrl: string;
+      error: string;
+      /** The source has no logo for this make; do not retry. */
+      notFound: boolean;
+    };
 
 /**
  * Fetch a logo from the external source and store it. Does not check whether
@@ -29,6 +36,20 @@ export const downloadLogo = async (make: string): Promise<ScrapeResult> => {
         make: normalisedMake,
         sourceUrl,
         error: `Failed to fetch logo: ${response.status}`,
+        notFound: response.status === 404,
+      };
+    }
+
+    // The source redirects unknown makes to its homepage with a 200, so a
+    // non-image body means there is no logo rather than a transient failure.
+    const responseType = response.headers.get("content-type") ?? "";
+    if (!responseType.startsWith("image/")) {
+      return {
+        success: false,
+        make: normalisedMake,
+        sourceUrl,
+        error: `Source returned ${responseType || "no content type"}, not an image`,
+        notFound: true,
       };
     }
 
@@ -40,6 +61,7 @@ export const downloadLogo = async (make: string): Promise<ScrapeResult> => {
         make: normalisedMake,
         sourceUrl,
         error: "Downloaded image is too small, likely corrupted",
+        notFound: false,
       };
     }
 
@@ -60,6 +82,7 @@ export const downloadLogo = async (make: string): Promise<ScrapeResult> => {
       make: normalisedMake,
       sourceUrl,
       error: error instanceof Error ? error.message : "Unknown error",
+      notFound: false,
     };
   }
 };


### PR DESCRIPTION
- Drop `useCache: false` from the manifest read: Vercel Blob only accepts it on private blobs and returns 400 on public ones, so every read threw, pages lost their logos, and the logos workflow never bootstrapped the manifest
- Once deployed, the next logos workflow run bootstraps the manifest from the existing images and revalidates the `logos` cache tag

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791279776&installation_model_id=21947&pr_number=1044&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1044&signature=e5591bda84f5ab704601b95835063d3b5692a4b996241f0469cddfbb012421f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->