### PR TITLE
Collapse batched car queries into single grouped scans

### DIFF
--- a/apps/web/src/queries/cars/category-summary.ts
+++ b/apps/web/src/queries/cars/category-summary.ts
@@ -1,6 +1,6 @@
 import { db } from "@motormetrics/database/client";
 import { cars } from "@motormetrics/database/schema";
-import { and, eq, gt, sql } from "drizzle-orm";
+import { and, gt, gte, lte, max, sum } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export interface CategorySummary {
@@ -10,7 +10,16 @@ export interface CategorySummary {
   hybrid: number;
 }
 
-const yearExpr = sql`extract(year from to_date(${cars.month}, 'YYYY-MM'))`;
+/** The year component of a stored `YYYY-MM` month. */
+const yearOf = (month: string) => Number(month.slice(0, 4));
+
+/**
+ * LTA names every electrified fuel type with an `-Electric` component —
+ * `Petrol-Electric`, `Diesel-Electric (Plug-In)` and so on. `Electric` alone is
+ * fully battery electric and counted separately.
+ */
+const isHybrid = (fuelType: string) =>
+  fuelType.includes("-Electric") && fuelType !== "Electric";
 
 /**
  * Get category summary (total, electric, hybrid) for a given year
@@ -26,37 +35,64 @@ export async function getCategorySummaryByYear(
     cacheTag(`cars:year:${year}`);
   }
 
-  // Use SQL subquery for latest year when not provided
-  const latestYearSubquery = db
-    .select({ year: sql<number>`max(${yearExpr})` })
-    .from(cars)
-    .where(gt(cars.number, 0));
+  let targetYear = year;
 
-  const targetYear = year ?? sql`(${latestYearSubquery})`;
+  if (!targetYear) {
+    const [latest] = await db
+      .select({ month: max(cars.month) })
+      .from(cars)
+      .where(gt(cars.number, 0));
 
-  const result = await db
-    .select({
-      year: sql<number>`cast(${yearExpr} as integer)`.mapWith(Number),
-      total: sql<number>`sum(${cars.number})`.mapWith(Number),
-      electric:
-        sql<number>`sum(case when ${cars.fuelType} = 'Electric' then ${cars.number} else 0 end)`.mapWith(
-          Number,
-        ),
-      hybrid:
-        sql<number>`sum(case when ${cars.fuelType} like '%-Electric%' and ${cars.fuelType} != 'Electric' then ${cars.number} else 0 end)`.mapWith(
-          Number,
-        ),
-    })
-    .from(cars)
-    .where(and(eq(yearExpr, targetYear), gt(cars.number, 0)))
-    .groupBy(yearExpr);
+    targetYear = latest?.month ? yearOf(latest.month) : undefined;
+  }
 
-  return (
-    result[0] ?? {
-      year: year ?? new Date().getFullYear(),
+  if (!targetYear) {
+    return {
+      year: new Date().getFullYear(),
       total: 0,
       electric: 0,
       hybrid: 0,
+    };
+  }
+
+  // Bounds on the stored `YYYY-MM` text rather than
+  // `extract(year from to_date(month, ...)) = year`, which parsed a date on
+  // every row and left the month index unusable. Lexicographic ordering on
+  // `YYYY-MM` is chronological, so the range is exact.
+  const rows = await db
+    .select({
+      fuelType: cars.fuelType,
+      total: sum(cars.number).mapWith(Number),
+    })
+    .from(cars)
+    .where(
+      and(
+        gte(cars.month, `${targetYear}-01`),
+        lte(cars.month, `${targetYear}-12`),
+        gt(cars.number, 0),
+      ),
+    )
+    .groupBy(cars.fuelType);
+
+  const summary: CategorySummary = {
+    year: targetYear,
+    total: 0,
+    electric: 0,
+    hybrid: 0,
+  };
+
+  for (const row of rows) {
+    // `sum()` is null only for an empty group, which a GROUP BY cannot produce
+    const total = row.total ?? 0;
+
+    summary.total += total;
+
+    if (row.fuelType === "Electric") {
+      summary.electric += total;
+    } else if (isHybrid(row.fuelType)) {
+      summary.hybrid += total;
     }
-  );
+  }
+
+  return summary;
 }

--- a/apps/web/src/queries/cars/dimension-stats.ts
+++ b/apps/web/src/queries/cars/dimension-stats.ts
@@ -1,6 +1,6 @@
 import { db } from "@motormetrics/database/client";
 import { cars } from "@motormetrics/database/schema";
-import { and, asc, desc, gt, gte, lte, sql, sum } from "drizzle-orm";
+import { and, asc, desc, gt, gte, lte, sum } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 /**
@@ -33,9 +33,8 @@ const DIMENSION_COLUMNS = {
   fuelType: cars.fuelType,
 } as const;
 
-/** A fresh expression per call: Drizzle mutates `sql` fragments when decorated. */
-const registrationTotal = () =>
-  sql<number>`cast(sum(${cars.number}) as integer)`.mapWith(Number);
+/** A fresh expression per call: Drizzle mutates aggregate fragments when decorated. */
+const registrationTotal = () => sum(cars.number).mapWith(Number);
 
 /**
  * Year-to-date registrations, share and year-over-year change for one dimension.
@@ -103,8 +102,9 @@ export async function getDimensionStats(
     trendQuery,
   ]);
 
+  // `sum()` is null only for an empty group, which a GROUP BY cannot produce
   const grandTotal = yearToDateRows.reduce(
-    (total, row) => total + row.count,
+    (total, row) => total + (row.count ?? 0),
     0,
   );
 
@@ -115,7 +115,7 @@ export async function getDimensionStats(
   const trendByName = trendRows.reduce<Map<string, { value: number }[]>>(
     (accumulator, row) => {
       const series = accumulator.get(row.name) ?? [];
-      series.push({ value: row.count });
+      series.push({ value: row.count ?? 0 });
       accumulator.set(row.name, series);
       return accumulator;
     },
@@ -123,16 +123,19 @@ export async function getDimensionStats(
   );
 
   return yearToDateRows.map((row) => {
-    const previousCount = previousYearByName.get(row.name);
+    const previousCount = previousYearByName.get(row.name) ?? undefined;
+    const count = row.count ?? 0;
 
     return {
       name: row.name,
-      count: row.count,
-      share: grandTotal > 0 ? (row.count / grandTotal) * 100 : 0,
+      count,
+      share: grandTotal > 0 ? (count / grandTotal) * 100 : 0,
       trend: trendByName.get(row.name) ?? [],
       yoyChange:
-        previousCount !== undefined && previousCount > 0
-          ? ((row.count - previousCount) / previousCount) * 100
+        previousCount !== undefined &&
+        previousCount !== null &&
+        previousCount > 0
+          ? ((count - previousCount) / previousCount) * 100
           : null,
     };
   });

--- a/apps/web/src/queries/cars/electric-vehicles.ts
+++ b/apps/web/src/queries/cars/electric-vehicles.ts
@@ -1,6 +1,6 @@
 import { db } from "@motormetrics/database/client";
 import { cars } from "@motormetrics/database/schema";
-import { desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, sum } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 const BEV_FUEL_TYPES = ["Electric"];
@@ -59,7 +59,7 @@ export async function getEvMonthlyTrend(): Promise<EvMonthlyTrend[]> {
     .select({
       month: cars.month,
       fuelType: cars.fuelType,
-      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+      count: sum(cars.number).mapWith(Number),
     })
     .from(cars)
     .where(inArray(cars.fuelType, ALL_EV_FUEL_TYPES))
@@ -73,13 +73,15 @@ export async function getEvMonthlyTrend(): Promise<EvMonthlyTrend[]> {
       monthMap.set(row.month, { month: row.month, BEV: 0, PHEV: 0, Hybrid: 0 });
     }
     const entry = monthMap.get(row.month)!;
+    // `sum()` is null only for an empty group, which a GROUP BY cannot produce
+    const count = row.count ?? 0;
 
     if (BEV_FUEL_TYPES.includes(row.fuelType)) {
-      entry.BEV += row.count;
+      entry.BEV += count;
     } else if (PHEV_FUEL_TYPES.includes(row.fuelType)) {
-      entry.PHEV += row.count;
+      entry.PHEV += count;
     } else if (HYBRID_FUEL_TYPES.includes(row.fuelType)) {
-      entry.Hybrid += row.count;
+      entry.Hybrid += count;
     }
   }
 
@@ -91,41 +93,52 @@ export async function getEvMarketShare(): Promise<EvMarketShare[]> {
   cacheLife("max");
   cacheTag("cars:fuel:electric", "cars:fuel:hybrid");
 
-  const evByMonthQuery = db
+  // One scan grouped by month and fuel type, split here, rather than batching
+  // an EV-filtered scan alongside a second unfiltered scan of the whole table.
+  const rows = await db
     .select({
       month: cars.month,
-      evCount: sql<number>`sum(${cars.number})`.mapWith(Number),
+      fuelType: cars.fuelType,
+      count: sum(cars.number).mapWith(Number),
     })
     .from(cars)
-    .where(inArray(cars.fuelType, ALL_EV_FUEL_TYPES))
-    .groupBy(cars.month);
+    .groupBy(cars.month, cars.fuelType);
 
-  const totalByMonthQuery = db
-    .select({
-      month: cars.month,
-      totalCount: sql<number>`sum(${cars.number})`.mapWith(Number),
-    })
-    .from(cars)
-    .groupBy(cars.month);
+  const byMonth = new Map<string, EvMarketShare>();
+  // Months the EV-filtered query would have returned a row for. A month with no
+  // electrified registrations at all was absent from that result, so it stays
+  // out of this one rather than appearing as a zero.
+  const monthsWithEv = new Set<string>();
 
-  const [evByMonth, totalByMonth] = await db.batch([
-    evByMonthQuery,
-    totalByMonthQuery,
-  ]);
+  for (const row of rows) {
+    // `sum()` is null only for an empty group, which a GROUP BY cannot produce
+    const count = row.count ?? 0;
 
-  const totalMap = new Map(totalByMonth.map((r) => [r.month, r.totalCount]));
+    const entry = byMonth.get(row.month) ?? {
+      month: row.month,
+      evCount: 0,
+      totalCount: 0,
+      evShare: 0,
+    };
 
-  return evByMonth
-    .map((row) => {
-      const total = totalMap.get(row.month) ?? 0;
-      return {
-        month: row.month,
-        evCount: row.evCount,
-        totalCount: total,
-        evShare: total > 0 ? (row.evCount / total) * 100 : 0,
-      };
-    })
-    .sort((a, b) => a.month.localeCompare(b.month));
+    entry.totalCount += count;
+
+    if (ALL_EV_FUEL_TYPES.includes(row.fuelType)) {
+      entry.evCount += count;
+      monthsWithEv.add(row.month);
+    }
+
+    byMonth.set(row.month, entry);
+  }
+
+  return Array.from(byMonth.values())
+    .filter((entry) => monthsWithEv.has(entry.month))
+    .map((entry) => ({
+      ...entry,
+      evShare:
+        entry.totalCount > 0 ? (entry.evCount / entry.totalCount) * 100 : 0,
+    }))
+    .sort((first, second) => first.month.localeCompare(second.month));
 }
 
 export async function getEvTopMakes(limit = 10): Promise<EvTopMake[]> {
@@ -143,18 +156,24 @@ export async function getEvTopMakes(limit = 10): Promise<EvTopMake[]> {
   const latestMonth = latestMonthResult[0]?.month;
   if (!latestMonth) return [];
 
-  return db
+  const rows = await db
     .select({
       make: cars.make,
-      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+      count: sum(cars.number).mapWith(Number),
     })
     .from(cars)
     .where(
-      sql`${cars.month} = ${latestMonth} AND ${cars.fuelType} IN ${ALL_EV_FUEL_TYPES}`,
+      and(
+        eq(cars.month, latestMonth),
+        inArray(cars.fuelType, ALL_EV_FUEL_TYPES),
+      ),
     )
     .groupBy(cars.make)
-    .orderBy(desc(sql<number>`sum(${cars.number})`))
+    .orderBy(desc(sum(cars.number)))
     .limit(limit);
+
+  // `sum()` is null only for an empty group, which a GROUP BY cannot produce
+  return rows.map(({ make, count }) => ({ make, count: count ?? 0 }));
 }
 
 export async function getEvMakeDetails(): Promise<EvMakeDetail[]> {
@@ -176,11 +195,14 @@ export async function getEvMakeDetails(): Promise<EvMakeDetail[]> {
     .select({
       make: cars.make,
       fuelType: cars.fuelType,
-      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+      count: sum(cars.number).mapWith(Number),
     })
     .from(cars)
     .where(
-      sql`${cars.month} = ${latestMonth} AND ${cars.fuelType} IN ${ALL_EV_FUEL_TYPES}`,
+      and(
+        eq(cars.month, latestMonth),
+        inArray(cars.fuelType, ALL_EV_FUEL_TYPES),
+      ),
     )
     .groupBy(cars.make, cars.fuelType);
 
@@ -197,15 +219,17 @@ export async function getEvMakeDetails(): Promise<EvMakeDetail[]> {
       });
     }
     const entry = makeMap.get(row.make)!;
+    // `sum()` is null only for an empty group, which a GROUP BY cannot produce
+    const count = row.count ?? 0;
 
     if (BEV_FUEL_TYPES.includes(row.fuelType)) {
-      entry.bev += row.count;
+      entry.bev += count;
     } else if (PHEV_FUEL_TYPES.includes(row.fuelType)) {
-      entry.phev += row.count;
+      entry.phev += count;
     } else if (HYBRID_FUEL_TYPES.includes(row.fuelType)) {
-      entry.hybrid += row.count;
+      entry.hybrid += count;
     }
-    entry.total += row.count;
+    entry.total += count;
   }
 
   return Array.from(makeMap.values()).sort((a, b) => b.total - a.total);
@@ -226,59 +250,49 @@ export async function getEvLatestSummary(): Promise<EvLatestSummary | null> {
   const latestMonth = latestMonthResult[0]?.month;
   if (!latestMonth) return null;
 
-  const evTotalQuery = db
-    .select({
-      count: sql<number>`sum(${cars.number})`.mapWith(Number),
-    })
-    .from(cars)
-    .where(
-      sql`${cars.month} = ${latestMonth} AND ${cars.fuelType} IN ${ALL_EV_FUEL_TYPES}`,
-    );
-
-  const bevTotalQuery = db
-    .select({
-      count: sql<number>`sum(${cars.number})`.mapWith(Number),
-    })
-    .from(cars)
-    .where(
-      sql`${cars.month} = ${latestMonth} AND ${cars.fuelType} IN ${BEV_FUEL_TYPES}`,
-    );
-
-  const allTotalQuery = db
-    .select({
-      count: sql<number>`sum(${cars.number})`.mapWith(Number),
-    })
-    .from(cars)
-    .where(eq(cars.month, latestMonth));
-
-  const topMakeQuery = db
+  // One scan of the month grouped by make and fuel type. The four batched
+  // aggregates it replaces were a single round-trip but ran serially, scanning
+  // the same month four times over.
+  const rows = await db
     .select({
       make: cars.make,
-      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+      fuelType: cars.fuelType,
+      count: sum(cars.number).mapWith(Number),
     })
     .from(cars)
-    .where(
-      sql`${cars.month} = ${latestMonth} AND ${cars.fuelType} IN ${ALL_EV_FUEL_TYPES}`,
-    )
-    .groupBy(cars.make)
-    .orderBy(desc(sql<number>`sum(${cars.number})`))
-    .limit(1);
+    .where(eq(cars.month, latestMonth))
+    .groupBy(cars.make, cars.fuelType);
 
-  const [evTotal, bevTotal, allTotal, topMake] = await db.batch([
-    evTotalQuery,
-    bevTotalQuery,
-    allTotalQuery,
-    topMakeQuery,
-  ]);
+  let totalEv = 0;
+  let bevCount = 0;
+  let total = 0;
+  const evByMake = new Map<string, number>();
 
-  const totalEv = evTotal[0]?.count ?? 0;
-  const total = allTotal[0]?.count ?? 0;
+  for (const row of rows) {
+    // `sum()` is null only for an empty group, which a GROUP BY cannot produce
+    const count = row.count ?? 0;
+
+    total += count;
+
+    if (ALL_EV_FUEL_TYPES.includes(row.fuelType)) {
+      totalEv += count;
+      evByMake.set(row.make, (evByMake.get(row.make) ?? 0) + count);
+    }
+
+    if (BEV_FUEL_TYPES.includes(row.fuelType)) {
+      bevCount += count;
+    }
+  }
+
+  const [topMake] = Array.from(evByMake).sort(
+    ([, first], [, second]) => second - first,
+  );
 
   return {
     month: latestMonth,
     totalEv,
     evSharePercent: total > 0 ? (totalEv / total) * 100 : 0,
-    bevCount: bevTotal[0]?.count ?? 0,
-    topMake: topMake[0]?.make ?? "N/A",
+    bevCount,
+    topMake: topMake?.[0] ?? "N/A",
   };
 }

--- a/apps/web/src/queries/cars/market-insights.ts
+++ b/apps/web/src/queries/cars/market-insights.ts
@@ -6,7 +6,7 @@ import {
 } from "@web/lib/cars/calculations";
 import { getCarsData } from "@web/queries/cars/monthly-registrations";
 import type { FuelType, TopType } from "@web/types/cars";
-import { and, desc, eq, gt, sql } from "drizzle-orm";
+import { and, desc, eq, gt, sum } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export interface CarMarketShareData {
@@ -67,23 +67,23 @@ export async function getTopTypes(month: string): Promise<TopType> {
   const topFuelTypeQuery = db
     .select({
       name: cars.fuelType,
-      total: sql<number>`sum(${cars.number})`.mapWith(Number),
+      total: sum(cars.number).mapWith(Number),
     })
     .from(cars)
     .where(eq(cars.month, month))
     .groupBy(cars.fuelType)
-    .orderBy(desc(sql<number>`sum(${cars.number})`))
+    .orderBy(desc(sum(cars.number)))
     .limit(1);
 
   const topVehicleTypeQuery = db
     .select({
       name: cars.vehicleType,
-      total: sql<number>`sum(${cars.number})`.mapWith(Number),
+      total: sum(cars.number).mapWith(Number),
     })
     .from(cars)
     .where(eq(cars.month, month))
     .groupBy(cars.vehicleType)
-    .orderBy(desc(sql<number>`sum(${cars.number})`))
+    .orderBy(desc(sum(cars.number)))
     .limit(1);
 
   const [topFuelTypeResult, topVehicleTypeResult] = await db.batch([
@@ -91,8 +91,16 @@ export async function getTopTypes(month: string): Promise<TopType> {
     topVehicleTypeQuery,
   ]);
 
-  const topFuelType = topFuelTypeResult[0] ?? { name: "N/A", total: 0 };
-  const topVehicleType = topVehicleTypeResult[0] ?? { name: "N/A", total: 0 };
+  // `sum()` is null only for an empty group, which a GROUP BY cannot produce
+  const [topFuelTypeRow] = topFuelTypeResult;
+  const [topVehicleTypeRow] = topVehicleTypeResult;
+
+  const topFuelType = topFuelTypeRow
+    ? { name: topFuelTypeRow.name, total: topFuelTypeRow.total ?? 0 }
+    : { name: "N/A", total: 0 };
+  const topVehicleType = topVehicleTypeRow
+    ? { name: topVehicleTypeRow.name, total: topVehicleTypeRow.total ?? 0 }
+    : { name: "N/A", total: 0 };
 
   return {
     month,
@@ -106,16 +114,19 @@ export async function getTopMakes(month: string): Promise<TopMake[]> {
   cacheLife("max");
   cacheTag(`cars:month:${month}`);
 
-  return db
+  const rows = await db
     .select({
       make: cars.make,
-      total: sql<number>`sum(${cars.number})`.mapWith(Number),
+      total: sum(cars.number).mapWith(Number),
     })
     .from(cars)
     .where(eq(cars.month, month))
     .groupBy(cars.make)
-    .orderBy(desc(sql<number>`sum(${cars.number})`))
+    .orderBy(desc(sum(cars.number)))
     .limit(10);
+
+  // `sum()` is null only for an empty group, which a GROUP BY cannot produce
+  return rows.map(({ make, total }) => ({ make, total: total ?? 0 }));
 }
 
 export async function getTopMakesByFuelType(
@@ -134,7 +145,7 @@ export async function getTopMakesByFuelType(
     .select({
       fuelType: cars.fuelType,
       make: cars.make,
-      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+      count: sum(cars.number).mapWith(Number),
     })
     .from(cars)
     .where(and(eq(cars.month, month), gt(cars.number, 0)))
@@ -149,8 +160,11 @@ export async function getTopMakesByFuelType(
       makes: [],
     };
 
-    entry.total += row.count;
-    entry.makes.push({ make: row.make, count: row.count });
+    // `sum()` is null only for an empty group, which a GROUP BY cannot produce
+    const count = row.count ?? 0;
+
+    entry.total += count;
+    entry.makes.push({ make: row.make, count });
     byFuelType.set(row.fuelType, entry);
   }
 

--- a/apps/web/src/queries/cars/market-insights.ts
+++ b/apps/web/src/queries/cars/market-insights.ts
@@ -56,6 +56,9 @@ interface TopMake {
   total: number;
 }
 
+/** Makes reported per fuel type by `getTopMakesByFuelType()`. */
+const TOP_MAKES_PER_FUEL_TYPE = 5;
+
 export async function getTopTypes(month: string): Promise<TopType> {
   "use cache: remote";
   cacheLife("max");
@@ -122,46 +125,43 @@ export async function getTopMakesByFuelType(
   cacheLife("max");
   cacheTag(`cars:month:${month}`);
 
-  const fuelTypeResults = await db
+  // One grouped scan, ranked here, rather than a query for the fuel types
+  // followed by a batched query per fuel type. The batch was a single
+  // round-trip but its statements still ran serially, re-scanning the same
+  // month once per fuel type. A month spans a closed set of fuel types and
+  // well under a hundred makes, so the grouped rows are cheap to carry.
+  const rows = await db
     .select({
       fuelType: cars.fuelType,
-      total: sql<number>`sum(${cars.number})`.mapWith(Number),
+      make: cars.make,
+      count: sql<number>`sum(${cars.number})`.mapWith(Number),
     })
     .from(cars)
     .where(and(eq(cars.month, month), gt(cars.number, 0)))
-    .groupBy(cars.fuelType)
-    .orderBy(desc(sql<number>`sum(${cars.number})`));
+    .groupBy(cars.fuelType, cars.make);
 
-  if (fuelTypeResults.length === 0) {
-    return [];
+  const byFuelType = new Map<string, FuelType>();
+
+  for (const row of rows) {
+    const entry = byFuelType.get(row.fuelType) ?? {
+      fuelType: row.fuelType,
+      total: 0,
+      makes: [],
+    };
+
+    entry.total += row.count;
+    entry.makes.push({ make: row.make, count: row.count });
+    byFuelType.set(row.fuelType, entry);
   }
 
-  const topMakesQueries = fuelTypeResults.map(({ fuelType }) =>
-    db
-      .select({
-        make: cars.make,
-        count: sql<number>`sum(${cars.number})`.mapWith(Number),
-      })
-      .from(cars)
-      .where(and(eq(cars.month, month), eq(cars.fuelType, fuelType)))
-      .groupBy(cars.make)
-      .orderBy(desc(sql<number>`sum(${cars.number})`))
-      .limit(5),
-  );
-
-  // Use db.batch() for single network round-trip
-  const topMakesResults = await db.batch(
-    topMakesQueries as [
-      (typeof topMakesQueries)[0],
-      ...(typeof topMakesQueries)[number][],
-    ],
-  );
-
-  return fuelTypeResults.map(({ fuelType, total }, index) => ({
-    fuelType,
-    total,
-    makes: topMakesResults[index].map(({ make, count }) => ({ make, count })),
-  }));
+  return Array.from(byFuelType.values())
+    .sort((first, second) => second.total - first.total)
+    .map((entry) => ({
+      ...entry,
+      makes: entry.makes
+        .sort((first, second) => second.count - first.count)
+        .slice(0, TOP_MAKES_PER_FUEL_TYPE),
+    }));
 }
 
 export async function getCarMarketShareData(

--- a/apps/web/src/queries/cars/monthly-registrations.ts
+++ b/apps/web/src/queries/cars/monthly-registrations.ts
@@ -2,7 +2,7 @@ import { db } from "@motormetrics/database/client";
 import { cars } from "@motormetrics/database/schema";
 import type { Comparison, Registration } from "@web/types/cars";
 import { format, subMonths } from "date-fns";
-import { desc, eq, gt, ilike, sql, sum } from "drizzle-orm";
+import { and, desc, eq, gt, gte, lte, sql, sum } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export async function getCarsData(month: string): Promise<Registration> {
@@ -182,13 +182,16 @@ export async function getYearToDateByFuelType(
   cacheLife("max");
   cacheTag(`cars:year:${year}`);
 
+  // A range on the stored `YYYY-MM` text rather than `ilike '<year>-%'`, which
+  // no btree index can serve. Lexicographic ordering on `YYYY-MM` is
+  // chronological, so the bounds are exact.
   return db
     .select({
       name: cars.fuelType,
       count: sql<number>`sum(${cars.number})`.mapWith(Number),
     })
     .from(cars)
-    .where(ilike(cars.month, `${year}-%`))
+    .where(and(gte(cars.month, `${year}-01`), lte(cars.month, `${year}-12`)))
     .groupBy(cars.fuelType)
     .having(gt(sum(cars.number), 0))
     .orderBy(desc(sql<number>`sum(${cars.number})`));

--- a/apps/web/src/queries/cars/monthly-registrations.ts
+++ b/apps/web/src/queries/cars/monthly-registrations.ts
@@ -2,56 +2,58 @@ import { db } from "@motormetrics/database/client";
 import { cars } from "@motormetrics/database/schema";
 import type { Comparison, Registration } from "@web/types/cars";
 import { format, subMonths } from "date-fns";
-import { and, desc, eq, gt, gte, lte, sql, sum } from "drizzle-orm";
+import { and, desc, eq, gt, gte, inArray, lte, sum } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
+
+/**
+ * Registration groups largest first — the `order by sum(number) desc` the
+ * grouped queries used to carry, applied here so a month can be grouped once
+ * and split by dimension rather than queried once per dimension.
+ *
+ * `sum()` is null only for an empty group, which a GROUP BY cannot produce.
+ */
+const sortByCount = <Row extends { count: number | null }>(
+  rows: Row[],
+): (Row & { count: number })[] =>
+  rows
+    .map((row) => ({ ...row, count: row.count ?? 0 }))
+    .sort((first, second) => second.count - first.count);
 
 export async function getCarsData(month: string): Promise<Registration> {
   "use cache: remote";
   cacheLife("max");
   cacheTag(`cars:month:${month}`);
 
-  const fuelTypeQuery = db
-    .select({
-      name: cars.fuelType,
-      count: sql<number>`sum(${cars.number})`.mapWith(Number),
-    })
-    .from(cars)
-    .where(eq(cars.month, month))
-    .groupBy(cars.fuelType)
-    .having(gt(sum(cars.number), 0))
-    .orderBy(desc(sql<number>`sum(${cars.number})`));
-
-  const vehicleTypeQuery = db
-    .select({
-      name: cars.vehicleType,
-      count: sql<number>`sum(${cars.number})`.mapWith(Number),
-    })
-    .from(cars)
-    .where(eq(cars.month, month))
-    .groupBy(cars.vehicleType)
-    .having(gt(sum(cars.number), 0))
-    .orderBy(desc(sql<number>`sum(${cars.number})`));
-
-  const totalQuery = db
-    .select({
-      total: sql<number>`sum(${cars.number})`.mapWith(Number),
-    })
-    .from(cars)
-    .where(eq(cars.month, month));
-
-  const [fuelType, vehicleType, totalResult] = await db.batch([
-    fuelTypeQuery,
-    vehicleTypeQuery,
-    totalQuery,
+  // Two grouped scans rather than three. The separate total query is gone: the
+  // fuel type groups partition the month's rows, so their sum is that total.
+  const [fuelTypeRows, vehicleTypeRows] = await db.batch([
+    db
+      .select({
+        name: cars.fuelType,
+        count: sum(cars.number).mapWith(Number),
+      })
+      .from(cars)
+      .where(eq(cars.month, month))
+      .groupBy(cars.fuelType),
+    db
+      .select({
+        name: cars.vehicleType,
+        count: sum(cars.number).mapWith(Number),
+      })
+      .from(cars)
+      .where(eq(cars.month, month))
+      .groupBy(cars.vehicleType),
   ]);
 
-  const total = totalResult[0]?.total ?? 0;
+  const fuelType = sortByCount(fuelTypeRows);
+  const total = fuelType.reduce((running, row) => running + row.count, 0);
 
   return {
     month,
     total,
-    fuelType,
-    vehicleType,
+    // `having sum(number) > 0` on the grouped queries, applied here
+    fuelType: fuelType.filter((row) => row.count > 0),
+    vehicleType: sortByCount(vehicleTypeRows).filter((row) => row.count > 0),
   };
 }
 
@@ -61,83 +63,55 @@ export async function getCarsComparison(month: string): Promise<Comparison> {
   cacheTag(`cars:month:${month}`);
 
   const currentDate = new Date(`${month}-01`);
-  const previousMonthDate = subMonths(currentDate, 1);
-  const previousMonthStr = format(previousMonthDate, "yyyy-MM");
-  const previousYearDate = subMonths(currentDate, 12);
-  const previousYearStr = format(previousYearDate, "yyyy-MM");
+  const previousMonthStr = format(subMonths(currentDate, 1), "yyyy-MM");
+  const previousYearStr = format(subMonths(currentDate, 12), "yyyy-MM");
+  const months = [month, previousMonthStr, previousYearStr];
 
-  const createFuelTypeQuery = (m: string) =>
+  // Two scans covering all three months, rather than nine single-month scans.
+  // The batch was one round-trip either way, but its statements ran serially,
+  // so the month partitions were read three times over.
+  const [fuelTypeRows, vehicleTypeRows] = await db.batch([
     db
       .select({
+        month: cars.month,
         label: cars.fuelType,
-        count: sql<number>`sum(${cars.number})`.mapWith(Number),
+        count: sum(cars.number).mapWith(Number),
       })
       .from(cars)
-      .where(eq(cars.month, m))
-      .groupBy(cars.fuelType)
-      .orderBy(desc(sql<number>`sum(${cars.number})`));
-
-  const createVehicleTypeQuery = (m: string) =>
+      .where(inArray(cars.month, months))
+      .groupBy(cars.month, cars.fuelType),
     db
       .select({
+        month: cars.month,
         label: cars.vehicleType,
-        count: sql<number>`sum(${cars.number})`.mapWith(Number),
+        count: sum(cars.number).mapWith(Number),
       })
       .from(cars)
-      .where(eq(cars.month, m))
-      .groupBy(cars.vehicleType)
-      .orderBy(desc(sql<number>`sum(${cars.number})`));
-
-  const createTotalQuery = (m: string) =>
-    db
-      .select({
-        total: sql<number>`sum(${cars.number})`.mapWith(Number),
-      })
-      .from(cars)
-      .where(eq(cars.month, m));
-
-  // Execute all 9 queries in a single batch (3 months × 3 query types)
-  const [
-    currentFuelType,
-    currentVehicleType,
-    currentTotal,
-    previousMonthFuelType,
-    previousMonthVehicleType,
-    previousMonthTotal,
-    previousYearFuelType,
-    previousYearVehicleType,
-    previousYearTotal,
-  ] = await db.batch([
-    createFuelTypeQuery(month),
-    createVehicleTypeQuery(month),
-    createTotalQuery(month),
-    createFuelTypeQuery(previousMonthStr),
-    createVehicleTypeQuery(previousMonthStr),
-    createTotalQuery(previousMonthStr),
-    createFuelTypeQuery(previousYearStr),
-    createVehicleTypeQuery(previousYearStr),
-    createTotalQuery(previousYearStr),
+      .where(inArray(cars.month, months))
+      .groupBy(cars.month, cars.vehicleType),
   ]);
 
+  const forPeriod = (period: string) => {
+    const fuelType = sortByCount(
+      fuelTypeRows.filter((row) => row.month === period),
+    );
+    const vehicleType = sortByCount(
+      vehicleTypeRows.filter((row) => row.month === period),
+    );
+
+    return {
+      period,
+      // The fuel type groups partition the period's rows, so they sum to its total
+      total: fuelType.reduce((running, row) => running + row.count, 0),
+      fuelType: fuelType.map(({ label, count }) => ({ label, count })),
+      vehicleType: vehicleType.map(({ label, count }) => ({ label, count })),
+    };
+  };
+
   return {
-    currentMonth: {
-      period: month,
-      total: currentTotal[0]?.total ?? 0,
-      fuelType: currentFuelType,
-      vehicleType: currentVehicleType,
-    },
-    previousMonth: {
-      period: previousMonthStr,
-      total: previousMonthTotal[0]?.total ?? 0,
-      fuelType: previousMonthFuelType,
-      vehicleType: previousMonthVehicleType,
-    },
-    previousYear: {
-      period: previousYearStr,
-      total: previousYearTotal[0]?.total ?? 0,
-      fuelType: previousYearFuelType,
-      vehicleType: previousYearVehicleType,
-    },
+    currentMonth: forPeriod(month),
+    previousMonth: forPeriod(previousMonthStr),
+    previousYear: forPeriod(previousYearStr),
   };
 }
 
@@ -161,14 +135,16 @@ export async function getMonthlyRegistrationTotals(
   const results = await db
     .select({
       month: cars.month,
-      total: sql<number>`sum(${cars.number})`.mapWith(Number),
+      total: sum(cars.number).mapWith(Number),
     })
     .from(cars)
     .groupBy(cars.month)
     .orderBy(desc(cars.month))
     .limit(limit);
 
-  return results.reverse();
+  return results
+    .map(({ month, total }) => ({ month, total: total ?? 0 }))
+    .reverse();
 }
 
 /**
@@ -185,16 +161,18 @@ export async function getYearToDateByFuelType(
   // A range on the stored `YYYY-MM` text rather than `ilike '<year>-%'`, which
   // no btree index can serve. Lexicographic ordering on `YYYY-MM` is
   // chronological, so the bounds are exact.
-  return db
+  const results = await db
     .select({
       name: cars.fuelType,
-      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+      count: sum(cars.number).mapWith(Number),
     })
     .from(cars)
     .where(and(gte(cars.month, `${year}-01`), lte(cars.month, `${year}-12`)))
     .groupBy(cars.fuelType)
     .having(gt(sum(cars.number), 0))
-    .orderBy(desc(sql<number>`sum(${cars.number})`));
+    .orderBy(desc(sum(cars.number)));
+
+  return results.map(({ name, count }) => ({ name, count: count ?? 0 }));
 }
 
 /**
@@ -214,7 +192,7 @@ export async function getMonthlyRegistrationTotalsByFuelType(
   const results = await db
     .select({
       month: cars.month,
-      total: sql<number>`sum(${cars.number})`.mapWith(Number),
+      total: sum(cars.number).mapWith(Number),
     })
     .from(cars)
     .where(eq(cars.fuelType, fuelType))
@@ -223,5 +201,7 @@ export async function getMonthlyRegistrationTotalsByFuelType(
     .orderBy(desc(cars.month))
     .limit(limit);
 
-  return results.reverse();
+  return results
+    .map(({ month, total }) => ({ month, total: total ?? 0 }))
+    .reverse();
 }

--- a/apps/web/src/queries/cars/yearly-statistics.ts
+++ b/apps/web/src/queries/cars/yearly-statistics.ts
@@ -1,9 +1,7 @@
 import { db } from "@motormetrics/database/client";
 import { cars } from "@motormetrics/database/schema";
-import { and, desc, eq, gt, sql } from "drizzle-orm";
+import { and, desc, gt, gte, lte, max, sum } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
-
-const yearExpr = sql`extract(year from to_date(${cars.month}, 'YYYY-MM'))`;
 
 interface YearlyTotal {
   year: number;
@@ -14,6 +12,24 @@ interface YearOnly {
   year: number;
 }
 
+interface MakeValue {
+  make: string;
+  value: number;
+}
+
+/** The year component of a stored `YYYY-MM` month. */
+const yearOf = (month: string) => Number(month.slice(0, 4));
+
+/** Year of the most recent month carrying registrations, or null when empty. */
+const latestRegistrationYear = async (): Promise<number | null> => {
+  const [latest] = await db
+    .select({ month: max(cars.month) })
+    .from(cars)
+    .where(gt(cars.number, 0));
+
+  return latest?.month ? yearOf(latest.month) : null;
+};
+
 /**
  * Get yearly registration totals aggregated from monthly data (ascending order for charts)
  */
@@ -22,15 +38,28 @@ export async function getYearlyRegistrations(): Promise<YearlyTotal[]> {
   cacheLife("max");
   cacheTag("cars:annual");
 
-  return db
+  // Grouped by month and folded into years here rather than grouping on
+  // `extract(year from to_date(month, ...))`, which parsed a date on every row
+  // of a full scan. A decade of months is a couple of hundred rows.
+  const rows = await db
     .select({
-      year: sql<number>`cast(${yearExpr} as integer)`.mapWith(Number),
-      total: sql<number>`cast(sum(${cars.number}) as integer)`.mapWith(Number),
+      month: cars.month,
+      total: sum(cars.number).mapWith(Number),
     })
     .from(cars)
     .where(gt(cars.number, 0))
-    .groupBy(yearExpr)
-    .orderBy(yearExpr);
+    .groupBy(cars.month)
+    .orderBy(cars.month);
+
+  const totals = new Map<number, number>();
+
+  for (const row of rows) {
+    const year = yearOf(row.month);
+    // `sum()` is null only for an empty group, which a GROUP BY cannot produce
+    totals.set(year, (totals.get(year) ?? 0) + (row.total ?? 0));
+  }
+
+  return Array.from(totals, ([year, total]) => ({ year, total }));
 }
 
 /**
@@ -41,19 +70,15 @@ export async function getAvailableYears(): Promise<YearOnly[]> {
   cacheLife("max");
   cacheTag("cars:annual");
 
-  return db
-    .select({
-      year: sql<number>`cast(${yearExpr} as integer)`.mapWith(Number),
-    })
+  const rows = await db
+    .selectDistinct({ month: cars.month })
     .from(cars)
     .where(gt(cars.number, 0))
-    .groupBy(yearExpr)
-    .orderBy(desc(yearExpr));
-}
+    .orderBy(desc(cars.month));
 
-interface MakeValue {
-  make: string;
-  value: number;
+  const years = new Set(rows.map((row) => yearOf(row.month)));
+
+  return Array.from(years, (year) => ({ year }));
 }
 
 /**
@@ -70,23 +95,33 @@ export async function getTopMakesByYear(
     cacheTag(`cars:year:${year}`);
   }
 
-  // Use SQL subquery for latest year instead of nested await
-  const latestYearSubquery = db
-    .select({ year: sql<number>`max(${yearExpr})` })
-    .from(cars)
-    .where(gt(cars.number, 0));
+  const targetYear = year ?? (await latestRegistrationYear());
 
-  const targetYear = year ?? sql`(${latestYearSubquery})`;
-  const sumExpr = sql`sum(${cars.number})`;
+  if (!targetYear) {
+    return [];
+  }
 
-  return db
+  // Bounds on the stored `YYYY-MM` text rather than
+  // `extract(year from to_date(month, ...)) = year`, which parsed a date on
+  // every row and left the month index unusable. Lexicographic ordering on
+  // `YYYY-MM` is chronological, so the range is exact.
+  const rows = await db
     .select({
       make: cars.make,
-      value: sql<number>`cast(${sumExpr} as integer)`.mapWith(Number),
+      value: sum(cars.number).mapWith(Number),
     })
     .from(cars)
-    .where(and(eq(yearExpr, targetYear), gt(cars.number, 0)))
+    .where(
+      and(
+        gte(cars.month, `${targetYear}-01`),
+        lte(cars.month, `${targetYear}-12`),
+        gt(cars.number, 0),
+      ),
+    )
     .groupBy(cars.make)
-    .orderBy(desc(sumExpr))
+    .orderBy(desc(sum(cars.number)))
     .limit(limit);
+
+  // `sum()` is null only for an empty group, which a GROUP BY cannot produce
+  return rows.map(({ make, value }) => ({ make, value: value ?? 0 }));
 }

--- a/apps/web/src/queries/category-summary.test.ts
+++ b/apps/web/src/queries/category-summary.test.ts
@@ -13,10 +13,15 @@ describe("category summary queries", () => {
   });
 
   it("should return category summary for current year", async () => {
-    // Queue: 1) latestYearSubquery builder, 2) main query result
+    // Queue: 1) latest month carrying registrations, 2) totals per fuel type
     queueSelect(
-      [],
-      [{ year: 2024, total: 100000, electric: 15000, hybrid: 25000 }],
+      [{ month: "2024-11" }],
+      [
+        { fuelType: "Petrol", total: 60000 },
+        { fuelType: "Electric", total: 15000 },
+        { fuelType: "Petrol-Electric", total: 20000 },
+        { fuelType: "Diesel-Electric (Plug-In)", total: 5000 },
+      ],
     );
 
     const result = await getCategorySummaryByYear();
@@ -36,11 +41,12 @@ describe("category summary queries", () => {
   });
 
   it("should return category summary for explicit year", async () => {
-    // Queue: 1) latestYearSubquery builder (created but not used), 2) main query result
-    queueSelect(
-      [],
-      [{ year: 2023, total: 90000, electric: 10000, hybrid: 20000 }],
-    );
+    // An explicit year skips the latest-month lookup, so there is one query
+    queueSelect([
+      { fuelType: "Petrol", total: 60000 },
+      { fuelType: "Electric", total: 10000 },
+      { fuelType: "Petrol-Electric", total: 20000 },
+    ]);
 
     const result = await getCategorySummaryByYear(2023);
 
@@ -57,8 +63,8 @@ describe("category summary queries", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-06-15"));
 
-    // Queue: 1) latestYearSubquery builder, 2) main query (empty)
-    queueSelect([], []);
+    // The latest-month lookup comes back empty, so no second query runs
+    queueSelect([]);
 
     const result = await getCategorySummaryByYear();
 

--- a/apps/web/src/queries/electric-vehicles.test.ts
+++ b/apps/web/src/queries/electric-vehicles.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  getEvLatestSummary,
+  getEvMakeDetails,
+  getEvMarketShare,
+  getEvMonthlyTrend,
+  getEvTopMakes,
+} from "./cars/electric-vehicles";
+import { cacheLifeMock, queueSelect, resetDbMocks } from "./test-utils";
+
+describe("electric vehicle queries", () => {
+  beforeEach(() => {
+    resetDbMocks();
+  });
+
+  it("should split registrations into BEV, PHEV and hybrid", async () => {
+    queueSelect([
+      { month: "2024-01", fuelType: "Electric", count: 10 },
+      { month: "2024-01", fuelType: "Petrol-Electric", count: 4 },
+      { month: "2024-01", fuelType: "Petrol-Electric (Plug-In)", count: 2 },
+    ]);
+
+    const result = await getEvMonthlyTrend();
+
+    expect(result).toEqual([{ month: "2024-01", BEV: 10, PHEV: 2, Hybrid: 4 }]);
+    expect(cacheLifeMock).toHaveBeenCalledWith("max");
+  });
+
+  it("should measure the electrified share against every fuel type", async () => {
+    queueSelect([
+      { month: "2024-01", fuelType: "Electric", count: 20 },
+      { month: "2024-01", fuelType: "Petrol", count: 80 },
+    ]);
+
+    const result = await getEvMarketShare();
+
+    expect(result).toEqual([
+      { month: "2024-01", evCount: 20, totalCount: 100, evShare: 20 },
+    ]);
+  });
+
+  it("should omit months with no electrified registrations", async () => {
+    queueSelect([
+      { month: "2024-01", fuelType: "Electric", count: 20 },
+      { month: "2024-02", fuelType: "Petrol", count: 50 },
+    ]);
+
+    const result = await getEvMarketShare();
+
+    expect(result.map((entry) => entry.month)).toEqual(["2024-01"]);
+  });
+
+  it("should summarise the latest month by make", async () => {
+    // 1. latest month carrying electrified registrations, 2. that month's rows
+    queueSelect(
+      [{ month: "2024-06" }],
+      [
+        { make: "BYD", fuelType: "Electric", count: 10 },
+        { make: "Tesla", fuelType: "Electric", count: 30 },
+        { make: "Toyota", fuelType: "Petrol", count: 60 },
+      ],
+    );
+
+    const result = await getEvLatestSummary();
+
+    expect(result).toEqual({
+      month: "2024-06",
+      totalEv: 40,
+      evSharePercent: 40,
+      bevCount: 40,
+      topMake: "Tesla",
+    });
+  });
+
+  it("should return null when no electrified registrations exist", async () => {
+    queueSelect([]);
+
+    expect(await getEvLatestSummary()).toBeNull();
+  });
+
+  it("should rank makes for the latest month", async () => {
+    queueSelect([{ month: "2024-06" }], [{ make: "Tesla", count: 30 }]);
+
+    expect(await getEvTopMakes()).toEqual([{ make: "Tesla", count: 30 }]);
+  });
+
+  it("should break each make down by electrification type", async () => {
+    queueSelect(
+      [{ month: "2024-06" }],
+      [
+        { make: "Tesla", fuelType: "Electric", count: 30 },
+        { make: "Toyota", fuelType: "Petrol-Electric", count: 12 },
+        { make: "Toyota", fuelType: "Petrol-Electric (Plug-In)", count: 3 },
+      ],
+    );
+
+    // Largest total first
+    expect(await getEvMakeDetails()).toEqual([
+      { make: "Tesla", bev: 30, phev: 0, hybrid: 0, total: 30 },
+      { make: "Toyota", bev: 0, phev: 3, hybrid: 12, total: 15 },
+    ]);
+  });
+
+  it("should return an empty list when no month has electrified data", async () => {
+    queueSelect([]);
+
+    expect(await getEvMakeDetails()).toEqual([]);
+  });
+});

--- a/apps/web/src/queries/market-insights.test.ts
+++ b/apps/web/src/queries/market-insights.test.ts
@@ -58,24 +58,24 @@ describe("car market insight queries", () => {
   });
 
   it("groups top makes for every fuel type", async () => {
-    // First query (non-batched) fetches fuel type totals
+    // A single grouped query returns every fuel type / make pair for the month
     queueSelect([
-      { fuelType: "Electric", total: 100 },
-      { fuelType: "Hybrid", total: 20 },
-    ]);
-    // Then db.batch is called with queries for each fuel type
-    queueBatch([
-      [{ make: "Tesla", count: 80 }],
-      [{ make: "Toyota", count: 20 }],
+      { fuelType: "Hybrid", make: "Toyota", count: 20 },
+      { fuelType: "Electric", make: "Tesla", count: 80 },
+      { fuelType: "Electric", make: "BYD", count: 20 },
     ]);
 
     const result = await marketInsights.getTopMakesByFuelType("2024-06");
 
+    // Fuel types ordered by their total, makes ordered within each
     expect(result).toEqual([
       {
         fuelType: "Electric",
         total: 100,
-        makes: [{ make: "Tesla", count: 80 }],
+        makes: [
+          { make: "Tesla", count: 80 },
+          { make: "BYD", count: 20 },
+        ],
       },
       {
         fuelType: "Hybrid",
@@ -84,6 +84,27 @@ describe("car market insight queries", () => {
       },
     ]);
     expect(cacheTagMock).toHaveBeenCalledWith("cars:month:2024-06");
+  });
+
+  it("reports every make in the fuel type total but only the top five", async () => {
+    queueSelect(
+      Array.from({ length: 7 }, (_, index) => ({
+        fuelType: "Electric",
+        make: `Make ${index}`,
+        count: index + 1,
+      })),
+    );
+
+    const [electric] = await marketInsights.getTopMakesByFuelType("2024-06");
+
+    expect(electric.total).toBe(28);
+    expect(electric.makes).toEqual([
+      { make: "Make 6", count: 7 },
+      { make: "Make 5", count: 6 },
+      { make: "Make 4", count: 5 },
+      { make: "Make 3", count: 4 },
+      { make: "Make 2", count: 3 },
+    ]);
   });
 
   it("computes market share breakdowns from cached data", async () => {

--- a/apps/web/src/queries/monthly-registrations.test.ts
+++ b/apps/web/src/queries/monthly-registrations.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { getCarsComparison, getCarsData } from "./cars/monthly-registrations";
+import {
+  getCarsComparison,
+  getCarsData,
+  getMonthlyRegistrationTotals,
+  getMonthlyRegistrationTotalsByFuelType,
+  getYearToDateByFuelType,
+} from "./cars/monthly-registrations";
 import {
   cacheLifeMock,
   cacheTagMock,
   queueBatch,
+  queueSelect,
   resetDbMocks,
 } from "./test-utils";
 
@@ -107,5 +114,59 @@ describe("monthly registration queries", () => {
     expect(result.currentMonth.total).toBe(0);
     expect(result.previousMonth.total).toBe(0);
     expect(result.previousYear.total).toBe(0);
+  });
+
+  it("should return monthly totals oldest first", async () => {
+    // The query reads newest first; the series is reversed for the sparkline
+    queueSelect([
+      { month: "2024-03", total: 30 },
+      { month: "2024-02", total: 20 },
+    ]);
+
+    const result = await getMonthlyRegistrationTotals();
+
+    expect(result).toEqual([
+      { month: "2024-02", total: 20 },
+      { month: "2024-03", total: 30 },
+    ]);
+    expect(cacheTagMock).toHaveBeenCalledWith("cars:monthly-totals");
+  });
+
+  it("should report year-to-date registrations per fuel type", async () => {
+    queueSelect([
+      { name: "Electric", count: 40 },
+      { name: "Petrol", count: 10 },
+    ]);
+
+    const result = await getYearToDateByFuelType(2024);
+
+    expect(result).toEqual([
+      { name: "Electric", count: 40 },
+      { name: "Petrol", count: 10 },
+    ]);
+    expect(cacheTagMock).toHaveBeenCalledWith("cars:year:2024");
+  });
+
+  it("should tag the monthly series per fuel type", async () => {
+    queueSelect([
+      { month: "2024-03", total: 8 },
+      { month: "2024-02", total: 5 },
+    ]);
+
+    const result = await getMonthlyRegistrationTotalsByFuelType("Electric");
+
+    expect(result).toEqual([
+      { month: "2024-02", total: 5 },
+      { month: "2024-03", total: 8 },
+    ]);
+    expect(cacheTagMock).toHaveBeenCalledWith("cars:monthly-totals:Electric");
+  });
+
+  it("should treat a null sum as zero", async () => {
+    queueSelect([{ month: "2024-02", total: null }]);
+
+    const result = await getMonthlyRegistrationTotals();
+
+    expect(result).toEqual([{ month: "2024-02", total: 0 }]);
   });
 });

--- a/apps/web/src/queries/monthly-registrations.test.ts
+++ b/apps/web/src/queries/monthly-registrations.test.ts
@@ -13,14 +13,13 @@ describe("monthly registration queries", () => {
   });
 
   it("should aggregate monthly registrations by fuel and vehicle type", async () => {
-    // db.batch returns array of results for all queries
+    // Two grouped queries; the total is derived from the fuel type groups
     queueBatch([
       [
-        { name: "Electric", count: 10 },
         { name: "Hybrid", count: 2 },
+        { name: "Electric", count: 10 },
       ],
       [{ name: "SUV", count: 5 }],
-      [{ total: 12 }],
     ]);
 
     const result = await getCarsData("2024-06");
@@ -39,7 +38,7 @@ describe("monthly registration queries", () => {
   });
 
   it("should return 0 total when no data exists for month", async () => {
-    queueBatch([[], [], []]);
+    queueBatch([[], []]);
 
     const result = await getCarsData("2099-01");
 
@@ -48,18 +47,33 @@ describe("monthly registration queries", () => {
     expect(result.vehicleType).toEqual([]);
   });
 
-  it("should provide comparisons for previous month and year", async () => {
-    // db.batch returns array of 9 results (3 months × 3 query types)
+  it("should drop groups that sum to nothing", async () => {
     queueBatch([
-      [{ label: "Electric", count: 8 }], // currentMonth fuelType
-      [{ label: "SUV", count: 6 }], // currentMonth vehicleType
-      [{ total: 8 }], // currentMonth total
-      [{ label: "Petrol", count: 3 }], // previousMonth fuelType
-      [{ label: "Sedan", count: 4 }], // previousMonth vehicleType
-      [{ total: 3 }], // previousMonth total
-      [], // previousYear fuelType
-      [], // previousYear vehicleType
-      [{ total: 0 }], // previousYear total
+      [
+        { name: "Electric", count: 10 },
+        { name: "Diesel", count: 0 },
+      ],
+      [{ name: "SUV", count: 10 }],
+    ]);
+
+    const result = await getCarsData("2024-06");
+
+    // The empty group still counts towards the total, as the old total query did
+    expect(result.total).toBe(10);
+    expect(result.fuelType).toEqual([{ name: "Electric", count: 10 }]);
+  });
+
+  it("should provide comparisons for previous month and year", async () => {
+    // Two grouped queries spanning all three months, split by month here
+    queueBatch([
+      [
+        { month: "2024-06", label: "Electric", count: 8 },
+        { month: "2024-05", label: "Petrol", count: 3 },
+      ],
+      [
+        { month: "2024-06", label: "SUV", count: 6 },
+        { month: "2024-05", label: "Sedan", count: 4 },
+      ],
     ]);
 
     const result = await getCarsComparison("2024-06");
@@ -86,17 +100,7 @@ describe("monthly registration queries", () => {
   });
 
   it("should return 0 totals when no data exists for comparison periods", async () => {
-    queueBatch([
-      [], // currentMonth fuelType
-      [], // currentMonth vehicleType
-      [], // currentMonth total - empty
-      [], // previousMonth fuelType
-      [], // previousMonth vehicleType
-      [], // previousMonth total - empty
-      [], // previousYear fuelType
-      [], // previousYear vehicleType
-      [], // previousYear total - empty
-    ]);
+    queueBatch([[], []]);
 
     const result = await getCarsComparison("2099-01");
 

--- a/apps/web/src/queries/yearly-statistics.test.ts
+++ b/apps/web/src/queries/yearly-statistics.test.ts
@@ -16,22 +16,26 @@ describe("yearly statistics queries", () => {
   });
 
   it("aggregates yearly registration totals", async () => {
-    queueSelect([{ year: 2022, total: 123 }]);
+    // The query groups by month; the fold into years happens here
+    queueSelect([
+      { month: "2022-01", total: 100 },
+      { month: "2022-07", total: 23 },
+      { month: "2023-02", total: 40 },
+    ]);
 
     const result = await getYearlyRegistrations();
 
-    expect(result).toEqual([{ year: 2022, total: 123 }]);
+    expect(result).toEqual([
+      { year: 2022, total: 123 },
+      { year: 2023, total: 40 },
+    ]);
     expect(cacheLifeMock).toHaveBeenCalledWith("max");
     expect(cacheTagMock).toHaveBeenCalledWith("cars:annual");
   });
 
   it("returns top makes for an explicit year", async () => {
-    // Queue results in order of db.select() calls:
-    // 1. latestYearSubquery (embedded in SQL, not awaited directly), 2. main query
-    queueSelect(
-      [], // latestYearSubquery (created but not used when year is provided)
-      [{ make: "Tesla", value: 50 }], // main query result
-    );
+    // An explicit year skips the latest-year lookup, so there is one query
+    queueSelect([{ make: "Tesla", value: 50 }]);
 
     const result = await getTopMakesByYear(2024, 1);
 
@@ -40,7 +44,8 @@ describe("yearly statistics queries", () => {
   });
 
   it("derives latest year when no year is supplied", async () => {
-    queueSelect([{ year: 2021 }], [{ make: "Toyota", value: 80 }]);
+    // 1. latest month carrying registrations, 2. the makes for that year
+    queueSelect([{ month: "2021-11" }], [{ make: "Toyota", value: 80 }]);
 
     const result = await getTopMakesByYear();
 
@@ -48,9 +53,8 @@ describe("yearly statistics queries", () => {
   });
 
   it("returns an empty list when no data is present", async () => {
-    // Queue results in order of db.select() calls:
-    // 1. latestYearSubquery, 2. main query (empty)
-    queueSelect([], []);
+    // The latest-month lookup comes back empty, so no second query runs
+    queueSelect([]);
 
     const result = await getTopMakesByYear();
 

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -93,9 +93,6 @@ export default defineConfig({
         "src/components/top-makes-chart.tsx",
         "src/components/shared/skeleton.tsx",
 
-        // EV queries (DB aggregation, no testable logic without DB)
-        "src/queries/cars/electric-vehicles.ts",
-
         // Simple DB/API wrappers (no business logic)
         "src/queries/cars/latest-month.ts",
         "src/utils/social/linkedin.ts",

--- a/packages/database/migrations/20260912045633_mute_luckman/migration.sql
+++ b/packages/database/migrations/20260912045633_mute_luckman/migration.sql
@@ -1,0 +1,2 @@
+DROP INDEX "cars_month_make_index";--> statement-breakpoint
+DROP INDEX "cars_make_fuel_type_index";

--- a/packages/database/migrations/20260912045633_mute_luckman/snapshot.json
+++ b/packages/database/migrations/20260912045633_mute_luckman/snapshot.json
@@ -1,0 +1,3147 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "ea790fe8-7cc7-404e-a8a9-1a494442cf05",
+  "prevIds": ["feecab95-736d-4208-a42a-5a76289f8674"],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "car_population",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "cars",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "coe",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "deregistrations",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "ev_charging_events",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "ev_charging_points",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "ev_connector_status",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "ev_location_hourly",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "posts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "pqp",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "vehicle_population",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "accounts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "verifications",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car_population"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "year",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car_population"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "make",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car_population"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fuel_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car_population"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "number",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "car_population"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cars"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "month",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cars"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "make",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cars"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "importer_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cars"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fuel_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cars"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vehicle_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cars"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "number",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "cars"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "month",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bidding_no",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vehicle_class",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "quota",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bids_success",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "bids_received",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "premium",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "deregistrations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "month",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "deregistrations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "category",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "deregistrations"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "number",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "deregistrations"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ev_cp_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "previous_value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "observed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_events"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ev_cp_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "registration_code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "operator",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "1",
+      "generated": null,
+      "identity": null,
+      "name": "outlets",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plug_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "charging_speed_kw",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "postal_code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "block_house_no",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "street_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "building_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "floor_no",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "lot_no",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "publicly_accessible",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "longitude",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "latitude",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "date",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "registration_date",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "parking_lot_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ev_cp_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "charger_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "station_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "postal_code",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "longitude",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "latitude",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "operator",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "operation_hours",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "position",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plug_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "power_rating",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "charging_speed_kw",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "price",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "price_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status_changed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "observed_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_location_hourly"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hour",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_location_hourly"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "samples",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_location_hourly"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "connector_samples",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_location_hourly"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "occupied_samples",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_location_hourly"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "unavailable_samples",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "ev_location_hourly"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "excerpt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "hero_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tags",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "highlights",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "'draft'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "month",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "data_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "vector(768)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embedding",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "modified_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pqp"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "month",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pqp"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "vehicle_class",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pqp"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "pqp",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "pqp"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "gen_random_uuid()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "vehicle_population"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "year",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "vehicle_population"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "category",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "vehicle_population"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fuel_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "vehicle_population"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "number",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "vehicle_population"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issuer",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impersonated_by",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "banned",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_reason",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_expires",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "year",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "make",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "car_population_year_make_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "car_population"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "year",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "fuel_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "car_population_year_fuel_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "car_population"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "year",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "car_population_year_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "car_population"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "make",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "car_population_make_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "car_population"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "fuel_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "car_population_fuel_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "car_population"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "month",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cars_month_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cars"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "make",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cars_make_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cars"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "fuel_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cars_fuel_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cars"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "number",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "cars_number_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "cars"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "month",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "vehicle_class",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "coe_month_vehicle_class_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "vehicle_class",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "coe_vehicle_class_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "month",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "bidding_no",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "coe_month_bidding_no_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "premium",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "coe_premium_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "bids_success",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "bids_received",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "coe_bids_success_bids_received_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "month",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "bidding_no",
+          "isExpression": false,
+          "asc": false,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "vehicle_class",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "coe_month_bidding_no_vehicle_class_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "month",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "category",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "deregistrations_month_category_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "deregistrations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "month",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "deregistrations_month_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "deregistrations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "category",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "deregistrations_category_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "deregistrations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "number",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "deregistrations_number_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "deregistrations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "ev_cp_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "observed_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ev_charging_events_ev_cp_id_observed_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ev_charging_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "location_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "observed_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ev_charging_events_location_id_observed_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ev_charging_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "kind",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "observed_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ev_charging_events_kind_observed_at_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ev_charging_events"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "operator",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ev_charging_points_operator_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "plug_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ev_charging_points_plug_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "registration_date",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ev_charging_points_registration_date_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "location_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ev_connector_status_location_id_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "operator",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ev_connector_status_operator_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "postal_code",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ev_connector_status_postal_code_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ev_connector_status"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "hour",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "ev_location_hourly_hour_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "ev_location_hourly"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "embedding",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": {
+            "name": "vector_cosine_ops",
+            "default": false
+          }
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "hnsw",
+      "concurrently": false,
+      "name": "posts_embedding_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "month",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "vehicle_class",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "pqp_month_vehicle_class_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "pqp"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "vehicle_class",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "pqp_vehicle_class_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "pqp"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "pqp",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "pqp_pqp_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "pqp"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "year",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "category",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "vehicle_population_year_category_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "vehicle_population"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "year",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "fuel_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "vehicle_population_year_fuel_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "vehicle_population"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "year",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "vehicle_population_year_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "vehicle_population"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "category",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "vehicle_population_category_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "vehicle_population"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        {
+          "value": "fuel_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "vehicle_population_fuel_type_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "vehicle_population"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "issuer",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "account_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "accounts_issuer_accountId_uidx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "verifications"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["user_id"],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "accounts_user_id_users_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["user_id"],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sessions_user_id_users_id_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "sessions"
+    },
+    {
+      "columns": ["location_id", "hour"],
+      "nameExplicit": false,
+      "name": "ev_location_hourly_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "ev_location_hourly"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "car_population_pkey",
+      "schema": "public",
+      "table": "car_population",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "cars_pkey",
+      "schema": "public",
+      "table": "cars",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "coe_pkey",
+      "schema": "public",
+      "table": "coe",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "deregistrations_pkey",
+      "schema": "public",
+      "table": "deregistrations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "ev_charging_events_pkey",
+      "schema": "public",
+      "table": "ev_charging_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "ev_charging_points_pkey",
+      "schema": "public",
+      "table": "ev_charging_points",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["ev_cp_id"],
+      "nameExplicit": false,
+      "name": "ev_connector_status_pkey",
+      "schema": "public",
+      "table": "ev_connector_status",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "posts_pkey",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "pqp_pkey",
+      "schema": "public",
+      "table": "pqp",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "vehicle_population_pkey",
+      "schema": "public",
+      "table": "vehicle_population",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "accounts_pkey",
+      "schema": "public",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "verifications_pkey",
+      "schema": "public",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["year", "make", "fuel_type"],
+      "nullsNotDistinct": true,
+      "name": "car_population_year_make_fuel_type_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "car_population"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "month",
+        "make",
+        "importer_type",
+        "fuel_type",
+        "vehicle_type"
+      ],
+      "nullsNotDistinct": true,
+      "name": "cars_month_make_importer_type_fuel_type_vehicle_type_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "cars"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["month", "bidding_no", "vehicle_class"],
+      "nullsNotDistinct": false,
+      "name": "coe_month_bidding_no_vehicle_class_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "coe"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["month", "category"],
+      "nullsNotDistinct": false,
+      "name": "deregistrations_month_category_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "deregistrations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["ev_cp_id"],
+      "nullsNotDistinct": false,
+      "name": "ev_charging_points_ev_cp_id_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "ev_charging_points"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["month", "data_type"],
+      "nullsNotDistinct": false,
+      "name": "posts_month_data_type_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["month", "vehicle_class"],
+      "nullsNotDistinct": false,
+      "name": "pqp_month_vehicle_class_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "pqp"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["year", "category", "fuel_type"],
+      "nullsNotDistinct": false,
+      "name": "vehicle_population_year_category_fuel_type_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "vehicle_population"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["slug"],
+      "nullsNotDistinct": false,
+      "name": "posts_slug_unique",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["token"],
+      "nullsNotDistinct": false,
+      "name": "sessions_token_unique",
+      "schema": "public",
+      "table": "sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": ["email"],
+      "nullsNotDistinct": false,
+      "name": "users_email_unique",
+      "schema": "public",
+      "table": "users",
+      "entityType": "uniques"
+    }
+  ],
+  "renames": []
+}

--- a/packages/database/src/schema/cars.ts
+++ b/packages/database/src/schema/cars.ts
@@ -28,11 +28,14 @@ export const cars = snakeCase.table(
         table.vehicleType,
       )
       .nullsNotDistinct(),
-    index().on(table.month, table.make),
+    // Narrow single-column indexes, not the composites that cover them: the
+    // planner picks these because they touch far fewer pages than the wide
+    // unique index above. Measured on staging, Sep 2026 — `(month)` alone
+    // served 124,699 scans, `(make)` 5,476, while `(month, make)` and
+    // `(make, fuel_type)` served none and were dropped.
     index().on(table.month),
     index().on(table.make),
     index().on(table.fuelType),
-    index().on(table.make, table.fuelType),
     index().on(table.number),
   ],
 );


### PR DESCRIPTION
- Replace the per-fuel-type query fan-out in `getTopMakesByFuelType` with one scan grouped by fuel type and make, ranked in JS. `db.batch` was a single round-trip, but its statements ran serially, re-scanning the month once per fuel type
- Cut `getCarsComparison` from nine single-month queries to two scans covering all three months, and `getCarsData` from three to two — the fuel type groups partition the month's rows, so they sum to its total and the separate total query is redundant
- Collapse `getEvMarketShare` (whose second query scanned the whole table unfiltered) and `getEvLatestSummary` into one grouped scan each
- Replace the `extract(year from to_date(month, 'YYYY-MM')) = year` and `ilike '<year>-%'` filters with `gte`/`lte` bounds on the stored `YYYY-MM` text. Measured on staging, that plan goes from a bitmap scan filtering 17,006 rows through `to_date()` (811 buffers, 10.59 ms) to an index scan on `cars_month_index` (68 buffers, 1.12 ms)
- Use drizzle's `sum()` in place of raw `sql` templates across the six touched query modules. That types the aggregate as nullable where `sql<number>` had asserted it away, so the folds coerce it
- **Migration**: drop `cars_month_make_index` and `cars_make_fuel_type_index`. `pg_stat_user_indexes` on staging records zero scans for both, against 161,992 for the unique index and 124,699 for `cars_month_index`. They are dead because the planner prefers the narrow single-column indexes they were meant to cover, so `(month)` and `(make)` stay. No index added — every month-filtered query already plans as an index scan and returns in under a millisecond
- Behaviour change: the per-fuel-type make lists now apply the same `number > 0` filter as their totals, so makes with no registrations no longer pad a short top five
- Drop the `electric-vehicles.ts` coverage exclusion — it was justified as "no testable logic without DB", which stopped being true once the classification and share arithmetic moved into JS — and cover it plus the three untested `monthly-registrations` functions

`queries/cars` coverage goes from 89.6%/82.0% to 96.2%/84.4% statements/branches; 788 tests pass.