### PR TITLE
Lower the EV charging utilisation threshold to match hourly ingest

### DIFF
--- a/apps/web/src/queries/ev-charging/location-utilisation.ts
+++ b/apps/web/src/queries/ev-charging/location-utilisation.ts
@@ -30,10 +30,12 @@ export interface EvChargingLocationUtilisation extends EvChargingLocation {
 }
 
 /**
- * A location needs about a day of five-minute samples before its average
- * says anything; below that a single busy evening dominates.
+ * A location needs about a day of samples before its average says anything;
+ * below that a single busy evening dominates. The `ev-charging-live` ingest
+ * adds one sample per location per run and runs hourly, so a day is 24 —
+ * change this with the schedule, or the threshold can outgrow the window.
  */
-const MIN_SAMPLES = 24 * 12;
+const MIN_SAMPLES = 24;
 
 /**
  * Locations ranked by average occupancy over the past `days`.


### PR DESCRIPTION
- `MIN_SAMPLES` in `location-utilisation.ts` assumed five-minute ingests (`24 * 12` = 288 samples a day), but the `ev-charging-live` QStash schedule runs hourly (`0 * * * *`)
- Each run adds one sample per location, so a location gains at most 168 samples in the 7-day window and none ever cleared 288 — the busiest and quietest location lists and the map's "Busiest sites" heat layer were always empty
- Lower it to 24, a day of hourly samples, which keeps the original intent and the map legend's "sites under a day old are left out" accurate
- The comment now ties the value to the schedule so a future cadence change updates both
- Not verified against real data: dev and preview branches hold about an hour of samples; locations should appear once they accumulate a day

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791837408&installation_model_id=21947&pr_number=1087&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1087&signature=6750b343783e7ea5ab1c927cddb85bf42aafe33c6b87618a4420379222a67cad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->