### PR TITLE
Checksum ZIP bytes before extraction

### DIFF
--- a/apps/web/src/lib/updater/calculate-checksum.test.ts
+++ b/apps/web/src/lib/updater/calculate-checksum.test.ts
@@ -1,7 +1,10 @@
 import crypto from "node:crypto";
 import { unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { calculateChecksum } from "@web/lib/updater/services/calculate-checksum";
+import {
+  calculateBufferChecksum,
+  calculateChecksum,
+} from "@web/lib/updater/services/calculate-checksum";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("calculateChecksum", () => {
@@ -57,5 +60,15 @@ describe("calculateChecksum", () => {
       crypto.createHash("sha256").update(largeContent).digest("hex"),
     );
     expect(duration).toBeLessThan(1000); // Should complete in less than a second
+  });
+});
+
+describe("calculateBufferChecksum", () => {
+  it("should match the SHA-256 of the buffer contents", () => {
+    const buffer = Buffer.from("Hello, world!");
+
+    expect(calculateBufferChecksum(buffer)).toBe(
+      crypto.createHash("sha256").update(buffer).digest("hex"),
+    );
   });
 });

--- a/apps/web/src/lib/updater/download-file.test.ts
+++ b/apps/web/src/lib/updater/download-file.test.ts
@@ -1,4 +1,8 @@
-import { fetchAndExtractZip } from "@web/lib/updater/services/download-file";
+import {
+  extractZip,
+  fetchAndExtractZip,
+  fetchZipBuffer,
+} from "@web/lib/updater/services/download-file";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@web/config/workflow", () => ({
@@ -36,6 +40,38 @@ vi.mock("adm-zip", () => {
       }
     },
   };
