### PR TITLE
Prerender the homepage data sections into the static shell

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -32,7 +32,16 @@ granular cache tags (e.g. `cars:month:2024-01`, `coe:period:12m`). The custom "m
 **Why `remote`, not plain `"use cache"`**: at request time, plain `"use cache"` stores entries in a per-instance
 in-memory handler, which never persists across serverless invocations. Every request outside the static shell
 (anything reading `searchParams`) re-ran every query against Neon. `"use cache: remote"` writes to the shared
-Vercel Data Cache instead, while still prerendering into the static shell where possible.
+Vercel Data Cache instead. Note that `"use cache: remote"` is runtime-only — it is never captured into the
+build-time static shell, unlike plain `"use cache"`.
+
+**Prerendering the static pages**: pages that don't read `searchParams` (the homepage, in particular) wrap their
+data-rendering server components in an outer `"use cache"` with the same `cacheLife("max")` and the union of the
+inner query functions' cache tags (so existing `revalidateTag()` calls still invalidate them). Nesting a
+`"use cache: remote"` call inside a `"use cache"` function is valid, and — because nothing in that call chain reads
+`searchParams`/`cookies()`/`headers()` — the whole result gets computed and baked into the static shell at build
+time, so a cache hit is served straight from the CDN with no function invocation at all. Query functions reused by
+`searchParams`-driven pages keep their `"use cache: remote"` directive unchanged.
 
 **Why "max" (30-day stale/revalidate, 1-year expire)**: data updates monthly, so this yields ~2 regenerations/month
 (1 automatic + 1 on-demand) versus ~30 with daily checks — roughly **15x less** Vercel Fluid Compute. Do not shorten

