### PR TITLE
Default to use cache and drop remote caching

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/components/make-rows.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/components/make-rows.ts
@@ -276,7 +276,7 @@ export async function loadMakeRows(
   range: Range,
   fuel: string | null,
 ): Promise<MakeRowsResult> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:months", "cars:makes", LOGOS_CACHE_TAG);
   if (isFuelFilter(fuel)) {
@@ -381,7 +381,7 @@ export function selectElectricOnlyMakes(
 }
 
 export async function loadElectricOnlyMakes(): Promise<ElectricOnlySummary | null> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(
     "cars:months",

--- a/apps/web/src/queries/car-population/available-years.ts
+++ b/apps/web/src/queries/car-population/available-years.ts
@@ -4,7 +4,7 @@ import { desc } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export async function getCarPopulationYears(): Promise<{ year: string }[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:population:years");
 

--- a/apps/web/src/queries/car-population/by-make-and-fuel-type.ts
+++ b/apps/web/src/queries/car-population/by-make-and-fuel-type.ts
@@ -19,7 +19,7 @@ export interface CarPopulationBreakdown {
 export async function getCarPopulationByMakeAndFuelType(): Promise<
   CarPopulationBreakdown[]
 > {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:population:totals");
 

--- a/apps/web/src/queries/car-population/by-year-and-make.ts
+++ b/apps/web/src/queries/car-population/by-year-and-make.ts
@@ -12,7 +12,7 @@ interface YearMakeTotal {
 export async function getCarPopulationByYearAndMake(): Promise<
   YearMakeTotal[]
 > {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:population:totals");
 

--- a/apps/web/src/queries/car-population/yearly-totals.ts
+++ b/apps/web/src/queries/car-population/yearly-totals.ts
@@ -9,7 +9,7 @@ interface YearlyTotal {
 }
 
 export async function getCarPopulationYearlyTotals(): Promise<YearlyTotal[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:population:totals");
 

--- a/apps/web/src/queries/cars/category-report.ts
+++ b/apps/web/src/queries/cars/category-report.ts
@@ -41,7 +41,7 @@ export async function getCategoryTotals(
   field: CategoryField,
   months: string[],
 ): Promise<CategoryTotal[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(...monthTags(months));
 
@@ -76,7 +76,7 @@ export async function getCategoryMonthlySeries(
   field: CategoryField,
   months: string[],
 ): Promise<CategoryMonthlyPoint[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(...monthTags(months));
 
@@ -116,7 +116,7 @@ export async function getTopMakesByCategory(
   months: string[],
   makesPerType = 3,
 ): Promise<CategoryLeader[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(...monthTags(months));
 
@@ -173,7 +173,7 @@ export interface ElectricShare {
 export async function getElectricShareByVehicleType(
   months: string[],
 ): Promise<ElectricShare[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(...monthTags(months));
 

--- a/apps/web/src/queries/cars/category-summary.ts
+++ b/apps/web/src/queries/cars/category-summary.ts
@@ -19,7 +19,7 @@ const yearExpr = sql`extract(year from to_date(${cars.month}, 'YYYY-MM'))`;
 export async function getCategorySummaryByYear(
   year?: number,
 ): Promise<CategorySummary> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:annual", "cars:fuel:electric", "cars:fuel:hybrid");
   if (year) {

--- a/apps/web/src/queries/cars/compare.ts
+++ b/apps/web/src/queries/cars/compare.ts
@@ -11,7 +11,7 @@ export async function getComparisonData(
   monthA: string,
   monthB: string,
 ): Promise<ComparisonData> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:month:${monthA}`, `cars:month:${monthB}`);
 

--- a/apps/web/src/queries/cars/dimension-stats.ts
+++ b/apps/web/src/queries/cars/dimension-stats.ts
@@ -53,7 +53,7 @@ export async function getDimensionStats(
   dimension: CarDimension,
   month: string,
 ): Promise<DimensionStat[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   // `cars:annual` as well as the month: these totals are year to date, so a new
   // month changes every cached dimension, not only the one just loaded.

--- a/apps/web/src/queries/cars/electric-vehicles.ts
+++ b/apps/web/src/queries/cars/electric-vehicles.ts
@@ -51,7 +51,7 @@ export interface EvMakeDetail {
 }
 
 export async function getEvMonthlyTrend(): Promise<EvMonthlyTrend[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:fuel:electric", "cars:fuel:hybrid");
 
@@ -87,7 +87,7 @@ export async function getEvMonthlyTrend(): Promise<EvMonthlyTrend[]> {
 }
 
 export async function getEvMarketShare(): Promise<EvMarketShare[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:fuel:electric", "cars:fuel:hybrid");
 
@@ -129,7 +129,7 @@ export async function getEvMarketShare(): Promise<EvMarketShare[]> {
 }
 
 export async function getEvTopMakes(limit = 10): Promise<EvTopMake[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:fuel:electric", "cars:fuel:hybrid");
 
@@ -158,7 +158,7 @@ export async function getEvTopMakes(limit = 10): Promise<EvTopMake[]> {
 }
 
 export async function getEvMakeDetails(): Promise<EvMakeDetail[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:fuel:electric", "cars:fuel:hybrid");
 
@@ -212,7 +212,7 @@ export async function getEvMakeDetails(): Promise<EvMakeDetail[]> {
 }
 
 export async function getEvLatestSummary(): Promise<EvLatestSummary | null> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:fuel:electric", "cars:fuel:hybrid");
 

--- a/apps/web/src/queries/cars/filter-options.ts
+++ b/apps/web/src/queries/cars/filter-options.ts
@@ -5,7 +5,7 @@ import { cacheLife, cacheTag } from "next/cache";
 import { FUEL_TYPE, type TypeConfig, VEHICLE_TYPE } from "./categories";
 
 export async function getDistinctMakes() {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:makes");
 
@@ -34,7 +34,7 @@ function queryDistinctTypeValues(config: TypeConfig, month?: string) {
 export async function getDistinctFuelTypes(
   month?: string,
 ): Promise<{ fuelType: string }[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   if (month) {
     cacheTag(`cars:month:${month}`);
@@ -47,7 +47,7 @@ export async function getDistinctFuelTypes(
 export async function getDistinctVehicleTypes(
   month?: string,
 ): Promise<{ vehicleType: string }[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   if (month) {
     cacheTag(`cars:month:${month}`);
@@ -58,7 +58,7 @@ export async function getDistinctVehicleTypes(
 }
 
 export async function getCarsMonths(): Promise<{ month: string }[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:months");
 

--- a/apps/web/src/queries/cars/latest-month.ts
+++ b/apps/web/src/queries/cars/latest-month.ts
@@ -5,7 +5,7 @@ import { cacheLife, cacheTag } from "next/cache";
  * Get the latest month with car registration data
  */
 export async function getCarsLatestMonth(): Promise<string | null> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:months");
 

--- a/apps/web/src/queries/cars/makes/coe-comparison.ts
+++ b/apps/web/src/queries/cars/makes/coe-comparison.ts
@@ -14,7 +14,7 @@ export interface MakeCoeComparisonData {
 export async function getMakeCoeComparison(
   make: string,
 ): Promise<MakeCoeComparisonData[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
 
   const { startMonth, endMonth } = getDateRange24Months();

--- a/apps/web/src/queries/cars/makes/current-year-popular-makes.ts
+++ b/apps/web/src/queries/cars/makes/current-year-popular-makes.ts
@@ -29,7 +29,7 @@ const getPopularMakesByYearData = async (year: string, limit: number = 8) => {
  * Returns array of make names sorted by registration volume.
  */
 export async function getPopularMakes(year?: string) {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   if (year) {
     cacheTag(`cars:year:${year}`);

--- a/apps/web/src/queries/cars/makes/entity-breakdowns.ts
+++ b/apps/web/src/queries/cars/makes/entity-breakdowns.ts
@@ -91,7 +91,7 @@ export async function getMakeDetails(
   make: string,
   month?: string | null,
 ): Promise<MakeDetails> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:make:${make}`);
   if (month) {
@@ -134,7 +134,7 @@ export async function getFuelTypeData(
   fuelType: string,
   month?: string,
 ): Promise<FuelTypeData> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:fuel:${fuelType}`);
   if (month) {
@@ -149,7 +149,7 @@ export async function getMakeFuelTypeBreakdown(
   make: string,
   month?: string | null,
 ): Promise<{ name: string; value: number }[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:make:${make}`);
   if (month) {
@@ -180,7 +180,7 @@ export async function getMakeVehicleTypeBreakdown(
   make: string,
   month?: string | null,
 ): Promise<{ name: string; value: number }[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:make:${make}`);
   if (month) {
@@ -211,7 +211,7 @@ export async function getVehicleTypeData(
   vehicleType: string,
   month?: string,
 ): Promise<VehicleTypeData> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:vehicle:${vehicleType}`);
   if (month) {
@@ -229,7 +229,7 @@ export async function getVehicleTypeData(
 export async function getMakeMonthlyTotals(
   make: string,
 ): Promise<MakeMonthlyTotal[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:make:${make}`);
 

--- a/apps/web/src/queries/cars/makes/entity-checks.ts
+++ b/apps/web/src/queries/cars/makes/entity-checks.ts
@@ -38,7 +38,7 @@ function findEntity(config: EntityCheckConfig, value: string) {
 export async function checkMakeIfExist(
   make: string,
 ): Promise<{ make: string } | undefined> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:make:${make}`);
 
@@ -49,7 +49,7 @@ export async function checkMakeIfExist(
 export async function checkFuelTypeIfExist(
   fuelType: string,
 ): Promise<{ fuelType: string } | undefined> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:fuel:${fuelType}`);
 
@@ -60,7 +60,7 @@ export async function checkFuelTypeIfExist(
 export async function checkVehicleTypeIfExist(
   vehicleType: string,
 ): Promise<{ vehicleType: string } | undefined> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:vehicle:${vehicleType}`);
 

--- a/apps/web/src/queries/cars/makes/get-make-from-slug.ts
+++ b/apps/web/src/queries/cars/makes/get-make-from-slug.ts
@@ -12,7 +12,7 @@ import { cacheLife, cacheTag } from "next/cache";
 export async function getMakeFromSlug(
   slug: string,
 ): Promise<string | undefined> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:makes");
 

--- a/apps/web/src/queries/cars/makes/grouped-makes.ts
+++ b/apps/web/src/queries/cars/makes/grouped-makes.ts
@@ -16,7 +16,7 @@ const getLetterFromMake = (make: Make): string => {
 };
 
 export async function getGroupedMakes(): Promise<GroupedMakesResult> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:makes");
 

--- a/apps/web/src/queries/cars/makes/period-totals.ts
+++ b/apps/web/src/queries/cars/makes/period-totals.ts
@@ -33,7 +33,7 @@ export interface MakeCrossTabRow {
 export async function getMakeCrossTab(
   make: string,
 ): Promise<MakeCrossTabRow[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:make:${make}`);
 
@@ -65,7 +65,7 @@ export async function getMakeTotalsInRange(
   start: string,
   end: string,
 ): Promise<MakePeriodTotal[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:makes");
 
@@ -95,7 +95,7 @@ export async function getMarketMonthlyTotals(
   start: string,
   end: string,
 ): Promise<MarketMonthlyTotal[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:monthly-totals");
 

--- a/apps/web/src/queries/cars/makes/registration-stats.ts
+++ b/apps/web/src/queries/cars/makes/registration-stats.ts
@@ -47,7 +47,7 @@ export function getComparisonWindows(latestMonth: string): {
 export async function getMakeRegistrationStats(): Promise<
   MakeRegistrationStat[]
 > {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:makes");
 

--- a/apps/web/src/queries/cars/market-insights.ts
+++ b/apps/web/src/queries/cars/market-insights.ts
@@ -57,7 +57,7 @@ interface TopMake {
 }
 
 export async function getTopTypes(month: string): Promise<TopType> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:month:${month}`);
 
@@ -99,7 +99,7 @@ export async function getTopTypes(month: string): Promise<TopType> {
 }
 
 export async function getTopMakes(month: string): Promise<TopMake[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:month:${month}`);
 
@@ -118,7 +118,7 @@ export async function getTopMakes(month: string): Promise<TopMake[]> {
 export async function getTopMakesByFuelType(
   month: string,
 ): Promise<FuelType[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:month:${month}`);
 
@@ -168,7 +168,7 @@ export async function getCarMarketShareData(
   month: string,
   category: "fuelType" | "vehicleType",
 ): Promise<CarMarketShareResponse> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:month:${month}`, `cars:category:${category}`);
 

--- a/apps/web/src/queries/cars/monthly-registrations.ts
+++ b/apps/web/src/queries/cars/monthly-registrations.ts
@@ -6,7 +6,7 @@ import { desc, eq, gt, ilike, sql, sum } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export async function getCarsData(month: string): Promise<Registration> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:month:${month}`);
 
@@ -56,7 +56,7 @@ export async function getCarsData(month: string): Promise<Registration> {
 }
 
 export async function getCarsComparison(month: string): Promise<Comparison> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:month:${month}`);
 
@@ -154,7 +154,7 @@ export interface MonthlyTotal {
 export async function getMonthlyRegistrationTotals(
   limit = 12,
 ): Promise<MonthlyTotal[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:monthly-totals");
 
@@ -178,7 +178,7 @@ export async function getMonthlyRegistrationTotals(
 export async function getYearToDateByFuelType(
   year: number,
 ): Promise<{ count: number; name: string }[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:year:${year}`);
 
@@ -204,7 +204,7 @@ export async function getMonthlyRegistrationTotalsByFuelType(
   fuelType: string,
   limit = 12,
 ): Promise<MonthlyTotal[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:monthly-totals:${fuelType}`);
 

--- a/apps/web/src/queries/cars/type-detail.ts
+++ b/apps/web/src/queries/cars/type-detail.ts
@@ -64,7 +64,7 @@ export async function getTypeMonthlySeries(
   month: string,
   limit = 12,
 ): Promise<TypeMonthlyPoint[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:month:${month}`, `cars:${DIMENSION_TAGS[dimension]}:${value}`);
 
@@ -100,7 +100,7 @@ export async function getTypeDistributionInWindow(
   from: string,
   to: string,
 ): Promise<TypeCount[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:month:${to}`, "cars:annual");
 
@@ -124,7 +124,7 @@ export async function getTypeMakesInWindow(
   from: string,
   to: string,
 ): Promise<{ count: number; make: string }[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:month:${to}`, `cars:${DIMENSION_TAGS[dimension]}:${value}`);
 
@@ -158,7 +158,7 @@ export async function getTypeCrossMixInWindow(
   from: string,
   to: string,
 ): Promise<TypeCount[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`cars:month:${to}`, `cars:${DIMENSION_TAGS[dimension]}:${value}`);
 

--- a/apps/web/src/queries/cars/yearly-statistics.ts
+++ b/apps/web/src/queries/cars/yearly-statistics.ts
@@ -18,7 +18,7 @@ interface YearOnly {
  * Get yearly registration totals aggregated from monthly data (ascending order for charts)
  */
 export async function getYearlyRegistrations(): Promise<YearlyTotal[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:annual");
 
@@ -37,7 +37,7 @@ export async function getYearlyRegistrations(): Promise<YearlyTotal[]> {
  * Get available years in descending order (for dropdowns/selectors)
  */
 export async function getAvailableYears(): Promise<YearOnly[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:annual");
 
@@ -63,7 +63,7 @@ export async function getTopMakesByYear(
   year?: number,
   limit = 8,
 ): Promise<MakeValue[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("cars:top-makes");
   if (year) {

--- a/apps/web/src/queries/coe/available-months.ts
+++ b/apps/web/src/queries/coe/available-months.ts
@@ -4,7 +4,7 @@ import { desc } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export async function getCoeMonths(): Promise<{ month: string }[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("coe:months");
 

--- a/apps/web/src/queries/coe/bidding-rounds.ts
+++ b/apps/web/src/queries/coe/bidding-rounds.ts
@@ -20,7 +20,7 @@ export interface MonthBiddingRounds {
 export async function getMonthBiddingRounds(
   month?: string,
 ): Promise<MonthBiddingRounds> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("coe:bidding-rounds", month ? `coe:month:${month}` : "coe:latest");
 

--- a/apps/web/src/queries/coe/exercises.ts
+++ b/apps/web/src/queries/coe/exercises.ts
@@ -24,7 +24,7 @@ export async function getExercisePair(month?: string): Promise<{
   current: ExerciseRows | null;
   previous: ExerciseRows | null;
 }> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("coe:exercises", month ? `coe:month:${month}` : "coe:latest");
 
@@ -93,7 +93,7 @@ export interface CategoryExercise {
 export async function getCategoryExercises(
   category: COECategory,
 ): Promise<CategoryExercise[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`coe:category:${category}`);
 

--- a/apps/web/src/queries/coe/historical-results.ts
+++ b/apps/web/src/queries/coe/historical-results.ts
@@ -15,7 +15,7 @@ export interface CoeMarketShareData {
 }
 
 export async function getCoeResults(): Promise<COEResult[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("coe:results");
 
@@ -30,7 +30,7 @@ export async function getCoeResults(): Promise<COEResult[]> {
 export async function getCoeResultsByPeriod(
   period: Period = "12m",
 ): Promise<COEResult[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`coe:period:${period}`);
 

--- a/apps/web/src/queries/coe/latest-month.ts
+++ b/apps/web/src/queries/coe/latest-month.ts
@@ -7,7 +7,7 @@ import { cacheLife, cacheTag } from "next/cache";
  * Get the latest month with COE bidding data
  */
 export async function getCOELatestMonth(): Promise<string | null> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("coe:months");
 

--- a/apps/web/src/queries/coe/latest-results.ts
+++ b/apps/web/src/queries/coe/latest-results.ts
@@ -5,7 +5,7 @@ import { and, asc, desc, eq, max, or, sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export async function getLatestCoeResults(): Promise<COEResult[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("coe:latest");
 
@@ -36,7 +36,7 @@ export async function getLatestCoeResults(): Promise<COEResult[]> {
  * Handles both same-month previous round and previous month's last round.
  */
 export async function getPreviousCoeResults(): Promise<COEResult[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("coe:previous");
 
@@ -79,7 +79,7 @@ export async function getLatestAndPreviousCoeResults(): Promise<{
   latest: COEResult[];
   previous: COEResult[];
 }> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("coe:latest", "coe:previous");
 

--- a/apps/web/src/queries/coe/pqp/overview.ts
+++ b/apps/web/src/queries/coe/pqp/overview.ts
@@ -58,7 +58,7 @@ const toNumber = (value: number | string | null | undefined): number => {
 export async function getPQPOverview(
   categories: readonly PQPCategory[] = PQP_REPORTED_CATEGORIES,
 ): Promise<Pqp.Overview> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("coe:pqp");
 

--- a/apps/web/src/queries/coe/pqp/rates.ts
+++ b/apps/web/src/queries/coe/pqp/rates.ts
@@ -5,7 +5,7 @@ import { asc, desc } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export async function getPqpRates(): Promise<Record<string, Pqp.Rates>> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("coe:pqp");
 

--- a/apps/web/src/queries/coe/trends.ts
+++ b/apps/web/src/queries/coe/trends.ts
@@ -80,7 +80,7 @@ export async function getCoeCategoryTrends(
   category: COECategory,
   year?: number,
 ): Promise<CoeMonthlyPremium[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`coe:category:${category}`);
   if (year) {
@@ -102,7 +102,7 @@ export async function getCoeCategoryTrends(
 export async function getAllCoeCategoryTrends(
   year?: number,
 ): Promise<Record<COECategory, CoeMonthlyPremium[]>> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("coe:trends");
   if (year) {

--- a/apps/web/src/queries/deregistrations/all.ts
+++ b/apps/web/src/queries/deregistrations/all.ts
@@ -4,7 +4,7 @@ import { asc } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export async function getDeregistrations() {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("deregistrations:months");
 

--- a/apps/web/src/queries/deregistrations/available-months.ts
+++ b/apps/web/src/queries/deregistrations/available-months.ts
@@ -7,7 +7,7 @@ import { cacheLife, cacheTag } from "next/cache";
  * Get available months in descending order (for dropdowns/selectors)
  */
 export async function getDeregistrationsMonths() {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("deregistrations:months");
 

--- a/apps/web/src/queries/deregistrations/by-category.ts
+++ b/apps/web/src/queries/deregistrations/by-category.ts
@@ -18,7 +18,7 @@ interface MonthTotal {
 export async function getDeregistrationsByCategory(
   month: string,
 ): Promise<CategoryTotal[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`deregistrations:month:${month}`);
 
@@ -42,7 +42,7 @@ export async function getDeregistrationsByCategory(
 export async function getDeregistrationsTotalByMonth(
   month: string,
 ): Promise<MonthTotal[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`deregistrations:month:${month}`);
 

--- a/apps/web/src/queries/deregistrations/latest-month.ts
+++ b/apps/web/src/queries/deregistrations/latest-month.ts
@@ -7,7 +7,7 @@ import { cacheLife, cacheTag } from "next/cache";
  * Get the latest month available in deregistrations data
  */
 export async function getDeregistrationsLatestMonth() {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("deregistrations:months");
 

--- a/apps/web/src/queries/ev-charging/hourly-utilisation.ts
+++ b/apps/web/src/queries/ev-charging/hourly-utilisation.ts
@@ -23,7 +23,7 @@ export interface EvChargingHourlyUtilisation {
 export async function getEvChargingUtilisationByHour(
   days = 7,
 ): Promise<EvChargingHourlyUtilisation[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("hours");
 
   const hourOfDay =

--- a/apps/web/src/queries/ev-charging/live-summary.ts
+++ b/apps/web/src/queries/ev-charging/live-summary.ts
@@ -16,7 +16,7 @@ export interface EvChargingLiveSummary {
 export async function getEvChargingLiveSummary(
   district?: string,
 ): Promise<EvChargingLiveSummary> {
-  "use cache: remote";
+  "use cache";
   cacheLife("hours");
 
   const { observedAt, records } = await getEvChargingSnapshot();

--- a/apps/web/src/queries/ev-charging/location-utilisation.ts
+++ b/apps/web/src/queries/ev-charging/location-utilisation.ts
@@ -47,7 +47,7 @@ export async function getEvChargingLocationUtilisation({
   limit = 10,
   days = 7,
 }: LocationUtilisationOptions): Promise<EvChargingLocationUtilisation[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("hours");
 
   const locations = storedLocationsSubquery();

--- a/apps/web/src/queries/ev-charging/map-sites.ts
+++ b/apps/web/src/queries/ev-charging/map-sites.ts
@@ -28,7 +28,7 @@ interface SiteExtras {
  * Locations without coordinates are dropped rather than guessed at.
  */
 export async function getEvChargingMapSites(): Promise<EvChargingMapSite[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("hours");
 
   const [{ records }, utilisation] = await Promise.all([

--- a/apps/web/src/queries/ev-charging/network-summary.ts
+++ b/apps/web/src/queries/ev-charging/network-summary.ts
@@ -12,7 +12,7 @@ export interface EvChargingNetworkSummary {
 }
 
 export async function getEvChargingNetworkSummary(): Promise<EvChargingNetworkSummary> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(EV_CHARGING_CACHE_TAG);
 

--- a/apps/web/src/queries/ev-charging/price-rankings.ts
+++ b/apps/web/src/queries/ev-charging/price-rankings.ts
@@ -36,7 +36,7 @@ export async function getEvChargingPriceRankings({
   district,
   limit = 10,
 }: PriceRankingOptions): Promise<EvChargingPricedLocation[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("hours");
 
   const { records } = await getEvChargingSnapshot();

--- a/apps/web/src/queries/ev-charging/recent-changes.ts
+++ b/apps/web/src/queries/ev-charging/recent-changes.ts
@@ -37,7 +37,7 @@ export interface EvChargingRecentChanges {
 export async function getEvChargingRecentChanges(
   days = 7,
 ): Promise<EvChargingRecentChanges> {
-  "use cache: remote";
+  "use cache";
   cacheLife("hours");
 
   const locations = storedLocationsSubquery();

--- a/apps/web/src/queries/ev-charging/registrations-by-month.ts
+++ b/apps/web/src/queries/ev-charging/registrations-by-month.ts
@@ -21,7 +21,7 @@ export interface EvChargingMonthlyRegistrations {
 export async function getEvChargingRegistrationsByMonth(): Promise<
   EvChargingMonthlyRegistrations[]
 > {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(EV_CHARGING_CACHE_TAG);
 

--- a/apps/web/src/queries/ev-charging/snapshot.ts
+++ b/apps/web/src/queries/ev-charging/snapshot.ts
@@ -26,7 +26,7 @@ const EMPTY: EvChargingSnapshot = { observedAt: null, records: [] };
  * account key the snapshot is empty and the pages show their empty state.
  */
 export async function getEvChargingSnapshot(): Promise<EvChargingSnapshot> {
-  "use cache: remote";
+  "use cache";
   cacheLife("hours");
 
   const accountKey = process.env.LTA_DATAMALL_ACCOUNT_KEY;

--- a/apps/web/src/queries/logos/index.ts
+++ b/apps/web/src/queries/logos/index.ts
@@ -15,7 +15,7 @@ import { cacheLife, cacheTag } from "next/cache";
  * life of the entry.
  */
 async function readCarLogos(): Promise<CarLogo[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(LOGOS_CACHE_TAG);
 

--- a/apps/web/src/queries/posts/index.ts
+++ b/apps/web/src/queries/posts/index.ts
@@ -63,7 +63,7 @@ export async function searchPosts(query: string): Promise<SelectPost[]> {
 }
 
 export async function getAllPosts() {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("posts:list");
 
@@ -74,7 +74,7 @@ export async function getAllPosts() {
 }
 
 export async function getRecentPosts(limit = 3) {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("posts:recent");
 
@@ -86,7 +86,7 @@ export async function getRecentPosts(limit = 3) {
 }
 
 export async function getPostBySlug(slug: string) {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag(`posts:slug:${slug}`);
 
@@ -96,7 +96,7 @@ export async function getPostBySlug(slug: string) {
 }
 
 export async function getPostsByIds(postIds: string[]) {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("posts:list");
 
@@ -111,7 +111,7 @@ export async function getPostsByIds(postIds: string[]) {
 }
 
 export async function getPostCountsByCategory() {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("posts:list");
 
@@ -123,7 +123,7 @@ export async function getPostCountsByCategory() {
 }
 
 export async function getPreviousPost(publishedAt: Date) {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("posts:list");
 
@@ -134,7 +134,7 @@ export async function getPreviousPost(publishedAt: Date) {
 }
 
 export async function getNextPost(publishedAt: Date) {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("posts:list");
 

--- a/apps/web/src/queries/vehicle-population/available-years.ts
+++ b/apps/web/src/queries/vehicle-population/available-years.ts
@@ -4,7 +4,7 @@ import { desc } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export async function getVehiclePopulationYears(): Promise<{ year: string }[]> {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("vehicle-population:years");
 

--- a/apps/web/src/queries/vehicle-population/by-category-and-fuel-type.ts
+++ b/apps/web/src/queries/vehicle-population/by-category-and-fuel-type.ts
@@ -21,7 +21,7 @@ export interface VehiclePopulationBreakdown {
 export async function getVehiclePopulationByCategoryAndFuelType(): Promise<
   VehiclePopulationBreakdown[]
 > {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("vehicle-population:totals");
 

--- a/apps/web/src/queries/vehicle-population/by-year-and-fuel-type.ts
+++ b/apps/web/src/queries/vehicle-population/by-year-and-fuel-type.ts
@@ -12,7 +12,7 @@ interface YearFuelTypeTotal {
 export async function getVehiclePopulationByYearAndFuelType(): Promise<
   YearFuelTypeTotal[]
 > {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("vehicle-population:totals");
 

--- a/apps/web/src/queries/vehicle-population/yearly-totals.ts
+++ b/apps/web/src/queries/vehicle-population/yearly-totals.ts
@@ -11,7 +11,7 @@ interface YearlyTotal {
 export async function getVehiclePopulationYearlyTotals(): Promise<
   YearlyTotal[]
 > {
-  "use cache: remote";
+  "use cache";
   cacheLife("max");
   cacheTag("vehicle-population:totals");
 


### PR DESCRIPTION
- Move every cached query in the web app from `use cache: remote` to `use cache`, 96 directive sites across 52 files. Nothing in the codebase uses remote caching after this.
- `use cache` is the documented default. Remote is an escalation for a shared request-time operation with a concrete reason: a rate-limited upstream, a slow backend, or an expensive query with a high cache hit rate. No module here had a measured reason, and remote costs a network round trip plus platform fees on every lookup.
- Four of the last holdouts (`cars/compare`, `cars/category-report`, `cars/type-detail`, `cars/makes/period-totals`) are keyed on month pairs or date ranges, which the Next.js docs call out as giving near-zero cache utilisation.
- Build output is byte identical to `main`: 73 static, 30 SSG, 28 partial prerender and 22 dynamic routes either side, with the same 160 prerendered files totalling 6,616,123 bytes. The directive controls where runtime entries are stored, not whether a result is prerendered, so no route gains or loses prerendering.
- Remote can be reintroduced per function if query latency measurement shows upstream pressure. The bar the docs set is roughly 50ms.
