### PR TITLE
Place the Beta chip beside the EV charging title

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/page.tsx
@@ -98,17 +98,15 @@ export default function ChargingPage({ searchParams }: PageProps) {
       />
 
       <PageHead
+        badge={
+          <Chip color="accent" size="lg" variant="soft">
+            Beta
+          </Chip>
+        }
         controls={
-          <>
-            <Chip color="accent" variant="soft">
-              Beta
-            </Chip>
-            <Suspense
-              fallback={<Skeleton className="h-12 w-56 rounded-full" />}
-            >
-              <DistrictControl searchParams={searchParams} />
-            </Suspense>
-          </>
+          <Suspense fallback={<Skeleton className="h-12 w-56 rounded-full" />}>
+            <DistrictControl searchParams={searchParams} />
+          </Suspense>
         }
         title="EV charging"
       />

--- a/apps/web/src/components/shared/page-head.tsx
+++ b/apps/web/src/components/shared/page-head.tsx
@@ -16,10 +16,13 @@ import type { ReactNode } from "react";
  * 52); that is below the threshold worth a variant, so both use one scale.
  */
 export function PageHead({
+  badge,
   controls,
   description,
   title,
 }: {
+  /** Status chip rendered beside the title, e.g. a "Beta" marker. */
+  badge?: ReactNode;
   controls?: ReactNode;
   /** Lede paragraph. Report-family pages set it; bento-family pages omit it. */
   description?: string;
@@ -28,7 +31,10 @@ export function PageHead({
   return (
     <div className="flex flex-wrap items-end gap-6">
       <div className={cn("flex flex-col gap-2", description && "max-w-prose")}>
-        <Typography.Heading level={1}>{title}</Typography.Heading>
+        <div className="flex flex-wrap items-center gap-4">
+          <Typography.Heading level={1}>{title}</Typography.Heading>
+          {badge}
+        </div>
         {description ? (
           <Typography.Paragraph color="muted">
             {description}


### PR DESCRIPTION
- Add an optional `badge` slot to `PageHead` that renders inline with the H1
- Move the EV charging "Beta" chip from the controls row into that slot and bump it to the large size so it reads with the heading

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791626010&installation_model_id=21947&pr_number=1054&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1054&signature=13261dd301867ad6e6b742b105f0f1c3bfa13c7ef52ec5ca49039b395fc58419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->