### PR TITLE
Diagnose the share image prerender bailout by gating the OpenTelemetry tracer

### DIFF
--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -33,23 +33,32 @@ export async function register() {
     exportMode: "immediate",
   });
 
-  const tracerProvider = new NodeTracerProvider({
-    // Sentry decides sampling so trace propagation stays consistent.
-    sampler: sentryClient ? new SentrySampler(sentryClient) : undefined,
-    spanProcessors: [new SentrySpanProcessor(), langfuseSpanProcessor],
-    // Use Web Crypto API to avoid Math.random() which triggers
-    // Next.js prerender bailout in Server Components.
-    idGenerator: {
-      generateTraceId: () => toHex(crypto.getRandomValues(new Uint8Array(16))),
-      generateSpanId: () => toHex(crypto.getRandomValues(new Uint8Array(8))),
-    },
-  });
+  // DIAGNOSTIC (temporary, do not merge): tracing is off unless
+  // OTEL_TRACING_ENABLED=1. The OpenTelemetry tracer reads the clock for span
+  // start times, and we are testing whether that Date.now() call is what makes
+  // the opengraph-image and twitter-image routes bail out of static rendering
+  // on revalidation. The idGenerator below already works around the same class
+  // of bug for Math.random(), which is what points at the tracer here.
+  if (process.env.OTEL_TRACING_ENABLED === "1") {
+    const tracerProvider = new NodeTracerProvider({
+      // Sentry decides sampling so trace propagation stays consistent.
+      sampler: sentryClient ? new SentrySampler(sentryClient) : undefined,
+      spanProcessors: [new SentrySpanProcessor(), langfuseSpanProcessor],
+      // Use Web Crypto API to avoid Math.random() which triggers
+      // Next.js prerender bailout in Server Components.
+      idGenerator: {
+        generateTraceId: () =>
+          toHex(crypto.getRandomValues(new Uint8Array(16))),
+        generateSpanId: () => toHex(crypto.getRandomValues(new Uint8Array(8))),
+      },
+    });
 
-  tracerProvider.register({
-    propagator: new SentryPropagator(),
-    contextManager: new Sentry.SentryContextManager(),
-  });
-  Sentry.validateOpenTelemetrySetup();
+    tracerProvider.register({
+      propagator: new SentryPropagator(),
+      contextManager: new Sentry.SentryContextManager(),
+    });
+    Sentry.validateOpenTelemetrySetup();
+  }
 
   registerTelemetry(new OpenTelemetry({ runtimeContext: true }));
 }


### PR DESCRIPTION
Diagnostic only, not for merge. Branched from main so the share image routes still prerender as static.

- Gate the OpenTelemetry tracer registration behind `OTEL_TRACING_ENABLED=1`, leaving it off by default on this branch
- Tests whether the tracer reading the clock for span start times is what triggers `Route /twitter-image-... couldn't be rendered statically because it used Date.now()` (Sentry WEB-11) on revalidation
- The existing custom `idGenerator` in the same file already works around this class of bailout for `Math.random()`, which is what points at the tracer

To read the result: on this branch's preview, bump a cache tag through the revalidate endpoint, fetch a share image, and check whether WEB-11 recurs. No recurrence confirms the tracer as the source, and the fix becomes keeping spans off the image routes rather than making all 52 routes dynamic in #1072.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791732788&installation_model_id=21947&pr_number=1073&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1073&signature=af667d34d7f252c77bf274060d48cfc1fb41e6353242ac4b0fc7abf09e6149b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->