### PR TITLE
Cache the homepage EV charging figures as one small entry

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/components/ev-charging.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/ev-charging.tsx
@@ -1,12 +1,9 @@
 import { Chip, ProgressBar, Typography } from "@heroui/react";
 import { NumberValue } from "@heroui-pro/react";
 import { Headline, SectionHead } from "@web/components/shared/overview";
-import { districtForPostalCode } from "@web/config/postal-districts";
 import {
-  type EvChargingPricedLocation,
-  getEvChargingLiveSummary,
-  getEvChargingNetworkSummary,
-  getEvChargingPriceRankings,
+  type EvChargingRateStat,
+  getEvChargingOverview,
 } from "@web/queries/ev-charging";
 
 const LINK = {
@@ -14,36 +11,14 @@ const LINK = {
   label: "All charging data",
 };
 
-/**
- * Where a rate is charged: the operator and district when one location has
- * it, otherwise how many share it.
- */
-function describeRate(locations: EvChargingPricedLocation[]): string | null {
-  const leader = locations[0];
-  if (!leader) {
-    return null;
-  }
-
-  const atRate = locations.filter(
-    (location) => location.pricePerKwh === leader.pricePerKwh,
-  );
-  if (atRate.length > 1) {
-    return `${atRate.length} locations at this rate`;
-  }
-
-  return [leader.operator, districtForPostalCode(leader.postalCode)?.name]
-    .filter(Boolean)
-    .join(" · ");
-}
-
 function RateStat({
   label,
-  locations,
+  stat,
 }: {
   label: string;
-  locations: EvChargingPricedLocation[];
+  stat: EvChargingRateStat | null;
 }) {
-  const price = locations[0]?.pricePerKwh;
+  const price = stat?.pricePerKwh;
   return (
     <div className="flex min-w-0 flex-col gap-1">
       <Typography.Paragraph className="font-semibold" color="muted" size="sm">
@@ -59,7 +34,7 @@ function RateStat({
         size="sm"
         truncate
       >
-        {describeRate(locations) ?? "not advertised"}
+        {stat?.description ?? "not advertised"}
       </Typography.Paragraph>
     </div>
   );
@@ -71,20 +46,8 @@ function RateStat({
  * network counts and says so rather than showing a stale percentage.
  */
 export async function EvCharging() {
-  const [live, cheapest, priciest, network] = await Promise.all([
-    getEvChargingLiveSummary(),
-    getEvChargingPriceRankings({
-      limit: Number.MAX_SAFE_INTEGER,
-      order: "cheapest",
-      powerRating: "DC",
-    }),
-    getEvChargingPriceRankings({
-      limit: Number.MAX_SAFE_INTEGER,
-      order: "priciest",
-      powerRating: "DC",
-    }),
-    getEvChargingNetworkSummary(),
-  ]);
+  const { live, network, cheapestDc, priciestDc } =
+    await getEvChargingOverview();
 
   const isLive = live.connectors > 0 && live.observedAt !== null;
   const usable = live.connectors - live.unavailable;
@@ -184,10 +147,10 @@ export async function EvCharging() {
           </Typography.Paragraph>
         )}
 
-        {cheapest.length > 0 ? (
+        {cheapestDc ? (
           <div className="grid grid-cols-2 gap-6 border-separator border-t pt-4">
-            <RateStat label="Cheapest DC rate" locations={cheapest} />
-            <RateStat label="Most expensive DC rate" locations={priciest} />
+            <RateStat label="Cheapest DC rate" stat={cheapestDc} />
+            <RateStat label="Most expensive DC rate" stat={priciestDc} />
           </div>
         ) : null}
 

--- a/apps/web/src/queries/ev-charging/index.ts
+++ b/apps/web/src/queries/ev-charging/index.ts
@@ -4,6 +4,7 @@ export * from "./location-utilisation";
 export * from "./locations";
 export * from "./map-sites";
 export * from "./network-summary";
+export * from "./overview";
 export * from "./price-rankings";
 export * from "./recent-changes";
 export * from "./registrations-by-month";

--- a/apps/web/src/queries/ev-charging/overview.test.ts
+++ b/apps/web/src/queries/ev-charging/overview.test.ts
@@ -1,0 +1,84 @@
+vi.mock("./live-summary", () => ({ getEvChargingLiveSummary: vi.fn() }));
+vi.mock("./network-summary", () => ({ getEvChargingNetworkSummary: vi.fn() }));
+vi.mock("./price-rankings", () => ({ getEvChargingPriceRankings: vi.fn() }));
+
+import { cacheLifeMock } from "../test-utils";
+import { getEvChargingLiveSummary } from "./live-summary";
+import { getEvChargingNetworkSummary } from "./network-summary";
+import { getEvChargingOverview } from "./overview";
+import { getEvChargingPriceRankings } from "./price-rankings";
+
+const live = {
+  connectors: 100,
+  locations: 40,
+  available: 60,
+  occupied: 30,
+  unavailable: 10,
+  observedAt: "2026-09-10T00:00:00.000Z",
+};
+const network = { connectors: 120, sites: 45 };
+
+const location = (overrides: Record<string, unknown>) => ({
+  locationId: "L1",
+  stationName: "Station",
+  address: null,
+  postalCode: "018956",
+  operator: "SP",
+  connectors: 2,
+  pricePerKwh: 0.5,
+  speedKw: 50,
+  ...overrides,
+});
+
+describe("getEvChargingOverview", () => {
+  beforeEach(() => {
+    vi.mocked(getEvChargingLiveSummary).mockResolvedValue(live);
+    vi.mocked(getEvChargingNetworkSummary).mockResolvedValue(network);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should reduce the rankings to one rate stat each on the hours profile", async () => {
+    vi.mocked(getEvChargingPriceRankings)
+      .mockResolvedValueOnce([
+        location({ pricePerKwh: 0.45, operator: "SP" }),
+        location({ locationId: "L2", pricePerKwh: 0.5 }),
+      ] as never)
+      .mockResolvedValueOnce([
+        location({ pricePerKwh: 0.9 }),
+        location({ locationId: "L2", pricePerKwh: 0.9 }),
+        location({ locationId: "L3", pricePerKwh: 0.9 }),
+      ] as never);
+
+    const overview = await getEvChargingOverview();
+
+    expect(overview.live).toEqual(live);
+    expect(overview.network).toEqual(network);
+    expect(overview.cheapestDc).toEqual({
+      pricePerKwh: 0.45,
+      description: "SP · Raffles Place / Marina",
+    });
+    expect(overview.priciestDc).toEqual({
+      pricePerKwh: 0.9,
+      description: "3 locations at this rate",
+    });
+    expect(getEvChargingPriceRankings).toHaveBeenCalledWith(
+      expect.objectContaining({ order: "cheapest", powerRating: "DC" }),
+    );
+    expect(getEvChargingPriceRankings).toHaveBeenCalledWith(
+      expect.objectContaining({ order: "priciest", powerRating: "DC" }),
+    );
+    expect(cacheLifeMock).toHaveBeenCalledWith("hours");
+  });
+
+  it("should return null rate stats when no DC rate is advertised", async () => {
+    vi.mocked(getEvChargingPriceRankings).mockResolvedValue([]);
+
+    const overview = await getEvChargingOverview();
+
+    expect(overview.cheapestDc).toBeNull();
+    expect(overview.priciestDc).toBeNull();
+  });
+});

--- a/apps/web/src/queries/ev-charging/overview.ts
+++ b/apps/web/src/queries/ev-charging/overview.ts
@@ -1,0 +1,93 @@
+import { districtForPostalCode } from "@web/config/postal-districts";
+import { cacheLife } from "next/cache";
+import {
+  type EvChargingLiveSummary,
+  getEvChargingLiveSummary,
+} from "./live-summary";
+import {
+  type EvChargingNetworkSummary,
+  getEvChargingNetworkSummary,
+} from "./network-summary";
+import {
+  type EvChargingPricedLocation,
+  getEvChargingPriceRankings,
+  type PriceOrder,
+} from "./price-rankings";
+
+export interface EvChargingRateStat {
+  /** Advertised $/kWh at the leading location. */
+  pricePerKwh: number;
+  /** Where it is charged, or how many locations share the rate. */
+  description: string | null;
+}
+
+export interface EvChargingOverview {
+  live: EvChargingLiveSummary;
+  network: EvChargingNetworkSummary;
+  /** DC per-kWh extremes; `null` when no DC rate is advertised. */
+  cheapestDc: EvChargingRateStat | null;
+  priciestDc: EvChargingRateStat | null;
+}
+
+/**
+ * Where a rate is charged: the operator and district when one location has
+ * it, otherwise how many share it.
+ */
+function describeRate(locations: EvChargingPricedLocation[]): string | null {
+  const leader = locations[0];
+  if (!leader) {
+    return null;
+  }
+
+  const atRate = locations.filter(
+    (location) => location.pricePerKwh === leader.pricePerKwh,
+  );
+  if (atRate.length > 1) {
+    return `${atRate.length} locations at this rate`;
+  }
+
+  return [leader.operator, districtForPostalCode(leader.postalCode)?.name]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+async function rateStat(order: PriceOrder): Promise<EvChargingRateStat | null> {
+  const locations = await getEvChargingPriceRankings({
+    limit: Number.MAX_SAFE_INTEGER,
+    order,
+    powerRating: "DC",
+  });
+  const leader = locations[0];
+  if (!leader) {
+    return null;
+  }
+
+  return {
+    pricePerKwh: leader.pricePerKwh,
+    description: describeRate(locations),
+  };
+}
+
+/**
+ * The handful of figures the homepage shows for public charging, reduced
+ * from the full connector snapshot and cached as their own small entry.
+ *
+ * The homepage renders per request, and the snapshot behind these numbers is
+ * every connector in Singapore, several megabytes in the Data Cache. Reading
+ * it into the function on every visit was the bulk of the site's origin
+ * transfer, so the reduction happens once per cache life here and the page
+ * reads a few hundred bytes instead.
+ */
+export async function getEvChargingOverview(): Promise<EvChargingOverview> {
+  "use cache: remote";
+  cacheLife("hours");
+
+  const [live, network, cheapestDc, priciestDc] = await Promise.all([
+    getEvChargingLiveSummary(),
+    getEvChargingNetworkSummary(),
+    rateStat("cheapest"),
+    rateStat("priciest"),
+  ]);
+
+  return { live, network, cheapestDc, priciestDc };
+}


### PR DESCRIPTION
- Add \`getEvChargingOverview\`, a \`use cache: remote\` query on the \`hours\` profile that reduces the connector snapshot to the four figures the homepage shows: live connector state, network counts, and the cheapest and priciest DC rate with its description
- The homepage renders per request, and its EV section called three uncached helpers that each read the full snapshot, every public connector in Singapore at several megabytes, out of the Data Cache into the function on every visit; Data Cache reads count as Fast Origin Transfer, which is where the ~1 GB/day rise since Sep 5 comes from
- The section now reads a few hundred bytes per request; the rate description logic moves from the component into the query so the RSC payload carries only the rendered values
- Adds unit tests for the reduction; the charging page still reads the snapshot directly and is the follow-up

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791642511&installation_model_id=21947&pr_number=1061&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1061&signature=5191448f4b3abb05aecafc3c8b8ec9bd09214e971de16a5b22f8f17ec0f39e70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->