### PR TITLE
Correct the EV charging refresh cadence to hourly

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -216,7 +216,7 @@ Web-specific variables (see root `CLAUDE.md` for the cross-cutting ones):
   `advertise-page`, `blog-popular-posts`. (`advertise-nav` and `blog-nav` were removed: they were
   read at request time in the main layout, which pulled every page out of the static shell.)
 - `QSTASH_TOKEN` / `QSTASH_CURRENT_SIGNING_KEY` / `QSTASH_NEXT_SIGNING_KEY`: Upstash QStash. The
-  five-minute `ev-charging-live` schedule lives in QStash, not `vercel.ts` crons; it forwards
+  hourly (`0 * * * *`) `ev-charging-live` schedule lives in QStash, not `vercel.ts` crons; it forwards
   `CRON_SECRET` as the bearer token so the route needs no QStash-specific verification
 - `VERCEL_ENV`: social media redirects and production-only features activate only when this is `"production"`
 - `NEXT_PUBLIC_VERCEL_URL`: client-side deployment URL, without the `https://` protocol. `SITE_URL` falls back to it

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-overview.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/charging-overview.tsx
@@ -37,8 +37,7 @@ export async function ChargingIntro() {
         {formatPerKwh(stats.medianPerKwh)}, with AC charging from{" "}
         {formatPerKwh(stats.cheapestAc)} and DC fast charging from{" "}
         {formatPerKwh(stats.cheapestDc)}. Availability and prices below come
-        from the Land Transport Authority's DataMall feed and refresh every five
-        minutes.
+        from the Land Transport Authority's DataMall feed and refresh hourly.
       </Typography.Paragraph>
       {observedAt ? (
         <Typography.Paragraph color="muted" size="sm">

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/faq-data.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/faq-data.ts
@@ -32,6 +32,6 @@ export const buildChargingFaqs = (stats: ChargingStats): Faq[] => [
   {
     question: "How current is the availability shown here?",
     answer:
-      "Availability comes from LTA DataMall's EV Charging Points feed, which operators update and LTA republishes every five minutes. This page refreshes on the same cadence, so a connector shown as free was free within the last few minutes. Prices are the operators' advertised rates, including GST.",
+      "Availability comes from LTA DataMall's EV Charging Points feed, which operators update and LTA republishes every five minutes. This page pulls that feed hourly, so a connector shown as free was free as of the last update, up to about an hour ago. Prices are the operators' advertised rates, including GST.",
   },
 ];

--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/live-status.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/components/live-status.tsx
@@ -13,7 +13,7 @@ const formatObservedAt = (iso: string) =>
     minute: "2-digit",
   });
 
-/** Connector state at the last five-minute batch, island-wide or per district. */
+/** Connector state at the latest cached batch, island-wide or per district. */
 export async function LiveStatus({ district }: { district: string }) {
   const summary = await getEvChargingLiveSummary(district || undefined);
   const scope = getPostalDistrict(district)?.name ?? "Singapore";

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -110,7 +110,7 @@ ${popularMakes.map(({ make }) => make).join(", ")}
 
 ## EV Charging (Live)
 
-Singapore's public EV charger network, from LTA DataMall's EV Charging Points feed (refreshed every five minutes). Figures are live and per-kWh prices are the operators' advertised rates including GST.
+Singapore's public EV charger network, from LTA DataMall's EV Charging Points feed, updated hourly. Per-kWh prices are the operators' advertised rates including GST.
 
 - [EV Charging Overview](${SITE_URL}/cars/electric-vehicles/charging): Connectors in use, cheapest and most expensive AC and DC charging by district, common questions answered with current figures
 - Filter by district with the query parameter district=<slug> (for example ${SITE_URL}/cars/electric-vehicles/charging?district=jurong-boon-lay-tuas) and by power rating with power=AC or power=DC

--- a/apps/web/src/lib/metadata/structured-data.ts
+++ b/apps/web/src/lib/metadata/structured-data.ts
@@ -183,7 +183,7 @@ const DATASET_CONFIGS: Record<DatasetType, DatasetConfig> = {
   "ev-charging": {
     name: "Singapore Public EV Charger Availability and Prices",
     description:
-      "Live status of every public electric vehicle charging connector in Singapore, with advertised per-kWh prices, AC and DC power ratings and operator, refreshed every five minutes from LTA DataMall.",
+      "Live status of every public electric vehicle charging connector in Singapore, with advertised per-kWh prices, AC and DC power ratings and operator, refreshed hourly from LTA DataMall.",
     path: "/cars/electric-vehicles/charging",
     temporalCoverage: "2026-09/..",
     variableMeasured: [

--- a/apps/web/src/queries/ev-charging/hourly-utilisation.ts
+++ b/apps/web/src/queries/ev-charging/hourly-utilisation.ts
@@ -11,7 +11,7 @@ export interface EvChargingHourlyUtilisation {
   hour: number;
   /** Share of usable connectors occupied, 0–100. */
   utilisationPercent: number;
-  /** Five-minute readings behind the figure; zero until the hour is sampled. */
+  /** Hourly ingest readings behind the figure; zero until the hour is sampled. */
   samples: number;
 }
 

--- a/apps/web/src/workflows/ev-charging-live/index.ts
+++ b/apps/web/src/workflows/ev-charging-live/index.ts
@@ -7,7 +7,7 @@ import { emitEvent } from "@web/workflows/shared";
 /**
  * Live EV charger availability workflow using Vercel WDK.
  *
- * Runs every five minutes against LTA DataMall's EV Charging Points Batch
+ * Runs hourly against LTA DataMall's EV Charging Points Batch
  * API and records the current state of every connector, the transitions
  * since the last run, and per-location hourly utilisation counters.
  *

--- a/apps/web/vercel.ts
+++ b/apps/web/vercel.ts
@@ -9,7 +9,7 @@ export const config: VercelConfig = {
   },
   relatedProjects: ["prj_fyAvupEssH3LO4OQFDWplinVFlaI"],
   // The live EV charging ingest (/api/workflows/ev-charging-live) is not
-  // here: Hobby caps crons at once a day, so it runs every five minutes from
+  // here: Hobby caps crons at once a day, so it runs hourly from
   // a QStash schedule (id `ev-charging-live`) that forwards CRON_SECRET.
   crons: [
     {

--- a/packages/database/src/schema/ev-charging.ts
+++ b/packages/database/src/schema/ev-charging.ts
@@ -56,7 +56,7 @@ export type SelectEvChargingPoint = typeof evChargingPoints.$inferSelect;
 /**
  * Latest observed state of every public connector, one row per `evCpId`.
  *
- * Fed every five minutes from LTA DataMall's EV Charging Points Batch API and
+ * Fed hourly from LTA DataMall's EV Charging Points Batch API and
  * upserted in place, so this table is always the current snapshot. Station
  * and price attributes travel with the connector because the feed nests them
  * under each station and the batch is the only source that carries prices.


### PR DESCRIPTION
- The `ev-charging-live` QStash schedule runs hourly (`0 * * * *`), but the page intro, FAQ, dataset structured data and `llms.txt` told visitors the data refreshes every five minutes
- The FAQ no longer promises a connector shown as free was free "within the last few minutes"; it now says the data can be up to about an hour old
- `llms.txt` drops "Figures are live", which overstated freshness to LLM crawlers
- Also corrects the cadence in `vercel.ts`, `apps/web/CLAUDE.md`, and the workflow, schema, `hourly-utilisation` and `LiveStatus` comments
- Mentions of DataMall regenerating its batch file every five minutes are accurate and left as is

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791838008&installation_model_id=21947&pr_number=1089&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1089&signature=bc8521872b1ba2e1f1d723b4ef2674b336cf5ec1179f669cc37c171c48f9b460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->