--- a/apps/web/src/app/(main)/(dashboard)/components/coe-section.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/coe-section.tsx
@@ -17,6 +17,7 @@ import {
 import { SectionHead } from "@web/components/shared/overview";
 import { getAllCoeCategoryTrends, getPqpRates } from "@web/queries/coe";
 import { getLatestMonth } from "@web/utils/dates/months";
+import { cacheLife, cacheTag } from "next/cache";
 
 /** Bidding months drawn in the premium trend, the selected one last. */
 const TREND_MONTHS = 12;
@@ -36,8 +37,13 @@ const CATEGORY_NAMES: Record<string, string> = {
  * one before are merged to give a full 12-exercise run-up to any month.
  */
 export async function CoeSection() {
+  "use cache";
+  cacheLife("max");
+  cacheTag("cars:months", "coe:trends", "coe:pqp");
+
   const month = await getLatestMonth("cars");
   const year = Number(month.slice(0, 4));
+  cacheTag(`coe:year:${year - 1}`, `coe:year:${year}`);
   const [previousYearTrends, currentYearTrends, pqpRates] = await Promise.all([
     getAllCoeCategoryTrends(year - 1),
     getAllCoeCategoryTrends(year),

--- a/apps/web/src/app/(main)/(dashboard)/components/deregistrations-headline.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/deregistrations-headline.tsx
@@ -13,6 +13,7 @@ import { DeltaChip } from "@web/components/shared/delta-chip";
 import { Headline, SectionLink } from "@web/components/shared/overview";
 import { getDeregistrations } from "@web/queries/deregistrations";
 import { getLatestMonth } from "@web/utils/dates/months";
+import { cacheLife, cacheTag } from "next/cache";
 
 /** Months drawn in the column chart, the selected one last. */
 const CHART_MONTHS = 8;
@@ -31,6 +32,10 @@ const formatTick = (month: string) => {
  * at the newest month at or before the selection and the caption names it.
  */
 export async function DeregistrationsHeadline() {
+  "use cache";
+  cacheLife("max");
+  cacheTag("cars:months", "deregistrations:months");
+
   const month = await getLatestMonth("cars");
   const rows = await getDeregistrations();
   const series = windowEndingAt(sumByMonth(rows), month, CHART_MONTHS);

--- a/apps/web/src/app/(main)/(dashboard)/components/ev-charging.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/ev-charging.tsx
@@ -1,7 +1,9 @@
 import { Typography } from "@heroui/react";
 import { NumberValue } from "@heroui-pro/react";
 import { SectionHead } from "@web/components/shared/overview";
+import { EV_CHARGING_CACHE_TAG } from "@web/lib/cache-tags";
 import { getEvChargingNetworkSummary } from "@web/queries/ev-charging";
+import { cacheLife, cacheTag } from "next/cache";
 
 const LINK = {
   href: "/cars/electric-vehicles/charging",
@@ -14,6 +16,10 @@ const LINK = {
  * homepage carries nothing that would regenerate its shell that often.
  */
 export async function EvCharging() {
+  "use cache";
+  cacheLife("max");
+  cacheTag(EV_CHARGING_CACHE_TAG);
+
   const network = await getEvChargingNetworkSummary();
 
   if (network.connectors === 0) {

--- a/apps/web/src/app/(main)/(dashboard)/components/ev-momentum.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/ev-momentum.tsx
@@ -11,10 +11,12 @@ import { DeltaChip } from "@web/components/shared/delta-chip";
 import { MakeAvatar } from "@web/components/shared/make-avatar";
 import { Headline, SectionHead } from "@web/components/shared/overview";
 import { SparklineChart } from "@web/components/shared/sparkline-chart";
+import { LOGOS_CACHE_TAG } from "@web/lib/cache-tags";
 import { getEvMarketShare, getEvMonthlyTrend } from "@web/queries/cars";
 import { getTopMakesByFuelType } from "@web/queries/cars/market-insights";
 import { getAllCarLogos } from "@web/queries/logos";
 import { getLatestMonth } from "@web/utils/dates/months";
+import { cacheLife, cacheTag } from "next/cache";
 
 /** Months of share history drawn under the figure. */
 const SPARK_MONTHS = 12;
@@ -33,7 +35,17 @@ const formatMonthName = (month: string) => {
  * the section links to.
  */
 export async function EvMomentum() {
+  "use cache";
+  cacheLife("max");
+  cacheTag(
+    "cars:months",
+    "cars:fuel:electric",
+    "cars:fuel:hybrid",
+    LOGOS_CACHE_TAG,
+  );
+
   const month = await getLatestMonth("cars");
+  cacheTag(`cars:month:${month}`);
   const [trend, marketShare, fuelTypes, logoResult] = await Promise.all([
     getEvMonthlyTrend(),
     getEvMarketShare(),

--- a/apps/web/src/app/(main)/(dashboard)/components/fuel-mix.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/fuel-mix.tsx
@@ -4,6 +4,7 @@ import { donutArcs } from "@web/app/(main)/(dashboard)/components/overview-serie
 import { SectionHead } from "@web/components/shared/overview";
 import { getYearToDateByFuelType } from "@web/queries/cars";
 import { getLatestMonth } from "@web/utils/dates/months";
+import { cacheLife, cacheTag } from "next/cache";
 
 const RADIUS = 74;
 /** Arc length removed from each segment so the rounded caps read as separate. */
@@ -41,8 +42,13 @@ const OTHER = { color: "var(--chart-6)", label: "Other" };
 
 /** Registrations by powertrain for the selected month's year. */
 export async function FuelMix() {
+  "use cache";
+  cacheLife("max");
+  cacheTag("cars:months");
+
   const month = await getLatestMonth("cars");
   const year = Number(month.slice(0, 4));
+  cacheTag(`cars:year:${year}`);
   const fuelTypes = await getYearToDateByFuelType(year);
 
   const total = fuelTypes.reduce((sum, item) => sum + item.count, 0);

--- a/apps/web/src/app/(main)/(dashboard)/components/registrations-headline.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/registrations-headline.tsx
@@ -10,6 +10,7 @@ import { SparklineChart } from "@web/components/shared/sparkline-chart";
 import { getMonthlyRegistrationTotals } from "@web/queries/cars";
 import { getVehiclePopulationYearlyTotals } from "@web/queries/vehicle-population";
 import { getLatestMonth } from "@web/utils/dates/months";
+import { cacheLife, cacheTag } from "next/cache";
 
 /**
  * Deep enough to reach the oldest month the picker offers, so selecting an
@@ -22,6 +23,10 @@ const SPARK_MONTHS = 12;
 
 /** The page's opening figure: new car registrations for the selected month. */
 export async function RegistrationsHeadline() {
+  "use cache";
+  cacheLife("max");
+  cacheTag("cars:months", "cars:monthly-totals", "vehicle-population:totals");
+
   const month = await getLatestMonth("cars");
   const [monthlyTotals, populationTotals] = await Promise.all([
     getMonthlyRegistrationTotals(HISTORY_LIMIT),

--- a/apps/web/src/app/(main)/(dashboard)/components/top-makes.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/components/top-makes.tsx
@@ -5,16 +5,23 @@ import { buildLogoMap } from "@web/app/(main)/(dashboard)/cars/makes/components/
 import { BarRow } from "@web/components/shared/bar-row";
 import { MakeAvatar } from "@web/components/shared/make-avatar";
 import { SectionHead } from "@web/components/shared/overview";
+import { LOGOS_CACHE_TAG } from "@web/lib/cache-tags";
 import { getTopMakesByYear } from "@web/queries/cars";
 import { getAllCarLogos } from "@web/queries/logos";
 import { getLatestMonth } from "@web/utils/dates/months";
+import { cacheLife, cacheTag } from "next/cache";
 
 const ROW_COUNT = 5;
 
 /** The five best-selling makes for the selected month's year. */
 export async function TopMakes() {
+  "use cache";
+  cacheLife("max");
+  cacheTag("cars:months", "cars:top-makes", LOGOS_CACHE_TAG);
+
   const month = await getLatestMonth("cars");
   const year = Number(month.slice(0, 4));
+  cacheTag(`cars:year:${year}`);
   const [makes, logoResult] = await Promise.all([
     getTopMakesByYear(year, ROW_COUNT),
     getAllCarLogos(),

--- a/apps/web/src/app/(main)/(dashboard)/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/page.tsx
@@ -19,6 +19,7 @@ import { LOGO_URL, SITE_TITLE, SITE_URL, SUPPORT_EMAIL } from "@web/config";
 import { BRAND_SOCIAL_PROFILE_URLS } from "@web/config/socials";
 import { getLatestMonth } from "@web/utils/dates/months";
 import type { Metadata } from "next";
+import { cacheLife, cacheTag } from "next/cache";
 import { Suspense } from "react";
 
 export const metadata: Metadata = {
@@ -105,6 +106,10 @@ function OrganizationStructuredData() {
  * than offering a picker; each block links to the page that can change it.
  */
 async function LatestMonth() {
+  "use cache";
+  cacheLife("max");
+  cacheTag("cars:months");
+
   const month = await getLatestMonth("cars");
 
   return <EyebrowValue>{formatDateToMonthYear(month)}</EyebrowValue>;


### PR DESCRIPTION
- `"use cache: remote"` is runtime-only and never enters the build-time static shell, so every homepage view was a CDN HIT for the shell plus a function invocation to fill 11 Suspense holes
- Wrap the seven homepage section components and `LatestMonth` in a plain `"use cache"` with `cacheLife("max")` and the union of their queries' cache tags, so the whole page is served from the CDN with no function call; the query modules stay on remote for the `searchParams`-driven pages
- Tags are duplicated on the outer cache because nested `cacheTag` calls do not propagate, keeping the existing `revalidateTag` calls effective
- Correct the claim in apps/web/CLAUDE.md that remote still prerenders, and document the wrapper pattern

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791725049&installation_model_id=21947&pr_number=1071&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1071&signature=6f95e071f65e2f3865e1e3155bb940be1e635a5bcac49bedb16f3cea00ab6e80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->