### PR TITLE
Gate the Visitor Intent PostHog survey to once per browser

### DIFF
--- a/apps/web/src/app/(main)/layout.tsx
+++ b/apps/web/src/app/(main)/layout.tsx
@@ -4,6 +4,7 @@ import { Banner } from "@web/components/banner";
 import { FlaggedAppNav, FlaggedFooter } from "@web/components/flagged-chrome";
 import { Footer } from "@web/components/footer";
 import { NotificationPrompt } from "@web/components/notification-prompt";
+import { SurveyPrompt } from "@web/components/survey-prompt";
 import { type ReactNode, Suspense } from "react";
 
 export default function MainLayout({
@@ -12,6 +13,7 @@ export default function MainLayout({
   return (
     <div className="min-h-screen bg-background text-foreground">
       <NotificationPrompt />
+      <SurveyPrompt />
       <Announcement />
       <Banner />
 

--- a/apps/web/src/components/survey-prompt.test.tsx
+++ b/apps/web/src/components/survey-prompt.test.tsx
@@ -1,0 +1,136 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SURVEY_COOLDOWN_MS,
+  SURVEY_SHOWN_AT_KEY,
+  SurveyPrompt,
+  VISITOR_INTENT_SURVEY_ID,
+} from "./survey-prompt";
+
+const state = vi.hoisted(() => ({
+  pathname: "/coe/pqp",
+  visible: true,
+  loaded: true,
+}));
+
+const canRenderSurveyAsync = vi.hoisted(() =>
+  vi.fn(async () => ({ visible: state.visible })),
+);
+const displaySurvey = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => state.pathname,
+}));
+
+vi.mock("posthog-js", () => ({
+  default: {
+    get __loaded() {
+      return state.loaded;
+    },
+    canRenderSurveyAsync,
+    displaySurvey,
+  },
+  DisplaySurveyType: { Popover: "popover" },
+}));
+
+const storage = new Map<string, string>();
+
+async function renderAndWait() {
+  const result = render(<SurveyPrompt />);
+  await act(async () => {
+    await vi.runAllTimersAsync();
+  });
+  return result;
+}
+
+describe("SurveyPrompt", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    storage.clear();
+    state.pathname = "/coe/pqp";
+    state.visible = true;
+    state.loaded = true;
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("should display the survey on a COE page and remember it", async () => {
+    await renderAndWait();
+
+    expect(canRenderSurveyAsync).toHaveBeenCalledWith(
+      VISITOR_INTENT_SURVEY_ID,
+      false,
+    );
+    expect(displaySurvey).toHaveBeenCalledWith(VISITOR_INTENT_SURVEY_ID, {
+      displayType: "popover",
+      ignoreConditions: false,
+      ignoreDelay: false,
+    });
+    expect(Number(storage.get(SURVEY_SHOWN_AT_KEY))).toBeGreaterThan(0);
+  });
+
+  it("should not display outside the COE and cars routes", async () => {
+    state.pathname = "/blog/some-post";
+
+    await renderAndWait();
+
+    expect(canRenderSurveyAsync).not.toHaveBeenCalled();
+    expect(displaySurvey).not.toHaveBeenCalled();
+  });
+
+  it("should not display again within the cooldown", async () => {
+    storage.set(SURVEY_SHOWN_AT_KEY, String(Date.now() - 1_000));
+
+    await renderAndWait();
+
+    expect(displaySurvey).not.toHaveBeenCalled();
+  });
+
+  it("should display again once the cooldown has passed", async () => {
+    storage.set(
+      SURVEY_SHOWN_AT_KEY,
+      String(Date.now() - SURVEY_COOLDOWN_MS - 1_000),
+    );
+
+    await renderAndWait();
+
+    expect(displaySurvey).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not display when PostHog says the survey is ineligible", async () => {
+    state.visible = false;
+
+    await renderAndWait();
+
+    expect(displaySurvey).not.toHaveBeenCalled();
+    expect(storage.has(SURVEY_SHOWN_AT_KEY)).toBe(false);
+  });
+
+  it("should do nothing when PostHog has not loaded", async () => {
+    state.loaded = false;
+
+    await renderAndWait();
+
+    expect(canRenderSurveyAsync).not.toHaveBeenCalled();
+  });
+
+  it("should cancel a pending display on unmount", async () => {
+    const { unmount } = render(<SurveyPrompt />);
+    unmount();
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(displaySurvey).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/survey-prompt.test.tsx
+++ b/apps/web/src/components/survey-prompt.test.tsx
@@ -1,11 +1,11 @@
 import { act, render } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   SURVEY_COOLDOWN_MS,
   SURVEY_SHOWN_AT_KEY,
   SurveyPrompt,
   VISITOR_INTENT_SURVEY_ID,
-} from "./survey-prompt";
+} from "@web/components/survey-prompt";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const state = vi.hoisted(() => ({
   pathname: "/coe/pqp",

--- a/apps/web/src/components/survey-prompt.tsx
+++ b/apps/web/src/components/survey-prompt.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import posthog, { DisplaySurveyType } from "posthog-js";
+import { useEffect } from "react";
+
+// PostHog survey "Visitor Intent", created as a draft for #1027.
+export const VISITOR_INTENT_SURVEY_ID = "01a08b16-358f-0000-e30b-147c4ae4e28c";
+
+export const SURVEY_SHOWN_AT_KEY = "motormetrics:survey-shown-at";
+export const SURVEY_COOLDOWN_MS = 90 * 24 * 60 * 60 * 1000;
+export const SURVEY_ROUTE_PATTERN = /^\/(coe|cars)(\/|$)/;
+
+const SURVEY_PROMPT_DELAY_MS = 10_000;
+
+// Shows at most one survey per browser. PostHog holds the survey, its
+// targeting and its responses; automatic popover display is switched off in
+// instrumentation-client.ts so this component is the only display path.
+export function SurveyPrompt() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!SURVEY_ROUTE_PATTERN.test(pathname) || isWithinCooldown()) {
+      return;
+    }
+
+    let cancelled = false;
+    const timer = window.setTimeout(async () => {
+      if (cancelled || !posthog.__loaded) {
+        return;
+      }
+
+      const { visible } = await posthog.canRenderSurveyAsync(
+        VISITOR_INTENT_SURVEY_ID,
+        false,
+      );
+      if (cancelled || !visible) {
+        return;
+      }
+
+      posthog.displaySurvey(VISITOR_INTENT_SURVEY_ID, {
+        displayType: DisplaySurveyType.Popover,
+        ignoreConditions: false,
+        ignoreDelay: false,
+      });
+      rememberShown();
+    }, SURVEY_PROMPT_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [pathname]);
+
+  return null;
+}
+
+function isWithinCooldown() {
+  try {
+    const shownAt = Number(window.localStorage?.getItem(SURVEY_SHOWN_AT_KEY));
+    return shownAt > 0 && Date.now() - shownAt < SURVEY_COOLDOWN_MS;
+  } catch {
+    return false;
+  }
+}
+
+function rememberShown() {
+  try {
+    window.localStorage?.setItem(SURVEY_SHOWN_AT_KEY, String(Date.now()));
+  } catch {
+    // Storage unavailable; PostHog's own 90-day wait period still applies.
+  }
+}

--- a/apps/web/src/components/survey-prompt.tsx
+++ b/apps/web/src/components/survey-prompt.tsx
@@ -9,7 +9,7 @@ export const VISITOR_INTENT_SURVEY_ID = "01a08b16-358f-0000-e30b-147c4ae4e28c";
 
 export const SURVEY_SHOWN_AT_KEY = "motormetrics:survey-shown-at";
 export const SURVEY_COOLDOWN_MS = 90 * 24 * 60 * 60 * 1000;
-export const SURVEY_ROUTE_PATTERN = /^\/(coe|cars)(\/|$)/;
+const SURVEY_ROUTE_PATTERN = /^\/(coe|cars)(\/|$)/;
 
 const SURVEY_PROMPT_DELAY_MS = 10_000;
 

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -5,5 +5,7 @@ if (process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) {
     api_host: "/ingest",
     ui_host: "https://eu.posthog.com",
     defaults: "2026-01-30",
+    // Surveys are shown by SurveyPrompt, once per browser, never automatically.
+    disable_surveys_automatic_display: true,
   });
 }


### PR DESCRIPTION
- Add a client-side gate that shows the Visitor Intent survey at most once per browser, on the COE and cars routes only, with a 90-day cooldown
- Use the native PostHog `canRenderSurveyAsync` and `displaySurvey` APIs so PostHog keeps targeting, rendering and responses
- Switch off automatic popover display in the PostHog init so the gate is the only display path
- Survey is still a draft in PostHog and shows nothing until launched after #1035

Closes #1030
Closes #1031

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791632151&installation_model_id=21947&pr_number=1057&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1057&signature=2a6261b07003220ffde61b81f34889abf5b557a76212093e5bde62801066341b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->