### PR TITLE
Fetch charger map sites instead of inlining them in the page

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map-view.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map-view.tsx
@@ -38,6 +38,12 @@ const MODE_LEGENDS: Record<MapMode, string> = {
 /** How many matches the locator card lists before asking for more letters. */
 const LOCATOR_LIMIT = 5;
 
+/** Serves the same array that used to arrive as props. */
+const MAP_SITES_ENDPOINT = "/api/ev-charging/map-sites";
+
+/** Stable empty reference so the memos below do not rerun while loading. */
+const NO_SITES: EvChargingMapSite[] = [];
+
 const siteTitle = (site: EvChargingMapSite) =>
   site.stationName ?? site.address ?? site.locationId;
 
@@ -322,9 +328,13 @@ function SiteFocus({
   return null;
 }
 
-export function ChargingMapView({ sites }: { sites: EvChargingMapSite[] }) {
+export function ChargingMapView() {
   const [district] = useQueryState("district", parseAsString.withDefault(""));
   const scope = getPostalDistrict(district)?.name ?? "Singapore";
+  const [loadedSites, setLoadedSites] = useState<EvChargingMapSite[] | null>(
+    null,
+  );
+  const sites = loadedSites ?? NO_SITES;
   const [tokens, setTokens] = useState<MapTokens | null>(null);
   const [mode, setMode] = useState<MapMode>("availability");
   const [selected, setSelected] = useState<SelectedSite | null>(null);
@@ -353,6 +363,32 @@ export function ChargingMapView({ sites }: { sites: EvChargingMapSite[] }) {
 
   useEffect(() => {
     setTokens(readTokens());
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const load = async () => {
+      try {
+        const response = await fetch(MAP_SITES_ENDPOINT, {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`Map sites request failed: ${response.status}`);
+        }
+        setLoadedSites((await response.json()) as EvChargingMapSite[]);
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+        console.error("Failed to load charging map sites:", error);
+        // An empty list leaves the map usable, just without pins.
+        setLoadedSites(NO_SITES);
+      }
+    };
+
+    void load();
+    return () => controller.abort();
   }, []);
 
   const pointColor: MapClusterLayerProps["pointColor"] = tokens
@@ -450,6 +486,14 @@ export function ChargingMapView({ sites }: { sites: EvChargingMapSite[] }) {
           onPick={(site) => setSiteId(site.locationId)}
           sites={sites}
         />
+
+        {loadedSites === null ? (
+          <div className="absolute inset-0 z-10 flex items-center justify-center rounded-3xl bg-surface/60 backdrop-blur-xs">
+            <Typography.Paragraph color="muted" size="sm">
+              Loading chargers…
+            </Typography.Paragraph>
+          </div>
+        ) : null}
       </div>
 
       <Typography.Paragraph color="muted" size="xs">

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-map.tsx
@@ -7,9 +7,14 @@ import { ChargingMapView } from "./charging-map-view";
  * Every public charging site on a map, coloured by live availability.
  *
  * Reads no search params: the district filter is applied on the client, so
- * this card prerenders into the static shell with the cached site list and
- * costs nothing per request. Reading the district here would put a 2 MB
- * payload into every visit.
+ * this card prerenders into the static shell and costs nothing per request.
+ *
+ * The site list is deliberately not passed down. `ChargingMapView` fetches it
+ * from `/api/ev-charging/map-sites`, which keeps 2,755 sites out of the RSC
+ * payload of every visit — the page serves both a prerender stream and a
+ * resume stream, so anything in the tree is paid for twice. The cached query
+ * is still awaited here, but only to decide whether the card has anything to
+ * show; the array itself never crosses the server/client boundary.
  */
 export async function ChargingMap() {
   const sites = await getEvChargingMapSites();
@@ -20,7 +25,7 @@ export async function ChargingMap() {
   return (
     <div className="scroll-mt-6" id={MAP_ANCHOR_ID}>
       <SurfaceCard className="gap-4 p-7">
-        <ChargingMapView sites={sites} />
+        <ChargingMapView />
       </SurfaceCard>
     </div>
   );

--- a/apps/web/src/app/api/ev-charging/map-sites/route.ts
+++ b/apps/web/src/app/api/ev-charging/map-sites/route.ts
@@ -1,0 +1,32 @@
+import { getEvChargingMapSites } from "@web/queries/ev-charging";
+import { NextResponse } from "next/server";
+
+/**
+ * The charger map's site list, as a resource the map fetches on mount.
+ *
+ * The same data used to travel as props to `ChargingMapView`, which put all
+ * 2,755 sites into the RSC payload of every visit — and twice over, since a
+ * page serves a prerender stream and a resume stream. Served from here it
+ * leaves the document entirely and the CDN and browser can cache it across
+ * navigations.
+ *
+ * `getEvChargingMapSites` carries its own `"use cache"` and cache tag, so the
+ * `ev-charging-live` workflow's revalidation refreshes this route too.
+ */
+export async function GET() {
+  try {
+    const sites = await getEvChargingMapSites();
+    return NextResponse.json(sites, {
+      headers: {
+        "cache-control":
+          "public, max-age=0, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching EV charging map sites:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch charging map sites" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
- Serve the 2,755-site map list from a new `/api/ev-charging/map-sites` route and fetch it in `ChargingMapView` on mount, instead of passing it as props
- The array was 2.05 MB of the 2.53 MB charging document: every route serves a prerender stream and a resume stream, so anything in the RSC tree ships twice
- `ChargingMap` still awaits the cached query to hide the card when the feed is empty, but the array no longer crosses the server/client boundary
- Adds a "Loading chargers…" overlay; a failed fetch logs and leaves an empty map rather than erroring the section
- Verified on the dev server: `locationId` occurrences in the document drop from 5,550 to 20, and the map clusters, locator search and popups work from the fetched data
- The route's `s-maxage=3600` does not follow the workflow's tag bust, so a mid-hour revalidation will not reach an already-cached CDN copy until it expires

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791834000&installation_model_id=21947&pr_number=1084&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1084&signature=1019e62ffda94a602dc037c3c740f5d89585ee201d47eecd6ca0ff55c997bee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->