+});
+
+describe("fetchZipBuffer", () => {
+  const mockUrl = "https://example.com/test.zip";
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should return the response body as a Buffer", async () => {
+    const bytes = new TextEncoder().encode("zip-bytes");
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(bytes.buffer),
+    } as unknown as Response);
+
+    const result = await fetchZipBuffer(mockUrl);
+
+    expect(global.fetch).toHaveBeenCalledWith(mockUrl);
+    expect(Buffer.isBuffer(result)).toBe(true);
+    expect(result.toString()).toBe("zip-bytes");
+  });
+});
+
+describe("extractZip", () => {
+  it("should extract files and skip directories", () => {
+    const result = extractZip(Buffer.alloc(0));
+
+    expect(result.size).toBe(2);
+    expect(result.get("test.csv")).toBe("/tmp/test.csv");
+    expect(result.has("folder/")).toBe(false);
+  });
 });
 
 describe("fetchAndExtractZip", () => {

--- a/apps/web/src/lib/updater/services/calculate-checksum.ts
+++ b/apps/web/src/lib/updater/services/calculate-checksum.ts
@@ -22,6 +22,12 @@ import { pipeline } from "node:stream/promises";
  * }
  * ```
  */
+/**
+ * Calculates the SHA-256 checksum of an in-memory buffer.
+ */
+export const calculateBufferChecksum = (buffer: Buffer): string =>
+  createHash("sha256").update(buffer).digest("hex");
+
 export const calculateChecksum = async (filePath: string): Promise<string> => {
   const hash = createHash("sha256");
   const fileStream = createReadStream(filePath);

--- a/apps/web/src/lib/updater/services/download-file.ts
+++ b/apps/web/src/lib/updater/services/download-file.ts
@@ -3,14 +3,9 @@ import { WORKFLOW_TEMP_DIR } from "@web/config/workflow";
 import AdmZip from "adm-zip";
 
 /**
- * Downloads a ZIP archive and extracts every file into the workflow temp
- * directory.
- *
- * @returns Map of file basename to its extracted absolute path
+ * Downloads a ZIP archive and returns its raw bytes.
  */
-export async function fetchAndExtractZip(
-  url: string,
-): Promise<Map<string, string>> {
+export async function fetchZipBuffer(url: string): Promise<Buffer> {
   const response = await fetch(url);
 
   if (!response.ok) {
@@ -25,8 +20,16 @@ export async function fetchAndExtractZip(
     throw new Error(`HTTP error! status: ${response.status}`);
   }
 
-  const arrayBuffer = await response.arrayBuffer();
-  const zip = new AdmZip(Buffer.from(arrayBuffer));
+  return Buffer.from(await response.arrayBuffer());
+}
+
+/**
+ * Extracts every file in a ZIP buffer into the workflow temp directory.
+ *
+ * @returns Map of file basename to its extracted absolute path
+ */
+export function extractZip(buffer: Buffer): Map<string, string> {
+  const zip = new AdmZip(buffer);
   const extracted = new Map<string, string>();
 
   for (const entry of zip.getEntries()) {
@@ -41,4 +44,16 @@ export async function fetchAndExtractZip(
   }
 
   return extracted;
+}
+
+/**
+ * Downloads a ZIP archive and extracts every file into the workflow temp
+ * directory.
+ *
+ * @returns Map of file basename to its extracted absolute path
+ */
+export async function fetchAndExtractZip(
+  url: string,
+): Promise<Map<string, string>> {
+  return extractZip(await fetchZipBuffer(url));
 }

--- a/apps/web/src/lib/updater/updater.test.ts
+++ b/apps/web/src/lib/updater/updater.test.ts
@@ -4,8 +4,14 @@ import {
   type UpdaterOptions,
   update,
 } from "@web/lib/updater";
-import { calculateChecksum } from "@web/lib/updater/services/calculate-checksum";
-import { fetchAndExtractZip } from "@web/lib/updater/services/download-file";
+import {
+  calculateBufferChecksum,
+  calculateChecksum,
+} from "@web/lib/updater/services/calculate-checksum";
+import {
+  extractZip,
+  fetchZipBuffer,
+} from "@web/lib/updater/services/download-file";
 import { processCsv } from "@web/lib/updater/services/process-csv";
 import type { Checksum } from "@web/utils/checksum";
 import type { PgTable } from "drizzle-orm/pg-core";
@@ -86,9 +92,11 @@ describe("update", () => {
     };
 
     // Default mock implementations
-    vi.mocked(fetchAndExtractZip).mockResolvedValue(
+    vi.mocked(fetchZipBuffer).mockResolvedValue(Buffer.from("zip-bytes"));
+    vi.mocked(extractZip).mockReturnValue(
       new Map([["test-file.csv", "/tmp/test-file.csv"]]),
     );
+    vi.mocked(calculateBufferChecksum).mockReturnValue("abc123");
     vi.mocked(calculateChecksum).mockResolvedValue("abc123");
     vi.mocked(processCsv).mockResolvedValue(mockData);
 
@@ -116,12 +124,14 @@ describe("update", () => {
       timestamp: expect.any(String),
     });
 
-    expect(fetchAndExtractZip).toHaveBeenCalledWith(
-      "https://example.com/data.zip",
+    expect(fetchZipBuffer).toHaveBeenCalledWith("https://example.com/data.zip");
+    expect(calculateBufferChecksum).toHaveBeenCalledWith(
+      Buffer.from("zip-bytes"),
     );
-    expect(calculateChecksum).toHaveBeenCalledWith("/tmp/test-file.csv");
+    expect(extractZip).toHaveBeenCalledWith(Buffer.from("zip-bytes"));
+    expect(calculateChecksum).not.toHaveBeenCalled();
     expect(mockChecksum.cacheChecksum).toHaveBeenCalledWith(
-      "test-file.csv",
+      "data.zip",
       "abc123",
     );
   });
@@ -138,6 +148,7 @@ describe("update", () => {
       timestamp: expect.any(String),
     });
 
+    expect(extractZip).not.toHaveBeenCalled();
     expect(processCsv).not.toHaveBeenCalled();
     expect(db.insert).not.toHaveBeenCalled();
   });
@@ -178,7 +189,7 @@ describe("update", () => {
     await update(updaterConfig, updaterOptions);
 
     expect(mockChecksum.cacheChecksum).toHaveBeenCalledWith(
-      "test-file.csv",
+      "data.zip",
       "abc123",
     );
   });
@@ -255,7 +266,8 @@ describe("update", () => {
   });
 
   it("should throw when the ZIP contains no files", async () => {
-    vi.mocked(fetchAndExtractZip).mockResolvedValue(new Map());
+    vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue(null);
+    vi.mocked(extractZip).mockReturnValue(new Map());
 
     await expect(update(updaterConfig, updaterOptions)).rejects.toThrow(
       "No files found in ZIP",
@@ -263,9 +275,7 @@ describe("update", () => {
   });
 
   it("should propagate errors from download", async () => {
-    vi.mocked(fetchAndExtractZip).mockRejectedValue(
-      new Error("Download failed"),
-    );
+    vi.mocked(fetchZipBuffer).mockRejectedValue(new Error("Download failed"));
 
     await expect(update(updaterConfig, updaterOptions)).rejects.toThrow(
       "Download failed",
@@ -283,7 +293,8 @@ describe("update", () => {
 
     await update(configWithFilePath, updaterOptions);
 
-    expect(fetchAndExtractZip).not.toHaveBeenCalled();
+    expect(fetchZipBuffer).not.toHaveBeenCalled();
+    expect(extractZip).not.toHaveBeenCalled();
     expect(calculateChecksum).toHaveBeenCalledWith("/tmp/pre-extracted.csv");
     expect(mockChecksum.cacheChecksum).toHaveBeenCalledWith(
       "pre-extracted.csv",

--- a/apps/web/src/lib/updater/updater.ts
+++ b/apps/web/src/lib/updater/updater.ts
@@ -1,7 +1,13 @@
 import path from "node:path";
 import { db } from "@motormetrics/database/client";
-import { calculateChecksum } from "@web/lib/updater/services/calculate-checksum";
-import { fetchAndExtractZip } from "@web/lib/updater/services/download-file";
+import {
+  calculateBufferChecksum,
+  calculateChecksum,
+} from "@web/lib/updater/services/calculate-checksum";
+import {
+  extractZip,
+  fetchZipBuffer,
+} from "@web/lib/updater/services/download-file";
 import {
   type CSVTransformOptions,
   processCsv,
@@ -49,21 +55,30 @@ export async function update<T>(
   const tableName = getTableName(table);
 
   // === Download and verify ===
-  let destinationPath: string;
-  if (config.url === undefined) {
-    destinationPath = config.filePath;
-  } else {
-    const extractedFiles = await fetchAndExtractZip(config.url);
-    const [firstFile] = extractedFiles.values();
-    if (!firstFile) {
-      throw new Error(`No files found in ZIP at ${config.url}`);
-    }
-    destinationPath = firstFile;
-  }
-  console.log("Destination path:", destinationPath);
+  // For URL sources, hash the raw ZIP bytes and compare before extracting so
+  // unchanged runs skip extraction, parsing and database work entirely.
+  let checksumKey: string;
+  let checksum: string;
+  let resolveCsvPath: () => string;
 
-  const checksumKey = path.basename(destinationPath);
-  const checksum = await calculateChecksum(destinationPath);
+  if (config.url === undefined) {
+    const { filePath } = config;
+    checksumKey = path.basename(filePath);
+    checksum = await calculateChecksum(filePath);
+    resolveCsvPath = () => filePath;
+  } else {
+    const { url } = config;
+    const zipBuffer = await fetchZipBuffer(url);
+    checksumKey = path.basename(new URL(url).pathname);
+    checksum = calculateBufferChecksum(zipBuffer);
+    resolveCsvPath = () => {
+      const [firstFile] = extractZip(zipBuffer).values();
+      if (!firstFile) {
+        throw new Error(`No files found in ZIP at ${url}`);
+      }
+      return firstFile;
+    };
+  }
   console.log("Checksum:", checksum);
 
   const cachedChecksum = await checksumService.getCachedChecksum(checksumKey);
@@ -84,6 +99,9 @@ export async function update<T>(
   } else {
     console.log("Checksum has been changed.");
   }
+
+  const destinationPath = resolveCsvPath();
+  console.log("Destination path:", destinationPath);
 
   // === Process CSV ===
   const processedData = await processCsv<T>(


### PR DESCRIPTION
- Hash the raw ZIP buffer and compare it against Redis before extracting, so unchanged daily runs skip extraction, CSV parsing and the database round-trip
- Split the downloader into `fetchZipBuffer` and `extractZip`; `fetchAndExtractZip` stays as a wrapper so the COE step is unchanged
- Key URL-sourced checksums by the ZIP basename; each table reprocesses once after deploy, which is safe because inserts are idempotent

Closes #731

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791655174&installation_model_id=21947&pr_number=1065&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1065&signature=d723628683a13964a3f2daae07fda6db5135951196831b6209d40166c81696a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->