### PR TITLE
Skip the proxy for PostHog ingest requests

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -158,6 +158,6 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+    "/((?!_next/static|_next/image|ingest|favicon.ico|sitemap.xml|robots.txt).*)",
   ],
 };

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -158,6 +158,6 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|ingest|favicon.ico|sitemap.xml|robots.txt).*)",
+    "/((?!_next/static|_next/image|ingest(?:/|$)|favicon.ico|sitemap.xml|robots.txt).*)",
   ],
 };


### PR DESCRIPTION
- Exclude `/ingest` from the proxy matcher so PostHog beacons no longer run the proxy function, which did a Redis maintenance-config read per event
- The `next.config.ts` rewrites forward `/ingest/*` to PostHog independently of the proxy, so ingestion is unaffected
- Follows PostHog's Next.js rewrites guide, which recommends excluding the proxy path from the matcher: https://posthog.com/docs/advanced/proxy/nextjs
- In an 8-minute production log sample, 74 of 100 middleware invocations were `/ingest/*`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791624584&installation_model_id=21947&pr_number=1052&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1052&signature=07de2e0b81c20f74fd51fc1064f54c63b53322af35848e4ae3251a840b633bdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->