### PR TITLE
Explain the survey prompt's 90-day display gate

### DIFF
--- a/apps/web/src/components/survey-prompt.tsx
+++ b/apps/web/src/components/survey-prompt.tsx
@@ -13,9 +13,28 @@ const SURVEY_ROUTE_PATTERN = /^\/(coe|cars)(\/|$)/;
 
 const SURVEY_PROMPT_DELAY_MS = 10_000;
 
-// Shows at most one survey per browser. PostHog holds the survey, its
-// targeting and its responses; automatic popover display is switched off in
-// instrumentation-client.ts so this component is the only display path.
+// Shows at most one survey per browser every 90 days. PostHog holds the
+// survey, its targeting and its responses; automatic popover display is
+// switched off in instrumentation-client.ts so this component is the only
+// display path.
+//
+// The 90-day gate is enforced four times over, so the survey vanishing after a
+// refresh is expected rather than a bug:
+//
+//   1. The survey's completion condition is `schedule: once`.
+//   2. Its display condition sets a 90-day wait period, which spans every
+//      survey in the project, not just this one.
+//   3. Its internal targeting flag requires `$survey_dismissed` and
+//      `$survey_responded` to be unset and `$last_seen_survey_date` to be unset
+//      or older than 90 days. PostHog writes that date when the survey is
+//      *shown*, so simply seeing it is enough to gate the person out.
+//   4. SURVEY_COOLDOWN_MS above, which saves the round trip when we already
+//      know PostHog would refuse.
+//
+// Loosening SURVEY_COOLDOWN_MS therefore changes nothing on its own; the
+// survey's conditions in PostHog have to change with it. Its URL condition is
+// also anchored to the production host, so the survey never displays on
+// localhost or a preview deployment.
 export function SurveyPrompt() {
   const pathname = usePathname();
 


### PR DESCRIPTION
- Document the four layers that gate the Visitor Intent survey to once per browser every 90 days: PostHog's `schedule: once` completion condition, its 90-day cross-survey wait period, its internal targeting flag on `$survey_dismissed` / `$survey_responded` / `$last_seen_survey_date`, and the local `SURVEY_COOLDOWN_MS`
- Note that PostHog writes `$last_seen_survey_date` when the survey is *shown* rather than answered, so a plain page refresh is enough to gate a visitor out — the disappearance reads as a bug without this
- Record the two traps found while investigating: loosening `SURVEY_COOLDOWN_MS` on its own changes nothing, and the survey's URL condition is anchored to the production host, so it never displays on localhost or a preview deployment
- Comment-only change; no runtime behaviour is affected

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791792403&installation_model_id=21947&pr_number=1079&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1079&signature=0335a619d438f9d38d4e0926a2d5462491050669beb7bf4cbc6bed870d1337b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->