### PR TITLE
Guard busy hours and move the live EV ingest schedule to QStash

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -207,6 +207,9 @@ Web-specific variables (see root `CLAUDE.md` for the cross-cutting ones):
   Without them, flags fall back to their `defaultValue` (`false`). Toggle independently in preview vs
   production via the dashboard or `vercel flags enable|disable --environment`. Keys:
   `advertise-page`, `advertise-nav`, `blog-nav`, `blog-popular-posts`, `social-links`
+- `QSTASH_TOKEN` / `QSTASH_CURRENT_SIGNING_KEY` / `QSTASH_NEXT_SIGNING_KEY`: Upstash QStash. The
+  five-minute `ev-charging-live` schedule lives in QStash, not `vercel.ts` crons; it forwards
+  `CRON_SECRET` as the bearer token so the route needs no QStash-specific verification
 - `VERCEL_ENV`: social media redirects and production-only features activate only when this is `"production"`
 - `NEXT_PUBLIC_VERCEL_URL`: client-side deployment URL, without the `https://` protocol. `SITE_URL` falls back to it
   when `NEXT_PUBLIC_SITE_URL` is unset

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/busy-hours.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/busy-hours.tsx
@@ -16,8 +16,28 @@ export async function BusyHours() {
   );
   const max = Math.max(peak.utilisationPercent, 1);
 
-  if (peak.utilisationPercent === 0) {
-    return null;
+  // A peak only means something once every hour of the day has been
+  // sampled; before that the busiest hour is just whichever one the cron
+  // happened to land on.
+  const sampledHours = hours.filter((item) => item.samples > 0).length;
+  if (sampledHours < hours.length) {
+    return (
+      <SurfaceCard className="gap-4 p-7">
+        <div className="flex flex-col gap-1">
+          <Typography.Paragraph className="text-muted">
+            Busy hours
+          </Typography.Paragraph>
+          <Typography.Heading level={3}>Busiest hour</Typography.Heading>
+        </div>
+        <Typography.Paragraph color="muted" size="sm">
+          Not enough usage history for Singapore yet. Check back after a day of
+          readings.
+        </Typography.Paragraph>
+        <Typography.Paragraph color="muted" size="xs">
+          Share of connectors in use, Singapore time · past 7 days
+        </Typography.Paragraph>
+      </SurfaceCard>
+    );
   }
 
   return (

--- a/apps/web/src/queries/ev-charging/hourly-utilisation.test.ts
+++ b/apps/web/src/queries/ev-charging/hourly-utilisation.test.ts
@@ -8,16 +8,20 @@ describe("getEvChargingUtilisationByHour", () => {
 
   it("should return 24 hours, zero-filling the ones without samples", async () => {
     queueSelect([
-      { hour: 1, utilisationPercent: 32 },
-      { hour: 19, utilisationPercent: 24.5 },
+      { hour: 1, utilisationPercent: 32, samples: 40 },
+      { hour: 19, utilisationPercent: 24.5, samples: 12 },
     ]);
 
     const rows = await getEvChargingUtilisationByHour();
 
     expect(rows).toHaveLength(24);
-    expect(rows[0]).toEqual({ hour: 0, utilisationPercent: 0 });
-    expect(rows[1]).toEqual({ hour: 1, utilisationPercent: 32 });
-    expect(rows[19]).toEqual({ hour: 19, utilisationPercent: 24.5 });
+    expect(rows[0]).toEqual({ hour: 0, utilisationPercent: 0, samples: 0 });
+    expect(rows[1]).toEqual({ hour: 1, utilisationPercent: 32, samples: 40 });
+    expect(rows[19]).toEqual({
+      hour: 19,
+      utilisationPercent: 24.5,
+      samples: 12,
+    });
     expect(cacheLifeMock).toHaveBeenCalledWith("hours");
   });
 

--- a/apps/web/src/queries/ev-charging/hourly-utilisation.ts
+++ b/apps/web/src/queries/ev-charging/hourly-utilisation.ts
@@ -11,6 +11,8 @@ export interface EvChargingHourlyUtilisation {
   hour: number;
   /** Share of usable connectors occupied, 0–100. */
   utilisationPercent: number;
+  /** Five-minute readings behind the figure; zero until the hour is sampled. */
+  samples: number;
 }
 
 /**
@@ -34,17 +36,20 @@ export async function getEvChargingUtilisationByHour(
       Number,
     );
 
+  const samples = sum(evLocationHourly.samples).mapWith(Number);
+
   const rows = await db
-    .select({ hour: hourOfDay, utilisationPercent: utilisation })
+    .select({ hour: hourOfDay, utilisationPercent: utilisation, samples })
     .from(evLocationHourly)
     .where(gte(evLocationHourly.hour, daysAgo(days)))
     .groupBy(hourOfDay)
     .orderBy(hourOfDay);
 
-  const byHour = new Map(rows.map((row) => [row.hour, row.utilisationPercent]));
+  const byHour = new Map(rows.map((row) => [row.hour, row]));
 
   return Array.from({ length: 24 }, (_, hour) => ({
     hour,
-    utilisationPercent: byHour.get(hour) ?? 0,
+    utilisationPercent: byHour.get(hour)?.utilisationPercent ?? 0,
+    samples: byHour.get(hour)?.samples ?? 0,
   }));
 }

--- a/apps/web/vercel.ts
+++ b/apps/web/vercel.ts
@@ -8,6 +8,9 @@ export const config: VercelConfig = {
     },
   },
   relatedProjects: ["prj_fyAvupEssH3LO4OQFDWplinVFlaI"],
+  // The live EV charging ingest (/api/workflows/ev-charging-live) is not
+  // here: Hobby caps crons at once a day, so it runs every five minutes from
+  // a QStash schedule (id `ev-charging-live`) that forwards CRON_SECRET.
   crons: [
     {
       path: "/api/workflows/cars",
@@ -41,13 +44,6 @@ export const config: VercelConfig = {
       // After the cars run so newly registered makes are in the database.
       path: "/api/workflows/logos",
       schedule: "0 11 * * *",
-    },
-    {
-      path: "/api/workflows/ev-charging-live",
-      // TODO: The DataMall batch refreshes every 5 minutes, but Hobby caps
-      // crons at once a day. Change to "*/5 * * * *" once the project is on
-      // Vercel Pro.
-      schedule: "0 22 * * *",
     },
   ],
   regions: ["sin1"],


### PR DESCRIPTION
- Busy hours card now shows the same "not enough usage history" state as the location cards until every hour of the day has readings, instead of reporting whichever hour the daily cron landed on as the peak
- Hourly utilisation query returns per-hour sample counts to drive that guard
- Remove the once-a-day `ev-charging-live` Vercel cron; the route is now hit every five minutes by a QStash schedule that forwards `CRON_SECRET`, documented in `vercel.ts` and the web CLAUDE.md

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791628930&installation_model_id=21947&pr_number=1055&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1055&signature=c217bffb5f9c22bb2121e0090d987b1a6f65ad107e45b4b52e5f0f60db655b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->