### PR TITLE
Stream EV charging cards independently instead of behind the snapshot

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/electric-vehicles/charging/page.tsx
@@ -23,7 +23,11 @@ import {
   generateBreadcrumbSchema,
   generateDatasetSchema,
 } from "@web/lib/metadata";
-import { getEvChargingSnapshot } from "@web/queries/ev-charging";
+import {
+  getEvChargingSnapshot,
+  type PriceOrder,
+  type UtilisationOrder,
+} from "@web/queries/ev-charging";
 import { PlugZap } from "lucide-react";
 import type { Metadata } from "next";
 import type { SearchParams } from "nuqs/server";
@@ -123,6 +127,10 @@ export default function ChargingPage({ searchParams }: PageProps) {
         </SectionErrorBoundary>
       </AnimatedSection>
 
+      <Suspense fallback={null}>
+        <ChargingEmptyState />
+      </Suspense>
+
       <Suspense
         fallback={
           <Bento>
@@ -147,34 +155,65 @@ async function DistrictControl({ searchParams }: PageProps) {
   return <DistrictSelect district={district} />;
 }
 
-async function ChargingBento({ searchParams }: PageProps) {
-  const [{ district, power }, snapshot] = await Promise.all([
-    loadSearchParams(searchParams),
-    getEvChargingSnapshot(),
-  ]);
-
-  if (snapshot.records.length === 0) {
-    return (
-      <EmptyState
-        description="Live charger availability is not available at the moment. Please check back later."
-        icon={
-          <div className="flex size-16 items-center justify-center rounded-2xl bg-default">
-            <PlugZap className="size-8 text-muted" />
-          </div>
-        }
-        showDefaultActions={false}
-        title="No Live Data Available"
-      />
-    );
+/**
+ * Explains an empty live feed. It has its own boundary so the S3 snapshot it
+ * awaits never holds back the cards: most of them read Postgres, and each one
+ * streams as soon as its own data is ready.
+ */
+async function ChargingEmptyState() {
+  const snapshot = await getEvChargingSnapshot();
+  if (snapshot.records.length > 0) {
+    return null;
   }
 
+  return (
+    <EmptyState
+      description="Live charger availability is not available at the moment. Please check back later."
+      icon={
+        <div className="flex size-16 items-center justify-center rounded-2xl bg-default">
+          <PlugZap className="size-8 text-muted" />
+        </div>
+      }
+      showDefaultActions={false}
+      title="No Live Data Available"
+    />
+  );
+}
+
+async function LiveStatusCard({ searchParams }: PageProps) {
+  const { district } = await loadSearchParams(searchParams);
+  return <LiveStatus district={district} />;
+}
+
+async function PriceListCard({
+  order,
+  searchParams,
+}: PageProps & { order: PriceOrder }) {
+  const { district, power } = await loadSearchParams(searchParams);
+  return <PriceList district={district} order={order} power={power} />;
+}
+
+async function UtilisationListCard({
+  order,
+  searchParams,
+}: PageProps & { order: UtilisationOrder }) {
+  const { district } = await loadSearchParams(searchParams);
+  return <UtilisationList district={district} order={order} />;
+}
+
+/**
+ * The card grid. It awaits nothing itself: aggregating the cards' data here
+ * would make the slowest read gate every card, so each card resolves search
+ * params and its own query inside its own Suspense boundary.
+ */
+function ChargingBento({ searchParams }: PageProps) {
   return (
     <Bento>
       <AnimatedGrid className="flex flex-col gap-6">
         <AnimatedSection>
           <SectionErrorBoundary title="Live status unavailable">
             <Suspense fallback={<CardSkeleton className="h-80" />}>
-              <LiveStatus district={district} />
+              <LiveStatusCard searchParams={searchParams} />
             </Suspense>
           </SectionErrorBoundary>
         </AnimatedSection>
@@ -198,14 +237,14 @@ async function ChargingBento({ searchParams }: PageProps) {
         <AnimatedSection>
           <SectionErrorBoundary title="Cheapest chargers unavailable">
             <Suspense fallback={<CardSkeleton className="h-[520px]" />}>
-              <PriceList district={district} order="cheapest" power={power} />
+              <PriceListCard order="cheapest" searchParams={searchParams} />
             </Suspense>
           </SectionErrorBoundary>
         </AnimatedSection>
         <AnimatedSection>
           <SectionErrorBoundary title="Most expensive chargers unavailable">
             <Suspense fallback={<CardSkeleton className="h-[520px]" />}>
-              <PriceList district={district} order="priciest" power={power} />
+              <PriceListCard order="priciest" searchParams={searchParams} />
             </Suspense>
           </SectionErrorBoundary>
         </AnimatedSection>
@@ -215,14 +254,20 @@ async function ChargingBento({ searchParams }: PageProps) {
         <AnimatedSection>
           <SectionErrorBoundary title="Busiest locations unavailable">
             <Suspense fallback={<CardSkeleton className="h-[520px]" />}>
-              <UtilisationList district={district} order="busiest" />
+              <UtilisationListCard
+                order="busiest"
+                searchParams={searchParams}
+              />
             </Suspense>
           </SectionErrorBoundary>
         </AnimatedSection>
         <AnimatedSection>
           <SectionErrorBoundary title="Quietest locations unavailable">
             <Suspense fallback={<CardSkeleton className="h-[520px]" />}>
-              <UtilisationList district={district} order="quietest" />
+              <UtilisationListCard
+                order="quietest"
+                searchParams={searchParams}
+              />
             </Suspense>
           </SectionErrorBoundary>
         </AnimatedSection>


### PR DESCRIPTION
- `ChargingBento` awaited `Promise.all` of `loadSearchParams` and `getEvChargingSnapshot()` before rendering any card, only to check for an empty feed, so every card waited on the S3 snapshot
- Measured in production after #1084: the shell streams at ~80–170 ms, but all bento cards landed together at 1.25–1.5 s on every run, including five cards that read Postgres and never use the snapshot
- `ChargingBento` now awaits nothing; each search-param-reading card resolves `district`/`power` and its own query inside its own Suspense boundary, following the existing `DistrictControl` pattern
- The empty-feed notice has its own boundary beside the grid; when the feed is empty the cards still render their own empty states alongside it, instead of the notice replacing the grid
- Verified on the dev server: 200 with every card, no error fallback, clean log, and cards now arrive in separate bursts instead of all at once; production timing still needs measuring after deploy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/1090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791840075&installation_model_id=21947&pr_number=1090&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F1090&signature=e1fe32987aacd4227c2952cd7371e1ee2cb0ccc6d8ea9796f6c29ba0a98936c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->