### PR TITLE
Finish the Vitest 5 migration and fix a Blob async leak

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
     fsModuleCache: true,
     globals: true,
     environment: "jsdom",
+    // Vitest 5 externalises @testing-library/jest-dom, which resolves its CJS
+    // entry and pulls in a second `vitest` module instance. That instance
+    // registers its own snapshot plugin, so toMatchSnapshot() looks up a
+    // SnapshotClient that was never set up for the file. Inlining keeps
+    // jest-dom on the ESM build that shares this run's vitest instance.
+    server: { deps: { inline: ["@testing-library/jest-dom"] } },
     // detectAsyncLeaks: true, // Available for targeted debugging; too noisy with framer-motion animation leaks
     coverage: {
       enabled: true,

--- a/packages/logos/src/services/manifest.test.ts
+++ b/packages/logos/src/services/manifest.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { LogoManifest } from "../types";
 import { manifestToLogos } from "./manifest";
+
+// manifestToLogos is pure, but importing ./manifest pulls in @vercel/blob,
+// which kicks off an unawaited feature-detection promise at module scope.
+// A factory mock keeps the real module out of the test run entirely.
+vi.mock("@vercel/blob", () => ({
+  get: vi.fn(),
+  list: vi.fn(),
+  put: vi.fn(),
+}));
 
 const manifest: LogoManifest = {
   version: 1,


### PR DESCRIPTION
- Inline `@testing-library/jest-dom` in the web Vitest config. Vitest 5 externalises it, so its CJS entry `require`d a second `vitest` module instance whose snapshot plugin overrode the real one — `toMatchSnapshot()` then looked up a `SnapshotClient` never set up for the file, failing all 77 snapshot assertions.
- Stub `@vercel/blob` in the logos manifest test. It only exercises the pure `manifestToLogos`, but importing the module ran Blob's import-time feature detection, an unawaited module-scope promise that tripped `detectAsyncLeaks`.
- Audited the rest of the Vitest 5 guide — hoisted mock placement, coverage glob matching, the new `clearMocks` default, removed entry points, `test.sequential`, unawaited async assertions — nothing else needed changing.
- Full suite green: 859 tests across utils, logos, ai and web; web coverage thresholds still met at 86.77%.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791291493&installation_model_id=21947&pr_number=1047&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1047&signature=6bac888e6207b341769f6ce797d60c8814d163651e803152f7aa484576a43be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->