### PR TITLE
Render the nav and footer statically instead of via request-time flags

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -213,7 +213,8 @@ Web-specific variables (see root `CLAUDE.md` for the cross-cutting ones):
   (`src/flags.ts`). Both are set per environment on Vercel; run `vercel env pull` to sync locally.
   Without them, flags fall back to their `defaultValue` (`false`). Toggle independently in preview vs
   production via the dashboard or `vercel flags enable|disable --environment`. Keys:
-  `advertise-page`, `advertise-nav`, `blog-nav`, `blog-popular-posts`
+  `advertise-page`, `blog-popular-posts`. (`advertise-nav` and `blog-nav` were removed: they were
+  read at request time in the main layout, which pulled every page out of the static shell.)
 - `QSTASH_TOKEN` / `QSTASH_CURRENT_SIGNING_KEY` / `QSTASH_NEXT_SIGNING_KEY`: Upstash QStash. The
   five-minute `ev-charging-live` schedule lives in QStash, not `vercel.ts` crons; it forwards
   `CRON_SECRET` as the bearer token so the route needs no QStash-specific verification

--- a/apps/web/src/app/(main)/layout.tsx
+++ b/apps/web/src/app/(main)/layout.tsx
@@ -4,21 +4,15 @@ import { Banner } from "@web/components/banner";
 import { Footer } from "@web/components/footer";
 import { NotificationPrompt } from "@web/components/notification-prompt";
 import { SurveyPrompt } from "@web/components/survey-prompt";
-import { advertiseNav, blogNav } from "@web/flags";
 import { footerNavItems, moreNavItems } from "@web/utils/flagged-nav";
-import { type ReactNode, Suspense } from "react";
+import type { ReactNode } from "react";
 
-async function FlaggedAppNav() {
-  const [advertise, blog] = await Promise.all([advertiseNav(), blogNav()]);
-
-  return <AppNav moreNavItems={moreNavItems({ advertise, blog })} />;
-}
-
-async function FlaggedFooter() {
-  const advertise = await advertiseNav();
-
-  return <Footer navItems={footerNavItems({ advertise })} />;
-}
+// advertise-nav and blog-nav previously gated these items per request via
+// the Flags SDK, which reads request headers and pulled every page out of
+// the static shell. The flags provider work is parked (#1019), so this
+// renders the declared defaultValue (false) statically instead.
+const moreItems = moreNavItems({ advertise: false, blog: false });
+const footerItems = footerNavItems({ advertise: false });
 
 export default function MainLayout({
   children,
@@ -36,13 +30,9 @@ export default function MainLayout({
         the content beneath them, and the two bars above use the same measure.
       */}
       <div className="mx-auto flex min-h-screen w-full max-w-page flex-col gap-8 px-4 py-8 sm:px-6 lg:px-9 lg:py-9">
-        <Suspense fallback={<AppNav />}>
-          <FlaggedAppNav />
-        </Suspense>
+        <AppNav moreNavItems={moreItems} />
         <main className="flex flex-1 flex-col gap-8">{children}</main>
-        <Suspense fallback={<Footer />}>
-          <FlaggedFooter />
-        </Suspense>
+        <Footer navItems={footerItems} />
       </div>
     </div>
   );

--- a/apps/web/src/flags.ts
+++ b/apps/web/src/flags.ts
@@ -8,20 +8,6 @@ export const advertisePage = flag<boolean>({
   adapter: vercelAdapter(),
 });
 
-/** Advertise in More menu and footer. Independent of advertise-page. */
-export const advertiseNav = flag<boolean>({
-  key: "advertise-nav",
-  defaultValue: false,
-  adapter: vercelAdapter(),
-});
-
-/** Blog in the More menu. The /blog route stays live either way. */
-export const blogNav = flag<boolean>({
-  key: "blog-nav",
-  defaultValue: false,
-  adapter: vercelAdapter(),
-});
-
 /** Popular posts on blog pages. */
 export const blogPopularPosts = flag<boolean>({
   key: "blog-popular-posts",


### PR DESCRIPTION
- Drop the `advertise-nav` and `blog-nav` flag reads from the main layout; the Flags SDK reads request headers, so every page (even `/about`) was a partial prerender that resumed in a function on each request
- Render `AppNav` and `Footer` with the flags' declared defaults (both are Off in production and preview today), and remove the two unused flag declarations
- The flags provider work stays parked on #1019

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791724762&installation_model_id=21947&pr_number=1070&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1070&signature=6aa91d79647aaf36eb6bb550ecbd72b1e4f2601923e88638b3b2013ec486098c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->