### PR TITLE
Prerender the charging map and cache the snapshot readers

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map-view.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map-view.tsx
@@ -6,11 +6,12 @@ import { Segment } from "@heroui-pro/react";
 import { Map, type MapClusterLayerProps, useMap } from "@heroui-pro/react/map";
 import { siteParam } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/search-params";
 import { describeConnectors } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/utils/describe-connectors";
+import { getPostalDistrict } from "@web/config/postal-districts";
 import { inDistrict } from "@web/queries/ev-charging/locations";
 import type { EvChargingMapSite } from "@web/queries/ev-charging/map-sites";
 import type { FeatureCollection, Point } from "geojson";
 import { type LngLatBoundsLike, setWorkerUrl } from "maplibre-gl";
-import { useQueryState } from "nuqs";
+import { parseAsString, useQueryState } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 setWorkerUrl("/maplibre/maplibre-gl-worker.mjs");
@@ -321,13 +322,9 @@ function SiteFocus({
   return null;
 }
 
-export function ChargingMapView({
-  district,
-  sites,
-}: {
-  district: string;
-  sites: EvChargingMapSite[];
-}) {
+export function ChargingMapView({ sites }: { sites: EvChargingMapSite[] }) {
+  const [district] = useQueryState("district", parseAsString.withDefault(""));
+  const scope = getPostalDistrict(district)?.name ?? "Singapore";
   const [tokens, setTokens] = useState<MapTokens | null>(null);
   const [mode, setMode] = useState<MapMode>("availability");
   const [selected, setSelected] = useState<SelectedSite | null>(null);
@@ -371,6 +368,13 @@ export function ChargingMapView({
 
   return (
     <>
+      <div className="flex flex-col gap-1">
+        <Typography.Paragraph className="text-muted">
+          Live availability by site
+        </Typography.Paragraph>
+        <Typography.Heading level={3}>Chargers in {scope}</Typography.Heading>
+      </div>
+
       <Segment
         aria-label="Map view"
         className="w-fit"

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map.tsx
@@ -1,29 +1,26 @@
-import { Typography } from "@heroui/react";
 import { MAP_ANCHOR_ID } from "@web/app/(main)/(dashboard)/cars/electric-vehicles/charging/search-params";
 import { SurfaceCard } from "@web/components/shared/bento";
-import { getPostalDistrict } from "@web/config/postal-districts";
 import { getEvChargingMapSites } from "@web/queries/ev-charging";
 import { ChargingMapView } from "./charging-map-view";
 
-/** Every public charging site on a map, coloured by live availability. */
-export async function ChargingMap({ district }: { district: string }) {
+/**
+ * Every public charging site on a map, coloured by live availability.
+ *
+ * Reads no search params: the district filter is applied on the client, so
+ * this card prerenders into the static shell with the cached site list and
+ * costs nothing per request. Reading the district here would put a 2 MB
+ * payload into every visit.
+ */
+export async function ChargingMap() {
   const sites = await getEvChargingMapSites();
   if (sites.length === 0) {
     return null;
   }
-  const scope = getPostalDistrict(district)?.name ?? "Singapore";
 
   return (
     <div className="scroll-mt-6" id={MAP_ANCHOR_ID}>
       <SurfaceCard className="gap-4 p-7">
-        <div className="flex flex-col gap-1">
-          <Typography.Paragraph className="text-muted">
-            Live availability by site
-          </Typography.Paragraph>
-          <Typography.Heading level={3}>Chargers in {scope}</Typography.Heading>
-        </div>
-
-        <ChargingMapView district={district} sites={sites} />
+        <ChargingMapView sites={sites} />
       </SurfaceCard>
     </div>
   );

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/page.tsx
@@ -118,7 +118,7 @@ export default function ChargingPage({ searchParams }: PageProps) {
       <AnimatedSection order={0}>
         <SectionErrorBoundary title="Charger map unavailable">
           <Suspense fallback={<CardSkeleton className="h-[600px]" />}>
-            <ChargingMapSection searchParams={searchParams} />
+            <ChargingMap />
           </Suspense>
         </SectionErrorBoundary>
       </AnimatedSection>
@@ -145,11 +145,6 @@ export default function ChargingPage({ searchParams }: PageProps) {
 async function DistrictControl({ searchParams }: PageProps) {
   const { district } = await loadSearchParams(searchParams);
   return <DistrictSelect district={district} />;
-}
-
-async function ChargingMapSection({ searchParams }: PageProps) {
-  const { district } = await loadSearchParams(searchParams);
-  return <ChargingMap district={district} />;
 }
 
 async function ChargingBento({ searchParams }: PageProps) {

--- a/apps/web/src/queries/ev-charging/live-summary.test.ts
+++ b/apps/web/src/queries/ev-charging/live-summary.test.ts
@@ -1,5 +1,6 @@
 vi.mock("./snapshot", () => ({ getEvChargingSnapshot: vi.fn() }));
 
+import "../test-utils";
 import { connector } from "./fixtures";
 import { getEvChargingLiveSummary } from "./live-summary";
 import { getEvChargingSnapshot } from "./snapshot";

--- a/apps/web/src/queries/ev-charging/live-summary.ts
+++ b/apps/web/src/queries/ev-charging/live-summary.ts
@@ -1,3 +1,4 @@
+import { cacheLife } from "next/cache";
 import { inDistrict } from "./locations";
 import { getEvChargingSnapshot } from "./snapshot";
 
@@ -15,6 +16,9 @@ export interface EvChargingLiveSummary {
 export async function getEvChargingLiveSummary(
   district?: string,
 ): Promise<EvChargingLiveSummary> {
+  "use cache: remote";
+  cacheLife("hours");
+
   const { observedAt, records } = await getEvChargingSnapshot();
   const summary: EvChargingLiveSummary = {
     connectors: 0,

--- a/apps/web/src/queries/ev-charging/map-sites.test.ts
+++ b/apps/web/src/queries/ev-charging/map-sites.test.ts
@@ -1,3 +1,4 @@
+import "../test-utils";
 import { connector } from "./fixtures";
 import { getEvChargingLocationUtilisation } from "./location-utilisation";
 import { getEvChargingMapSites } from "./map-sites";

--- a/apps/web/src/queries/ev-charging/map-sites.ts
+++ b/apps/web/src/queries/ev-charging/map-sites.ts
@@ -1,3 +1,4 @@
+import { cacheLife } from "next/cache";
 import { getEvChargingLocationUtilisation } from "./location-utilisation";
 import { type EvChargingLocation, groupLocations } from "./locations";
 import { getEvChargingSnapshot } from "./snapshot";
@@ -27,6 +28,9 @@ interface SiteExtras {
  * Locations without coordinates are dropped rather than guessed at.
  */
 export async function getEvChargingMapSites(): Promise<EvChargingMapSite[]> {
+  "use cache: remote";
+  cacheLife("hours");
+
   const [{ records }, utilisation] = await Promise.all([
     getEvChargingSnapshot(),
     getEvChargingLocationUtilisation({ order: "busiest", limit: 10_000 }),

--- a/apps/web/src/queries/ev-charging/price-rankings.test.ts
+++ b/apps/web/src/queries/ev-charging/price-rankings.test.ts
@@ -1,5 +1,6 @@
 vi.mock("./snapshot", () => ({ getEvChargingSnapshot: vi.fn() }));
 
+import "../test-utils";
 import { connector } from "./fixtures";
 import { getEvChargingPriceRankings } from "./price-rankings";
 import { getEvChargingSnapshot } from "./snapshot";

--- a/apps/web/src/queries/ev-charging/price-rankings.ts
+++ b/apps/web/src/queries/ev-charging/price-rankings.ts
@@ -1,3 +1,4 @@
+import { cacheLife } from "next/cache";
 import {
   type EvChargingLocation,
   groupLocations,
@@ -35,6 +36,9 @@ export async function getEvChargingPriceRankings({
   district,
   limit = 10,
 }: PriceRankingOptions): Promise<EvChargingPricedLocation[]> {
+  "use cache: remote";
+  cacheLife("hours");
+
   const { records } = await getEvChargingSnapshot();
   const matching = records.filter(
     (record) =>


### PR DESCRIPTION
- Move the district filter for the charging map to the client: the map card no longer reads search params, so it prerenders into the static shell with the cached site list instead of streaming a 2.5 MB payload from a function on every visit and every district or power change
- The map view reads \`district\` with nuqs and owns the "Chargers in …" heading; behaviour on the page is unchanged
- Put \`getEvChargingMapSites\`, \`getEvChargingLiveSummary\`, and \`getEvChargingPriceRankings\` behind \`use cache: remote\` on the \`hours\` profile, keyed by their arguments, so the live status and price lists read a district-sized entry per request instead of pulling the full connector snapshot out of the Data Cache
- Production today serialises all 2,755 sites twice per view (5,550 \`locationId\` occurrences, 2.51 MB raw); with the card in the shell that payload is served by the CDN and regenerated hourly
- Tests for the three queries now load the shared cache mock; 36 tests pass across the charging queries and page

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791643307&installation_model_id=21947&pr_number=1062&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1062&signature=8933f94d0350ecbf00b8fe6319618832fa48c85a9fc99d6518b7aef6dea344f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->