### PR TITLE
Stop the homepage regenerating every minute

### DIFF
--- a/apps/web/src/queries/ev-charging/snapshot.test.ts
+++ b/apps/web/src/queries/ev-charging/snapshot.test.ts
@@ -26,7 +26,7 @@ describe("getEvChargingSnapshot", () => {
       records: [],
     });
     expect(fetchBatch).not.toHaveBeenCalled();
-    expect(cacheLifeMock).toHaveBeenCalledWith("minutes");
+    expect(cacheLifeMock).toHaveBeenCalledWith("hours");
   });
 
   it("should fetch, parse and stamp the feed time", async () => {

--- a/apps/web/src/queries/ev-charging/snapshot.ts
+++ b/apps/web/src/queries/ev-charging/snapshot.ts
@@ -19,13 +19,15 @@ const EMPTY: EvChargingSnapshot = { observedAt: null, records: [] };
  * five-minute batch file.
  *
  * Nothing is stored: every live figure on the site derives from this one
- * cached download. The built-in `minutes` profile matches the feed's own
- * refresh rate, so a visitor sees at most a few minutes of staleness. Without
- * an account key the snapshot is empty and the pages show their empty state.
+ * cached download. The `hours` profile is deliberately coarser than the
+ * feed's five-minute refresh: this query feeds the homepage, and the shortest
+ * cache life on a route sets how often Vercel regenerates the whole page. A
+ * one-minute profile burned the Hobby ISR-write and CPU quotas. Without an
+ * account key the snapshot is empty and the pages show their empty state.
  */
 export async function getEvChargingSnapshot(): Promise<EvChargingSnapshot> {
   "use cache";
-  cacheLife("minutes");
+  cacheLife("hours");
 
   const accountKey = process.env.LTA_DATAMALL_ACCOUNT_KEY;
   if (!accountKey) {


### PR DESCRIPTION
- Move the live EV charging snapshot from the \`minutes\` cache profile to \`hours\`
- The snapshot feeds the homepage, and the shortest cache life on a route sets its revalidate; the build log showed \`/\` and \`/cars/electric-vehicles/charging\` at 1m/1h while every other route sits at 30d
- Under real traffic the homepage regenerated about every four minutes, which was over 90% of ISR writes, the top Active CPU route, and a fresh DataMall batch download each time
- Hobby quotas for Fluid Active CPU and ISR Writes were exceeded as a result; the daily refresh cron on Hobby already accepts hourly-scale staleness

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791599050&installation_model_id=21947&pr_number=1049&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1049&signature=028af5366ab53c1bf8cd27012f9aad8baddc30a320b733430cfb2498ba756994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->