### PR TITLE
Stop Sentry attaching the V8 inspector on every cold start

### DIFF
--- a/apps/web/src/sentry.server.config.ts
+++ b/apps/web/src/sentry.server.config.ts
@@ -7,6 +7,8 @@ export const sentryClient = Sentry.init({
   environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
   skipOpenTelemetrySetup: true,
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
-  includeLocalVariables: true,
+  // Local variable capture attaches the V8 inspector on every cold start
+  // (the "Debugger listening on ws://" log lines), which costs CPU on
+  // Fluid Compute — left off.
   enableLogs: true,
 });


### PR DESCRIPTION
- Drop `includeLocalVariables` from the Sentry server config; it attaches the V8 inspector on each cold start (the "Debugger listening on ws://" runtime log lines) and adds CPU on Fluid Compute
- Error capture and tracing are unchanged; only local-variable capture on exception frames is lost

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791724716&installation_model_id=21947&pr_number=1069&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1069&signature=aa1e181b6cd6a4d1c8c4290ecf676383a87be00a9881d7b132e080811c865791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->