### PR TITLE
Render share images dynamically to stop the Date.now prerender bailout

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/annual/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/annual/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/annual/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/annual/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/deregistrations/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/deregistrations/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/deregistrations/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/deregistrations/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadFuelMix } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Electric vehicle share of new registrations - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadFuelMix(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadFuelMix } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Electric vehicle share of new registrations - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadFuelMix(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadFuelMix } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Electric vehicle share of new registrations - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadFuelMix(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadFuelMix } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Electric vehicle share of new registrations - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadFuelMix(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/fuel-types/[type]/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/fuel-types/[type]/opengraph-image.tsx
@@ -5,6 +5,7 @@ import { loadFuelMix } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { getDistinctFuelTypes } from "@web/queries/cars";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Fuel-type share of new registrations - MotorMetrics";
 export const size = OG_SIZE;
@@ -18,6 +19,8 @@ export async function generateStaticParams() {
 }
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadFuelMix(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/fuel-types/[type]/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/fuel-types/[type]/twitter-image.tsx
@@ -5,6 +5,7 @@ import { loadFuelMix } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { getDistinctFuelTypes } from "@web/queries/cars";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Fuel-type share of new registrations - MotorMetrics";
 export const size = TWITTER_SIZE;
@@ -18,6 +19,8 @@ export async function generateStaticParams() {
 }
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadFuelMix(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/fuel-types/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/fuel-types/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadFuelMix } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Fuel-type share of new registrations - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadFuelMix(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/fuel-types/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/fuel-types/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadFuelMix } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Fuel-type share of new registrations - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadFuelMix(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/[make]/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/[make]/opengraph-image.tsx
@@ -5,6 +5,7 @@ import { loadMake } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { getDistinctMakes } from "@web/queries/cars";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 interface ImageProps {
   params: Promise<{ make: string }>;
@@ -22,6 +23,8 @@ export async function generateStaticParams() {
 }
 
 export default async function Image({ params }: ImageProps) {
+  await connection();
+
   const { make } = await params;
   const [data, fonts] = await Promise.all([loadMake(make), getOGFonts()]);
 

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/[make]/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/[make]/twitter-image.tsx
@@ -5,6 +5,7 @@ import { loadMake } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { getDistinctMakes } from "@web/queries/cars";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 interface ImageProps {
   params: Promise<{ make: string }>;
@@ -22,6 +23,8 @@ export async function generateStaticParams() {
 }
 
 export default async function Image({ params }: ImageProps) {
+  await connection();
+
   const { make } = await params;
   const [data, fonts] = await Promise.all([loadMake(make), getOGFonts()]);
 

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/parf/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/parf/opengraph-image.tsx
@@ -2,12 +2,15 @@ import { Parf } from "@web/lib/og/cards/parf";
 import { OG_CONTENT_TYPE, OG_HEADERS, OG_SIZE } from "@web/lib/og/config";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "PARF rebate calculator - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const fonts = await getOGFonts();
 
   return new ImageResponse(<Parf height={size.height} />, {

--- a/apps/web/src/app/(main)/(dashboard)/cars/parf/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/parf/twitter-image.tsx
@@ -2,12 +2,15 @@ import { Parf } from "@web/lib/og/cards/parf";
 import { OG_CONTENT_TYPE, OG_HEADERS, TWITTER_SIZE } from "@web/lib/og/config";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "PARF rebate calculator - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const fonts = await getOGFonts();
 
   return new ImageResponse(<Parf height={size.height} />, {

--- a/apps/web/src/app/(main)/(dashboard)/cars/registrations/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/registrations/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/registrations/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/registrations/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/vehicle-types/[type]/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/vehicle-types/[type]/opengraph-image.tsx
@@ -5,6 +5,7 @@ import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { getDistinctVehicleTypes } from "@web/queries/cars";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = OG_SIZE;
@@ -20,6 +21,8 @@ export async function generateStaticParams() {
 }
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/vehicle-types/[type]/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/vehicle-types/[type]/twitter-image.tsx
@@ -5,6 +5,7 @@ import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { getDistinctVehicleTypes } from "@web/queries/cars";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = TWITTER_SIZE;
@@ -20,6 +21,8 @@ export async function generateStaticParams() {
 }
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/vehicle-types/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/vehicle-types/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/cars/vehicle-types/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/vehicle-types/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadRegistrations } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest car registrations in Singapore - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadRegistrations(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/coe/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadCoePremiums } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Cat A and Cat B COE premiums - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadCoePremiums(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/coe/pqp/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/pqp/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadCoePremiums } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Cat A and Cat B COE premiums - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadCoePremiums(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/coe/pqp/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/pqp/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadCoePremiums } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Cat A and Cat B COE premiums - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadCoePremiums(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/coe/premiums/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/premiums/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadCoeResults } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest COE bidding results - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadCoeResults(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/coe/premiums/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/premiums/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadCoeResults } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest COE bidding results - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadCoeResults(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/coe/results/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/results/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadCoeResults } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest COE bidding results - MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadCoeResults(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/coe/results/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/results/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadCoeResults } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Latest COE bidding results - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadCoeResults(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/coe/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/coe/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadCoePremiums } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "Cat A and Cat B COE premiums - MotorMetrics";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadCoePremiums(), getOGFonts()]);
 
   if (!data) {

--- a/apps/web/src/app/(main)/(dashboard)/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/(main)/(dashboard)/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/(main)/(site)/about/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(site)/about/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/(main)/(site)/about/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(site)/about/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/(main)/(site)/advertise/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/(main)/(site)/advertise/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/(main)/(site)/blog/[slug]/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(site)/blog/[slug]/opengraph-image.tsx
@@ -8,6 +8,7 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { getAllPosts, getPostBySlug } from "@web/queries/posts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 interface ImageProps {
   params: Promise<{ slug: string }>;
@@ -23,6 +24,8 @@ export async function generateStaticParams() {
 }
 
 export default async function Image({ params }: ImageProps) {
+  await connection();
+
   const { slug } = await params;
   const [post, fonts] = await Promise.all([getPostBySlug(slug), getOGFonts()]);
 

--- a/apps/web/src/app/(main)/(site)/blog/[slug]/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(site)/blog/[slug]/twitter-image.tsx
@@ -8,6 +8,7 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { getAllPosts, getPostBySlug } from "@web/queries/posts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 interface ImageProps {
   params: Promise<{ slug: string }>;
@@ -23,6 +24,8 @@ export async function generateStaticParams() {
 }
 
 export default async function Image({ params }: ImageProps) {
+  await connection();
+
   const { slug } = await params;
   const [post, fonts] = await Promise.all([getPostBySlug(slug), getOGFonts()]);
 

--- a/apps/web/src/app/(main)/(site)/blog/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(site)/blog/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/(main)/(site)/blog/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(site)/blog/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/(main)/(site)/contact/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(site)/contact/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/(main)/(site)/contact/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(site)/contact/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/(main)/(site)/learn/[slug]/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/[slug]/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { Article } from "@web/lib/og/cards/article";
 import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 import {
   getAllGuideSlugs,
   getGuideBySlug,
@@ -22,6 +23,8 @@ export async function generateStaticParams() {
 }
 
 export default async function Image({ params }: ImageProps) {
+  await connection();
+
   const { slug } = await params;
   const guide = getGuideBySlug(slug);
 

--- a/apps/web/src/app/(main)/(site)/learn/[slug]/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/[slug]/twitter-image.tsx
@@ -3,6 +3,7 @@ import { Article } from "@web/lib/og/cards/article";
 import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 import {
   getAllGuideSlugs,
   getGuideBySlug,
@@ -22,6 +23,8 @@ export async function generateStaticParams() {
 }
 
 export default async function Image({ params }: ImageProps) {
+  await connection();
+
   const { slug } = await params;
   const guide = getGuideBySlug(slug);
 

--- a/apps/web/src/app/(main)/(site)/learn/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/(main)/(site)/learn/twitter-image.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, OG_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {

--- a/apps/web/src/app/twitter-image.tsx
+++ b/apps/web/src/app/twitter-image.tsx
@@ -3,12 +3,15 @@ import { OG_CONTENT_TYPE, TWITTER_SIZE } from "@web/lib/og/config";
 import { loadSiteDefault } from "@web/lib/og/data";
 import { getOGFonts } from "@web/lib/og/fonts";
 import { ImageResponse } from "next/og";
+import { connection } from "next/server";
 
 export const alt = "MotorMetrics - Singapore's car market, in numbers";
 export const size = TWITTER_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default async function Image() {
+  await connection();
+
   const [data, fonts] = await Promise.all([loadSiteDefault(), getOGFonts()]);
 
   return new ImageResponse(<SiteDefault height={size.height} {...data} />, {


### PR DESCRIPTION
- Await `connection()` at the top of every `opengraph-image` and `twitter-image` handler so the routes render per request instead of being prerendered
- Stops the production error `Route /twitter-image-... couldn't be rendered statically because it used Date.now()` (Sentry WEB-11) that fired on every revalidation after a cache tag was bumped
- Card data queries stay `use cache: remote`, so each crawler fetch is a cheap function invocation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791731565&installation_model_id=21947&pr_number=1072&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1072&signature=875f86348eaab2c7dbc0720f65e20043275ed3355b8b68580f4902a25c7dca9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->