### PR TITLE
Mock Sentry in the error boundary tests

### DIFF
--- a/apps/web/src/app/error.test.tsx
+++ b/apps/web/src/app/error.test.tsx
@@ -1,6 +1,11 @@
+import * as Sentry from "@sentry/nextjs";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AppError from "./error";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
 
 vi.mock("@heroui/react", async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
@@ -43,7 +48,7 @@ describe("AppError", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("Error ID: abc123")).toBeInTheDocument();
-    expect(console.error).toHaveBeenCalledWith(error);
+    expect(Sentry.captureException).toHaveBeenCalledWith(error);
   });
 
   it("should omit the error id when digest is missing", () => {

--- a/apps/web/src/app/global-error.test.tsx
+++ b/apps/web/src/app/global-error.test.tsx
@@ -1,6 +1,11 @@
+import * as Sentry from "@sentry/nextjs";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import GlobalError from "./global-error";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
 
 vi.mock("next/font/google", () => ({
   Geist: () => ({ className: "mock-geist" }),
@@ -24,7 +29,7 @@ describe("GlobalError", () => {
       screen.getByText("A critical error occurred. Please try again."),
     ).toBeInTheDocument();
     expect(screen.getByText("Error ID: xyz789")).toBeInTheDocument();
-    expect(console.error).toHaveBeenCalledWith(error);
+    expect(Sentry.captureException).toHaveBeenCalledWith(error);
   });
 
   it("should omit the error id when digest is missing", () => {


### PR DESCRIPTION
- Mock `@sentry/nextjs` in `error.test.tsx` and `global-error.test.tsx`; loading the real module under Vitest crashes in its bundler plugin, which has failed the web test job on every PR since #1064 merged
- Assert `captureException` is called with the error, replacing the stale `console.error` assertion the boundaries no longer satisfy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791659535&installation_model_id=21947&pr_number=1066&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1066&signature=a02e4b5e7a51564713f8f76e2bb549ad86ba0e94777022c4a9c3bf5224a10432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->