### PR TITLE
Report why the EV charging live ingest skipped a run

### DIFF
--- a/apps/web/src/workflows/ev-charging-live/index.ts
+++ b/apps/web/src/workflows/ev-charging-live/index.ts
@@ -29,10 +29,16 @@ export async function evChargingLiveWorkflow(): Promise<{ message: string }> {
     data: { recordsProcessed: result.connectors },
   });
 
-  if (result.skipped) {
+  // Either way nothing was written, so there is nothing to revalidate.
+  if (result.skipped === "missing-account-key") {
     return {
       message:
         "[EV CHARGING LIVE] LTA_DATAMALL_ACCOUNT_KEY is not set. Skipped.",
+    };
+  }
+  if (result.skipped === "already-ingested") {
+    return {
+      message: `[EV CHARGING LIVE] Batch at ${result.observedAt} is already stored. Skipped.`,
     };
   }
 

--- a/apps/web/src/workflows/ev-charging-live/steps/ingest.test.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/ingest.test.ts
@@ -72,7 +72,7 @@ describe("ingestLiveSnapshot", () => {
     vi.stubEnv("LTA_DATAMALL_ACCOUNT_KEY", "");
 
     await expect(ingestLiveSnapshot()).resolves.toMatchObject({
-      skipped: true,
+      skipped: "missing-account-key",
       connectors: 0,
     });
     expect(fetchBatch).not.toHaveBeenCalled();
@@ -95,7 +95,7 @@ describe("ingestLiveSnapshot", () => {
     selectChain.from.mockResolvedValueOnce([{ observedAt }]);
 
     await expect(ingestLiveSnapshot()).resolves.toMatchObject({
-      skipped: true,
+      skipped: "already-ingested",
       observedAt: observedAt.toISOString(),
     });
     expect(db.insert).not.toHaveBeenCalled();
@@ -113,7 +113,7 @@ describe("ingestLiveSnapshot", () => {
     const result = await ingestLiveSnapshot();
 
     expect(result).toMatchObject({
-      skipped: false,
+      skipped: null,
       connectors: 2,
       locations: 2,
       events: 2,

--- a/apps/web/src/workflows/ev-charging-live/steps/ingest.ts
+++ b/apps/web/src/workflows/ev-charging-live/steps/ingest.ts
@@ -21,8 +21,14 @@ import { max, sql } from "drizzle-orm";
 // upsert binds 19 columns a row, so 1,500 rows stays well under it.
 const BATCH_SIZE = 1500;
 
+/**
+ * Why a run wrote nothing: no DataMall key is configured, or the feed has not
+ * moved past the batch already stored. `null` means the batch was ingested.
+ */
+type SkipReason = "missing-account-key" | "already-ingested";
+
 export interface IngestResult {
-  skipped: boolean;
+  skipped: SkipReason | null;
   connectors: number;
   locations: number;
   events: number;
@@ -37,8 +43,8 @@ const chunk = <T>(items: T[], size: number): T[][] => {
   return chunks;
 };
 
-const skipped = (observedAt: Date): IngestResult => ({
-  skipped: true,
+const skipped = (reason: SkipReason, observedAt: Date): IngestResult => ({
+  skipped: reason,
   connectors: 0,
   locations: 0,
   events: 0,
@@ -48,7 +54,7 @@ const skipped = (observedAt: Date): IngestResult => ({
 export const ingestLiveSnapshot = async (): Promise<IngestResult> => {
   const accountKey = process.env.LTA_DATAMALL_ACCOUNT_KEY;
   if (!accountKey) {
-    return skipped(new Date());
+    return skipped("missing-account-key", new Date());
   }
 
   const payload = await fetchBatch(accountKey);
@@ -69,7 +75,7 @@ export const ingestLiveSnapshot = async (): Promise<IngestResult> => {
     latest?.observedAt &&
     new Date(latest.observedAt).getTime() >= observedAt.getTime()
   ) {
-    return skipped(observedAt);
+    return skipped("already-ingested", observedAt);
   }
 
   const previousRows = await db
@@ -145,7 +151,7 @@ export const ingestLiveSnapshot = async (): Promise<IngestResult> => {
   }
 
   return {
-    skipped: false,
+    skipped: null,
     connectors: records.length,
     locations: diff.hourly.length,
     events: diff.events.length,


### PR DESCRIPTION
- `IngestResult.skipped` was `true` both when `LTA_DATAMALL_ACCOUNT_KEY` is unset and when the feed had not moved past the stored batch, and the workflow logged "LTA_DATAMALL_ACCOUNT_KEY is not set" for both
- It now carries the reason — `"missing-account-key"`, `"already-ingested"`, or `null` when the batch was ingested — so a duplicate batch reports `Batch at <observedAt> is already stored`
- Both skips still return before the cache revalidation step, since nothing was written
- Ingest tests assert the specific reason instead of a boolean
- Stacked on #1082 because it edits the lines next to that PR's revalidation step

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791837706&installation_model_id=21947&pr_number=1088&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1088&signature=e0ce76c6d11375275f12a945cc544f21629bfadf1c86381840e3c1c22beffdc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->