### PR TITLE
Fix Recent changes card and mark EV charging page as beta

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map-view.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map-view.tsx
@@ -5,13 +5,13 @@ import { Segment } from "@heroui-pro/react";
 // biome-ignore lint/suspicious/noShadowRestrictedNames: HeroUI Pro Map component
 import { Map, type MapClusterLayerProps, useMap } from "@heroui-pro/react/map";
 import { siteParam } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/search-params";
+import { describeConnectors } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/utils/describe-connectors";
 import { inDistrict } from "@web/queries/ev-charging/locations";
 import type { EvChargingMapSite } from "@web/queries/ev-charging/map-sites";
 import type { FeatureCollection, Point } from "geojson";
 import { type LngLatBoundsLike, setWorkerUrl } from "maplibre-gl";
 import { useQueryState } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { describeConnectors } from "./location-row";
 
 setWorkerUrl("/maplibre/maplibre-gl-worker.mjs");
 

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/location-row.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/location-row.tsx
@@ -5,17 +5,11 @@ import {
   MAP_ANCHOR_ID,
   siteParam,
 } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/search-params";
+import { describeConnectors } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/utils/describe-connectors";
 import { districtForPostalCode } from "@web/config/postal-districts";
 import type { EvChargingLocation } from "@web/queries/ev-charging";
 import { useQueryState } from "nuqs";
 import type { ReactNode } from "react";
-
-/** "2× DC 120 kW" style summary of what a location offers. */
-export const describeConnectors = (location: EvChargingLocation): string => {
-  const rating = location.dcConnectors > 0 ? "DC" : "AC";
-  const speed = location.maxSpeedKw != null ? ` ${location.maxSpeedKw} kW` : "";
-  return `${location.connectors}× ${rating}${speed}`;
-};
 
 /**
  * A location line item shared by the ranked lists on the charging page.

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/recent-changes.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/recent-changes.tsx
@@ -1,9 +1,9 @@
 import { Typography } from "@heroui/react";
+import { describeConnectors } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/utils/describe-connectors";
 import { InkPanel } from "@web/components/shared/bento";
 import { districtForPostalCode } from "@web/config/postal-districts";
 import { getEvChargingRecentChanges } from "@web/queries/ev-charging";
 import { Sparkles } from "lucide-react";
-import { describeConnectors } from "./location-row";
 
 const LIMIT = 5;
 

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/page.tsx
@@ -1,4 +1,4 @@
-import { Skeleton } from "@heroui/react";
+import { Chip, Skeleton } from "@heroui/react";
 import { BusyHours } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/busy-hours";
 import { ChargingMap } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map";
 import {
@@ -99,9 +99,16 @@ export default function ChargingPage({ searchParams }: PageProps) {
 
       <PageHead
         controls={
-          <Suspense fallback={<Skeleton className="h-12 w-56 rounded-full" />}>
-            <DistrictControl searchParams={searchParams} />
-          </Suspense>
+          <>
+            <Chip color="accent" variant="soft">
+              Beta
+            </Chip>
+            <Suspense
+              fallback={<Skeleton className="h-12 w-56 rounded-full" />}
+            >
+              <DistrictControl searchParams={searchParams} />
+            </Suspense>
+          </>
         }
         title="EV charging"
       />

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/utils/describe-connectors.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/utils/describe-connectors.ts
@@ -1,0 +1,8 @@
+import type { EvChargingLocation } from "@web/queries/ev-charging";
+
+/** "2× DC 120 kW" style summary of what a location offers. */
+export const describeConnectors = (location: EvChargingLocation): string => {
+  const rating = location.dcConnectors > 0 ? "DC" : "AC";
+  const speed = location.maxSpeedKw != null ? ` ${location.maxSpeedKw} kW` : "";
+  return `${location.connectors}× ${rating}${speed}`;
+};


### PR DESCRIPTION
- Move `describeConnectors` out of the client-only `location-row.tsx` into `charging/utils/describe-connectors.ts`, so the server-rendered Recent changes card can call it instead of throwing React error #441
- Add a "Beta" chip to the EV charging page header, next to the district picker

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791625741&installation_model_id=21947&pr_number=1053&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1053&signature=5edde3198a92537566f5add7e67a997299bee1d8154fb9a493b930a9c441bba0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->