### PR TITLE
Temporarily limit PostHog to autocapture and pageviews

### DIFF
--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -5,5 +5,16 @@ if (process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) {
     api_host: "/ingest",
     ui_host: "https://eu.posthog.com",
     defaults: "2026-01-30",
+    // Temporarily autocapture and pageviews only. Every other extension is
+    // switched off to keep PostHog's share of Fast Origin Transfer down while
+    // the Hobby quotas recover. Session replay is the expensive one.
+    disable_session_recording: true,
+    disable_surveys: true,
+    disable_conversations: true,
+    capture_heatmaps: false,
+    capture_dead_clicks: false,
+    capture_exceptions: false,
+    capture_performance: { web_vitals: false, network_timing: false },
+    logs: { captureConsoleLogs: false },
   });
 }


### PR DESCRIPTION
- Switch off session replay, surveys, conversations, heatmaps, dead clicks, exception autocapture, web vitals, network timing, and console log capture in the client init
- Autocapture, pageviews, and the app's own \`posthog.capture\` events are unchanged
- Session replay uploads through \`/ingest/s/\` were the largest single route in Fast Data Transfer while the Hobby quotas were exceeded; this is a stopgap until usage resets and can be reverted by deleting the added options

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791600906&installation_model_id=21947&pr_number=1050&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1050&signature=84bda5c5d5b1ea3020945ac59fd8619d8cbb7dbcd345295ff77ff76a9aa28fc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->